### PR TITLE
docs: trim CREDITS.md — remove stale references and Tools section

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -10,7 +10,7 @@ Our primary data source. Showdown's battle-tested, generation-split data files p
 Maintained by [Smogon](https://www.smogon.com/) and the competitive Pokemon community.
 
 ### PokeAPI — [pokeapi.co](https://pokeapi.co/)
-Our secondary data source. PokeAPI fills in the species metadata that Showdown doesn't track: Pokedex entries, catch rates, egg groups, growth rates, and evolution chains. We pull from the [api-data](https://github.com/PokeAPI/api-data) repo (pre-joined JSON) and the [sprites](https://github.com/PokeAPI/sprites) repo.
+Our secondary data source. PokeAPI fills in the species metadata that Showdown doesn't track: Pokedex entries, catch rates, egg groups, growth rates, and evolution chains. We pull from the [api-data](https://github.com/PokeAPI/api-data) repo (pre-joined JSON).
 
 ### Bulbapedia — [bulbapedia.bulbagarden.net](https://bulbapedia.bulbagarden.net/)
 The authoritative wiki for Pokemon mechanics. Every stat formula, damage calculation, type chart, and generation quirk in this project was validated against Bulbapedia's documentation. Our testing philosophy starts here: if we can't match Bulbapedia's known values, we have a bug.
@@ -36,30 +36,13 @@ The fan game standard for 10+ years. Its Ruby-based battle system is a valuable 
 The competitive Pokemon community behind Showdown. Their rigorous approach to documenting and implementing battle mechanics — across every generation — set the standard we build against.
 
 ### Veekun — [veekun.com](https://veekun.com/)
-Open-source Pokemon database with downloadable data and sprites. Used as a supplementary reference for overworld sprites and data validation.
+Open-source Pokemon database with downloadable data. A useful general-purpose reference for Pokemon data and mechanics.
 
 ### Serebii — [serebii.net](https://www.serebii.net/)
 Comprehensive Pokemon reference site. Useful for cross-checking mechanics details and finding information that other sources don't cover.
 
 ### PokemonDB — [pokemondb.net](https://pokemondb.net/)
 Clean, well-organized Pokemon database. Referenced for ability documentation and generation-specific data lookups.
-
-## Tools
-
-### Turborepo — [turbo.build](https://turbo.build/)
-Monorepo build orchestration. Manages our multi-package build, test, and typecheck pipelines.
-
-### tsup — [github.com/egoist/tsup](https://github.com/egoist/tsup)
-Bundles each package into ESM + CJS dual output with zero config.
-
-### Vitest — [vitest.dev](https://vitest.dev/)
-Test framework with v8 coverage. Powers our 800+ tests across all packages.
-
-### Biome — [biomejs.dev](https://biomejs.dev/)
-Linting and formatting in one tool. Replaced ESLint + Prettier for us with better performance and simpler config.
-
-### TypeScript — [typescriptlang.org](https://www.typescriptlang.org/)
-The language. Strict mode, discriminated unions, and readonly interfaces are load-bearing for this project's design.
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove false claim that we pull from the PokeAPI `sprites` repo (only `api-data` is used)
- Reframe Veekun description — removed inaccurate "overworld sprites and data validation" language
- Drop entire Tools section (Turborepo, tsup, Vitest, Biome, TypeScript) — these are standard dev dependencies, not meaningful credits; also removes the stale "800+ tests" count

## Test plan

- [ ] Read the file — confirm no stale references remain and it reads naturally end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated credits documentation with streamlined source attribution and added curated reference links.
  * Removed outdated tooling references and improved content organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->