### PR TITLE
chore: add AI review docs and README badges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,18 @@ These specs are reference material. Implementation may deviate where code reveal
 - Snapshot tests for imported data (correct shapes and counts)
 - Validate against Showdown battle logs for battle engine correctness
 
+## PR Review
+
+Every PR gets reviewed by two AI tools plus a human approver:
+
+- **CodeRabbit** — inline comments, PR summary, security scan. Config: `.coderabbit.yaml`
+- **Qodo Merge** — structured review with severity categories. Free tier (75 PRs/month)
+- **Human** — required approval (1 reviewer). Final say on architecture and correctness
+
+AI reviews are advisory (comments only, never formal approvals). See `.github/AI_REVIEWERS.md` for interaction commands.
+
+Local pre-PR review: run `/review` in Claude Code (falcon/kestrel/sentinel agents).
+
 ## Implementation Phases
 
 - **Phase 1**: Core + Battle + Gen 1 (simplest gen — no abilities, no held items, 151 Pokemon, 165 moves, 15-type chart). Ship 0.1.0.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Pokemon Library Monorepo
 
+[![CI](https://github.com/uehlbran/pokemon-lib/actions/workflows/ci.yml/badge.svg)](https://github.com/uehlbran/pokemon-lib/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/github/license/uehlbran/pokemon-lib)](./LICENSE)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.4%2B-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-20%2B-5FA04E?logo=node.js&logoColor=white)](https://nodejs.org/)
+[![CodeRabbit](https://img.shields.io/coderabbit/prs/github/uehlbran/pokemon-lib?label=CodeRabbit&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6Ii8+PC9zdmc+)](https://coderabbit.ai)
+[![Qodo Merge](https://img.shields.io/badge/AI%20Review-Qodo%20Merge-5B4FC4?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJ3aGl0ZSI+PHBhdGggZD0iTTEyIDJDNi40OCAyIDIgNi40OCAyIDEyczQuNDggMTAgMTAgMTAgMTAtNC40OCAxMC0xMFMxNy41MiAyIDEyIDJ6Ii8+PC9zdmc+)](https://www.qodo.ai/products/qodo-merge/)
+
 A TypeScript monorepo producing open-source Pokemon libraries for building games, simulators, and tools.
 
 ## Packages


### PR DESCRIPTION
## Summary

- Add "PR Review" section to `CLAUDE.md` documenting CodeRabbit, Qodo Merge, and human review workflow
- Add badges to `README.md`: CI, License, TypeScript, Node.js, CodeRabbit, Qodo Merge
- Reusable `/setup-ai-reviewers` skill created in `~/.claude/skills/` (not in repo)

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Confirm CodeRabbit badge resolves (may show 0 until first review)
- [ ] Check CLAUDE.md PR Review section appears after Testing Philosophy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced project documentation with new PR review workflow section detailing review process and tools.
  * Expanded implementation phases documentation to include additional roadmap phases.
  * Added status badges (CI, License, TypeScript, Node.js, CodeRabbit, Qodo Merge) to project overview.
  * Improved documentation formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->