### PR TITLE
Add PR template and AI reviewer config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,12 @@
+reviews:
+  auto_review:
+    enabled: true
+  path_instructions:
+    - path: "packages/core/**"
+      instructions: "Core package must have zero runtime dependencies. Prefer readonly interfaces. Use lowercase string literals, not UPPERCASE enums."
+    - path: "packages/battle/**"
+      instructions: "Battle engine uses event-driven architecture (BattleEvent[] stream). State must be JSON-serializable. GenerationRuleset is the key interface — gen-specific behavior is delegated through it."
+    - path: "packages/gen1/**"
+      instructions: "Gen 1 implements GenerationRuleset directly (does NOT extend BaseRuleset). Uses unified Special stat (no split SpAtk/SpDef). 15-type chart (no Dark/Steel/Fairy). Verify formulas against Bulbapedia/Showdown."
+    - path: "packages/gen3/**"
+      instructions: "Gen 3+ extend BaseRuleset. Check that overrides are correct for this generation's mechanics."

--- a/.github/AI_REVIEWERS.md
+++ b/.github/AI_REVIEWERS.md
@@ -1,0 +1,48 @@
+# AI Review Setup
+
+This repo uses two free AI review tools on every PR, plus local Claude Code review before pushing.
+
+## CodeRabbit
+
+**What it does**: Posts a PR summary, walkthrough of changes, inline review comments, and security scan on every PR.
+
+**Config**: `.coderabbit.yaml` in repo root — contains path-specific review instructions (e.g., "core has zero dependencies", "gen1 uses unified Special stat").
+
+**Interacting with it**:
+- `@coderabbitai resolve` — dismiss a comment thread
+- `@coderabbitai explain` — get a deeper explanation of a suggestion
+- `@coderabbitai regenerate` — re-run the full review
+- `@coderabbitai configuration` — show current config
+- `@coderabbitai ignore` — ignore a specific file pattern going forward
+
+**Ignoring suggestions**: Reply to the comment explaining why you disagree — CodeRabbit learns from this feedback. Or just resolve the thread.
+
+## Qodo Merge (PR-Agent)
+
+**What it does**: Posts a structured review with categorized findings ("possible bug", "possible issue", "suggestion") and severity levels. Also generates PR descriptions and improvement suggestions.
+
+**Interacting with it**:
+- `@CodiumAI-Agent /review` — trigger a review on demand
+- `@CodiumAI-Agent /describe` — auto-generate a PR description
+- `@CodiumAI-Agent /improve` — get code improvement suggestions
+- `@CodiumAI-Agent /ask <question>` — ask a question about the PR
+
+## Local Claude Code Review
+
+**When to use**: Before pushing a PR, as a pre-flight check with full project context.
+
+**How to run**: Use `/review` in Claude Code. This runs three specialized agents:
+- **falcon** — correctness: bugs, logic errors, test quality
+- **kestrel** — architecture: SOLID principles, pattern consistency
+- **sentinel** — security: vulnerabilities, auth flaws, data exposure
+
+**How it differs from CI reviewers**: Reads CLAUDE.md, specs/, and full project context. Catches Pokemon-specific issues (mechanic correctness, spec alignment) that generic AI reviewers miss.
+
+## Full Review Workflow
+
+1. **Local**: Run `/review` in Claude Code before pushing
+2. **Push**: Open PR (or push to existing PR branch)
+3. **CI**: Build, test, typecheck, lint must pass (required)
+4. **CodeRabbit**: Auto-posts summary + inline comments (advisory)
+5. **Qodo Merge**: Auto-posts structured review (advisory)
+6. **Human**: You review AI feedback, address anything valid, approve and merge

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+<!-- What does this PR do and why? -->
+
+## Changes
+-
+
+## Affected Packages
+- [ ] `@pokemon-lib/core`
+- [ ] `@pokemon-lib/battle`
+- [ ] `@pokemon-lib/gen1`
+
+## Type
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Refactor
+- [ ] Data/schema change
+- [ ] Tests
+- [ ] CI/tooling
+
+## Test Plan
+<!-- How did you verify? -->
+-
+
+## Checklist
+- [ ] Tests pass (`npm run test`)
+- [ ] Types pass (`npm run typecheck`)
+- [ ] Lint passes (`npm run lint:check`)
+- [ ] Coverage >= 80%


### PR DESCRIPTION
## Summary
Set up automated AI review infrastructure for PRs. Adds CodeRabbit config with path-specific instructions, a structured PR template, and a reference guide for interacting with AI reviewers.

## Changes
- `.github/pull_request_template.md` — structured PR form with checklist
- `.coderabbit.yaml` — project-specific review instructions for CodeRabbit
- `.github/AI_REVIEWERS.md` — reference guide for CodeRabbit, Qodo Merge, and local Claude Code review

## Affected Packages
No code changes — CI/tooling only.

## Type
- [x] CI/tooling

## Test Plan
- Verify PR creation shows the template
- Verify CodeRabbit picks up `.coderabbit.yaml` path instructions on next PR
- Verify Qodo Merge posts structured review on next PR

## Checklist
- [x] No code changes — CI/tooling config only

## Manual Steps Required
After merge, install these GitHub Apps on `uehlbran/pokemon-lib`:
1. **CodeRabbit**: https://github.com/apps/coderabbitai
2. **Qodo Merge**: https://github.com/apps/qodo-merge-pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)