### PR TITLE
docs: rewrite root README — gen2, accurate versions, features, use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Modular TypeScript libraries for building Pokemon battle simulators, fan games, 
 - **Zero-dependency core** — pure TypeScript; `@pokemon-lib-ts/core` has no runtime dependencies
 - **Complete standalone data** — each gen bundles all Pokemon, moves, type charts, items
 - **Dual ESM + CJS** — works in Node, bundlers, and everywhere TypeScript runs
-- **Extensible** — implement `GenerationRuleset` (~20 methods) to plug in a custom battle system
+- **Extensible** — implement `GenerationRuleset` (~43 methods) to plug in a custom battle system
 
 ## Packages
 
@@ -39,11 +39,11 @@ core  <-  battle  <-  gen1  <-  your app
 ```
 
 - **Core** has zero runtime dependencies. Pure TypeScript interfaces, formulas, and utilities.
-- **Battle** provides the engine skeleton — a state machine that delegates all gen-specific behavior to a `GenerationRuleset` interface (~20 methods: damage calc, type chart, accuracy, move effects, turn order, etc.). The engine never contains generation-specific logic.
+- **Battle** provides the engine skeleton — a state machine that delegates all gen-specific behavior to a `GenerationRuleset` interface (~43 methods: damage calc, type chart, accuracy, move effects, turn order, etc.). The engine never contains generation-specific logic.
 - **Gen packages** implement `GenerationRuleset` and bundle complete, standalone data. Gen 1 and 2 implement the interface directly; Gen 3+ extend `BaseRuleset` with overrides.
 - **Tools** (`tools/data-importer`, `tools/replay-parser`) handle the build-time data pipeline and Showdown replay validation.
 
-The engine emits a `BattleEvent[]` stream — 38 typed events covering every battle action. Consumers subscribe and render however they want.
+The engine emits individual `BattleEvent` values to listeners — 38 typed event types covering every battle action. The full event log is available as `BattleEvent[]` via `engine.getEventLog()`. Consumers subscribe and render however they want.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Adds `@pokemon-lib-ts/gen2` to the packages table with correct version (0.1.2)
- Corrects all version numbers (core/battle were showing 0.1.0, now 0.4.0; gen1 now 0.2.4)
- Marks Phase 1 and Phase 2 as complete in Project Status
- Adds **Features** section (8 differentiators: modular, event-driven, deterministic PRNG, generation-accurate, zero-dep core, dual ESM+CJS, extensible)
- Expands **Quick Start** with Gen 2 and data-only examples alongside the existing Gen 1 example
- Adds **Use Cases** section (fan games, Discord bots, damage calcs, AI/ML, competitive analysis, Pokedex apps)
- Adds **Contributing** and **Documentation** sections with links to specs, CREDITS, package READMEs
- Expands architecture description to cover GenerationRuleset interface, event stream, and tools packages
- Adds Pokemon trademark notice from CREDITS.md to License section

## Test plan

- [ ] Verify markdown renders correctly on GitHub (check badges, tables, code blocks)
- [ ] Confirm all internal links resolve (`./packages/core`, `./packages/gen2`, `./specs/`, `./CREDITS.md`)
- [ ] Verify code examples match actual API exports in `packages/gen1/src/index.ts` and `packages/gen2/src/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README reorganized with a new Features section and expanded Packages table (updated versions)
  * Added comprehensive Architecture explanations emphasizing generation-based, event-driven flow
  * New Quick Start examples for Gen1, Gen2, and data-only usage
  * Added Use Cases, Development guidance, Project Status, Contributing, and Trademark note
  * Replaced older installation/summary sections with generation-focused narrative and examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->