### PR TITLE
fix: prevent push-and-review background reviewer from silently dying

### DIFF
--- a/scripts/push-and-review.sh
+++ b/scripts/push-and-review.sh
@@ -61,12 +61,13 @@ LOG_FILE="$LOG_DIR/review-PR${PR_NUMBER}-$(date +%Y%m%d-%H%M%S).log"
 ls -t "$LOG_DIR"/review-*.log 2>/dev/null | tail -n +11 | xargs rm -f 2>/dev/null || true
 
 # Launch the reviewer with proper backgrounding
-nohup timeout 300 claude \
+# Timeout 600s — reviews with tool calls can take 5-8 minutes
+nohup timeout 600 claude \
     --agent pokemon-reviewer \
     --print \
     --no-session-persistence \
-    --allowedTools "Read" "Grep" "Glob" "Bash(gh:*)" \
-    "Review PR #$PR_NUMBER on branch $BRANCH. Run gh pr diff to see changes and post your review." \
+    --allowedTools "Read,Grep,Glob,Bash(gh:*)" \
+    -- "Review PR #$PR_NUMBER on branch $BRANCH. Run gh pr diff to see changes and post your review." \
     > "$LOG_FILE" 2>&1 &
 disown
 


### PR DESCRIPTION
## Summary

- **Fixed SIGHUP kill**: `nohup ... & disown` keeps the Claude reviewer alive after the shell exits
- **Added output capture**: Logs to `~/.cache/pokemon-lib/reviews/` with rotation (keeps last 10)
- **Added explicit permissions**: `--allowedTools` on the command line eliminates dependency on settings file merging
- **Added `--check` subcommand**: `git pushreview --check` shows process status + latest log contents
- **Added safety guards**: `timeout 300` prevents zombie processes, prerequisite checks for `claude` and `gh` CLIs

## Root causes

Three reinforcing failures caused the background reviewer to silently fail:
1. SIGHUP killed the process when the parent shell exited (`claude ... &` without `nohup`/`disown`)
2. No output capture — stdout/stderr went to the terminal, errors were invisible
3. Possible permission blockage — `--print` mode can't prompt, and relying on settings merging was fragile

## Test plan

- [x] `bash -n` syntax check passes
- [x] `git pushreview --check` with no logs returns "No review logs found" (exit 1)
- [ ] `git pushreview` on a branch with an open PR creates a log file and review posts
- [ ] `git pushreview --check` shows status and log after a review runs
- [ ] Close terminal immediately after `git pushreview` — review still posts (SIGHUP fix)
- [ ] `git pushreview` with no PR open shows "No PR found" and exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--check` mode to monitor ongoing reviews and view the latest review logs
  * Creates timestamped log files per review with rotating retention (last 10 kept)

* **Improvements**
  * Validates required CLI prerequisites before running
  * Detects whether a PR exists for the current branch and exits with guidance if none found
  * Runs reviewer in a managed background process, reporting PID, log location, and status commands
  * More explicit user-facing status and logging messages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->