### PR TITLE
chore: mandate /loop with /babysit-pr for PR polling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,8 @@ Independent semantic versioning per package. A Gen 1 bug fix doesn't bump Gen 9.
 
 ## PR Workflow
 
-- Use **`/babysit-pr`** for all PR monitoring (waiting for CI, reviewer comments, following up after fixes). Do NOT use `/loop` or manual polling.
+- Use **`/babysit-pr`** for all PR monitoring (waiting for CI, reviewer comments, following up after fixes). Do NOT use manual polling.
+- **Always use `/loop` with `/babysit-pr`** for any PR that needs to wait for CI or reviews: `/loop 5m babysit-pr <number> --auto-merge`. A single `/babysit-pr` invocation runs once and exits — it does not poll.
 - **Act autonomously.** When handling a PR, agents should:
   - Push fixes for reviewer feedback without asking permission
   - Fix CI/lint/test failures independently


### PR DESCRIPTION
## Summary

- Removes the "Do NOT use `/loop`" prohibition from the `/babysit-pr` workflow rule
- Adds an explicit mandate to always pair `/babysit-pr` with `/loop` for any PR that needs CI or review monitoring

## Problem

A single `/babysit-pr` invocation runs once and exits. Without `/loop`, agents would invoke it once, get a "CI pending" result, and then stop — leaving the PR in limbo with no one watching it. The previous wording (`Do NOT use /loop`) made this worse by actively preventing the correct pattern.

## Fix

Changed the PR Workflow section in CLAUDE.md from:
> Use `/babysit-pr` for all PR monitoring. Do NOT use `/loop` or manual polling.

To:
> Use `/babysit-pr` for all PR monitoring. Do NOT use manual polling.
> **Always use `/loop` with `/babysit-pr`** for any PR that needs to wait for CI or reviews: `/loop 5m babysit-pr <number> --auto-merge`. A single `/babysit-pr` invocation runs once and exits — it does not poll.

## Test plan

- [ ] Verify CLAUDE.md diff looks correct
- [ ] CI passes (no code changes, only docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for using /loop command with /babysit-pr when waiting for CI or reviews, including command examples
  * Expanded PR workflow documentation with enhanced autonomous capabilities for conflict resolution and review request management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->