### PR TITLE
docs: archive ground-truth reference docs into specs/reference/

### DIFF
--- a/specs/reference/README.md
+++ b/specs/reference/README.md
@@ -1,0 +1,10 @@
+# Reference Documents
+
+This directory contains reference documents created during audit and spec-verification work. These are research artifacts — useful for understanding what was investigated, what was found, and why decisions were made — but they are **not authoritative specs**. The authoritative specs are in `specs/battle/`.
+
+## Contents
+
+- `gen1-ground-truth.md` — Verified Gen 1 mechanics findings (all 28 findings applied via PR #30)
+- `gen2-ground-truth.md` — Verified Gen 2 mechanics findings (all 32 findings applied via PR #29)
+- `gen1-spec-issues.md` — Gen 1 spec issues found during audit (documents what was found and fixed)
+- `gen2-spec-issues.md` — Gen 2 spec issues found during audit (documents what was found and fixed)

--- a/specs/reference/gen1-ground-truth.md
+++ b/specs/reference/gen1-ground-truth.md
@@ -1,0 +1,447 @@
+# Gen 1 Ground-Truth Mechanics Reference
+
+> Sources: pret/pokered disassembly, Bulbapedia, Smogon RBY research, The Cave of Dragonflies.
+> This document is the canonical reference for Gen 1 mechanics. If the spec (02-gen1.md) disagrees with this document, this document is correct.
+
+---
+
+## 1. Stat Calculation
+
+### DVs (Determinant Values), NOT IVs
+
+Gen 1 uses DVs (0-15), not IVs (0-31). Each stat except HP has an independent DV.
+
+**HP DV is derived from other DVs:**
+```
+HP_DV = (Attack_DV & 1) << 3 | (Defense_DV & 1) << 2 | (Speed_DV & 1) << 1 | (Special_DV & 1)
+```
+Result: 0-15 based on the parity (odd/even) of the four other DVs.
+
+### Stat Experience (NOT EVs)
+
+Gen 1 uses "Stat Experience" (0-65535 per stat). No total cap — all five stats can be maxed independently.
+
+Gained by defeating Pokemon: you gain stat exp equal to the defeated Pokemon's base stats.
+
+**Stat exp bonus calculation:**
+```
+statExpBonus = floor(ceil(sqrt(statExp)) / 4)
+```
+Cap: `ceil(sqrt(65535)) = 256`, capped at 255, so max bonus contribution is `floor(255 / 4) = 63` at level 100.
+
+### Formulas
+
+**HP:**
+```typescript
+floor(((Base + DV) * 2 + statExpBonus) * Level / 100) + Level + 10
+```
+
+**Other stats (Attack, Defense, Speed, Special):**
+```typescript
+floor(((Base + DV) * 2 + statExpBonus) * Level / 100) + 5
+```
+
+Where `statExpBonus = floor(ceil(sqrt(statExp)) / 4)`.
+
+**Special case:** Shedinja (doesn't exist in Gen 1, ignore).
+
+### Stat Stage Multipliers
+
+| Stage | Multiplier (fraction) |
+|-------|----------------------|
+| -6 | 2/8 = 25% |
+| -5 | 2/7 ≈ 28.6% |
+| -4 | 2/6 ≈ 33.3% |
+| -3 | 2/5 = 40% |
+| -2 | 2/4 = 50% |
+| -1 | 2/3 ≈ 66.7% |
+| 0 | 2/2 = 100% |
+| +1 | 3/2 = 150% |
+| +2 | 4/2 = 200% |
+| +3 | 5/2 = 250% |
+| +4 | 6/2 = 300% |
+| +5 | 7/2 = 350% |
+| +6 | 8/2 = 400% |
+
+Formula: `numerator / denominator` where numerator = max(2, 2 + stage), denominator = max(2, 2 - stage).
+
+Applied as: `floor(stat * numerator / denominator)`.
+
+### Badge Boosts
+
+| Badge | Stat |
+|-------|------|
+| Boulder | Attack |
+| Thunder | Defense |
+| Soul | Speed |
+| Volcano | Special |
+
+Multiplier: 9/8 (1.125x), floored. **NOT applied in link battles.**
+
+**Badge boost glitch:** When any stat stage is modified in battle, badge boosts are re-applied to the modified stat, causing compounding. Can stack indefinitely until stat caps at 999.
+
+---
+
+## 2. Type Chart (15 Types)
+
+Types: Normal, Fire, Water, Electric, Grass, Ice, Fighting, Poison, Ground, Flying, Psychic, Bug, Rock, Ghost, Dragon.
+
+**No Steel, Dark, or Fairy types.**
+
+### Key Gen 1-Specific Matchups
+
+| Interaction | Effectiveness | Notes |
+|-------------|--------------|-------|
+| Ghost → Psychic | **0x (immune)** | BUG: should be 2x. Psychic has no real weakness in Gen 1. |
+| Poison → Bug | 2x | Changed to 1x in Gen 2 |
+| Bug → Poison | 2x | Changed to 0.5x in Gen 2 |
+| Ice → Fire | 1x (neutral) | Changed to 0.5x (NVE) in Gen 2 |
+| Ghost → Normal | 0x (immune) | Correct behavior |
+| Normal → Ghost | 0x (immune) | Correct behavior |
+
+### Immunities
+- Normal → Ghost: 0x
+- Ghost → Normal: 0x
+- Ghost → Psychic: 0x (BUG)
+- Electric → Ground: 0x
+- Ground → Flying: 0x
+
+### Physical vs Special (by type)
+
+**Physical types:** Normal, Fighting, Flying, Ground, Rock, Bug, Ghost, Poison
+**Special types:** Fire, Water, Electric, Grass, Ice, Psychic, Dragon
+
+Note: Dragon is special. Poison is physical.
+
+---
+
+## 3. Damage Formula
+
+### Complete Order of Operations
+
+```
+1. Determine effective level (double if critical hit)
+2. Look up Attack and Defense stats:
+   - If crit: use unmodified stats (ignore ALL stat stages, Reflect, Light Screen)
+   - If not crit: apply stat stages, then Reflect/Light Screen (doubles defense)
+   - If burned and move is physical: halve Attack
+3. Handle stat overflow: if Attack or Defense >= 256, divide both by 4 mod 256
+   - If Attack becomes 0, set to 1
+   - If Defense becomes 0: division by zero (crash in original game)
+4. Base damage = floor(floor(floor(level * 2 / 5 + 2) * power * attack / defense) / 50) + 2
+5. Cap base damage at 997
+6. STAB: if move type matches attacker's type, damage += floor(damage / 2)
+7. Type effectiveness: for each defender type, multiply damage by effectiveness
+   - 2x: damage = floor(damage * 20 / 10)
+   - 0.5x: damage = floor(damage * 5 / 10)
+   - 0x: damage = 0
+   - Applied sequentially for dual types
+8. If damage == 0 and move is not immune: damage = 1
+9. Random factor: damage = floor(damage * random(217..255) / 255)
+10. If final damage == 0 and not immune: damage = 1
+```
+
+### Random Factor
+
+Range: 217 to 255 inclusive (39 possible values).
+217/255 ≈ 85.1%, 255/255 = 100%.
+
+### STAB
+
+Not a 1.5x multiplier. It's: `damage = damage + floor(damage / 2)`.
+This is equivalent to 1.5x with the floor applied to the bonus half, not the total.
+
+### Self-Destruct and Explosion
+
+Target's Defense is **halved** during the damage calculation (before the division step). Effectively doubles the power. User faints regardless of hit/miss/immunity.
+
+---
+
+## 4. Critical Hits
+
+### Rate Formula
+
+**Normal moves:** `threshold = floor(baseSpeed / 2)` → crit if `random(0..255) < threshold`
+- Probability: baseSpeed / 512
+
+**High-crit moves** (Slash, Razor Leaf, Crabhammer, Karate Chop):
+`threshold = floor(baseSpeed * 8 / 2)` capped at 255 → crit if `random(0..255) < threshold`
+- Probability: baseSpeed * 8 / 512 = baseSpeed / 64
+- For baseSpeed >= 64, this is virtually guaranteed (255/256)
+
+### Focus Energy Bug
+
+**Intended:** multiply threshold by 4.
+**Actual:** divides threshold by 4.
+Same bug applies to Dire Hit.
+
+### Crit Damage
+
+Crits **double the level** in the damage formula (not 2x damage).
+Crits **ignore ALL stat stages** on both sides.
+Crits **ignore Reflect and Light Screen**.
+Crits use unmodified base stats.
+
+### Examples
+
+| Pokemon | Base Speed | Normal Crit Rate | High-Crit Rate |
+|---------|-----------|-----------------|----------------|
+| Alakazam | 120 | 60/256 = 23.4% | 255/256 ≈ 99.6% |
+| Tauros | 110 | 55/256 = 21.5% | 255/256 ≈ 99.6% |
+| Chansey | 50 | 25/256 = 9.8% | 200/256 = 78.1% |
+| Snorlax | 30 | 15/256 = 5.9% | 120/256 = 46.9% |
+
+---
+
+## 5. Accuracy
+
+### Formula
+
+```
+threshold = floor(moveAccuracy * accStageMultiplier / evaStageMultiplier)
+```
+Clamped to 1-255.
+Hit if `random(0..255) < threshold`.
+
+### Accuracy/Evasion Stage Multipliers
+
+Same table as stat stages (numerator/denominator system).
+
+### 1/256 Miss Bug
+
+If `threshold` computes to 256 (or higher after stage modifiers on a 100% move), it's stored as a single byte, wrapping to 0. This means:
+- 100% accuracy moves (stored as 255 internally) have a 1/256 chance to miss
+- `random(0..255) < 255` fails when random == 255
+
+**Swift bypasses the accuracy check entirely** (does not roll). It is the ONLY move that truly cannot miss in Gen 1.
+
+### OHKO Moves (Horn Drill, Guillotine, Fissure)
+
+- Fail automatically if user's Speed < target's Speed
+- Base accuracy: 30%
+- Affected by accuracy/evasion stages
+- X Accuracy makes them auto-hit (bypasses accuracy check, but Speed check still applies)
+
+---
+
+## 6. Status Conditions
+
+### Sleep
+
+- Duration: 1-7 turns (random)
+- Counter decremented **before** action check
+- **Cannot act on the turn of waking** (counter hits 0 → wake but skip turn)
+- Rest: sets counter to exactly 2 (effectively 2 full turns of sleep, wake on 3rd but can't act)
+- Sleep counter does NOT reset on switch-out (persists)
+
+### Freeze
+
+- **No natural thaw in Gen 1** (0% per turn)
+- Thaw conditions: hit by a damaging Fire-type move, Haze, or item
+- Fire Spin does NOT thaw (it's a trapping move, not a standard damaging Fire move — actually need to verify this)
+- Ice-type Pokemon cannot be frozen
+- Fire-type Pokemon CAN be frozen in Gen 1 (no Fire immunity to freeze)
+
+### Burn
+
+- **1/16 max HP damage per turn** (this IS applied, contrary to some incorrect sources)
+- Halves Attack stat (applied to the stat value, not as a stage)
+- **Toxic counter bug:** burn damage uses the same counter as Toxic. If a Pokemon was previously Toxic'd, then cured, then burned, the burn damage escalates using the old Toxic counter value.
+
+### Poison (Regular)
+
+- **1/16 max HP damage per turn**
+
+### Toxic (Bad Poison)
+
+- Starts at 1/16, escalates by 1/16 each turn: 1/16, 2/16, 3/16, ...
+- Counter resets on switch (reverts to regular poison)
+- **Shared counter with burn and Leech Seed** (the toxic counter bug)
+
+### Paralysis
+
+- 25% chance (63/256) of full paralysis (cannot act) each turn
+- Speed quartered (×0.25), applied to the stat value directly
+- Speed reduction is immediate upon paralysis
+
+### Confusion
+
+- Duration: 1-4 turns (random, counter decremented before check)
+- 50% chance to hit self each turn
+- Self-hit: 40 power, typeless, physical (uses attacker's own Attack/Defense)
+- Clears on switch-out
+
+---
+
+## 7. Move Mechanics
+
+### Trapping Moves (Wrap, Bind, Fire Spin, Clamp)
+
+- Duration: 2-5 turns
+- Target is **completely immobilized** — cannot attack or switch
+- Deals damage each application (same damage as initial hit? Or 1/16? Need to verify — in Gen 1, each hit of the trapping move recalculates damage)
+- Attacker is locked into the move for the duration
+- If attacker is faster, can trap-lock opponent indefinitely by reusing after duration ends
+
+### Hyper Beam
+
+- Skips recharge if: KOs the target, breaks a Substitute, or misses
+- If frozen during recharge turn, stuck in recharge state until thaw
+
+### Counter
+
+- Priority: -1 (acts last)
+- Only reflects damage from **Normal and Fighting type moves** (not all physical moves)
+- Returns 2x the damage received
+- Various storage bugs: can counter damage from previous turn
+
+### Fixed Damage Moves
+
+| Move | Damage | Type |
+|------|--------|------|
+| Seismic Toss | = user's level | Fighting |
+| Night Shade | = user's level | Ghost |
+| Dragon Rage | 40 | Dragon |
+| Sonic Boom | 20 | Normal |
+| Super Fang | 50% current HP | Normal |
+| Psywave | random 1 to 1.5x user's level | Psychic |
+
+These ignore Attack/Defense stats and type effectiveness.
+Seismic Toss hits Ghost types (despite being Fighting type, it uses fixed damage).
+
+### Multi-Hit Moves
+
+Distribution: 37.5% / 37.5% / 12.5% / 12.5% for 2/3/4/5 hits.
+Only first hit can crit. All subsequent hits deal same damage as first.
+Ends immediately if it breaks Substitute.
+
+### Self-Destruct / Explosion
+
+- User always faints (even on miss or immunity)
+- Target's Defense halved during damage calc
+
+### Struggle
+
+- Used when all PP depleted
+- 50 power, Normal type, 100% accuracy (subject to 1/256 miss)
+- **Recoil: 50% of damage dealt** (NOT 25% of max HP)
+- Does not consume PP
+
+### Rage
+
+- Locks user into Rage after first use (1 PP consumed total)
+- Attack rises each time user is hit
+- If Rage misses due to accuracy/evasion, can get stuck in permanent miss loop
+- Disable interaction bug: Disable always triggers Rage counter buildup
+
+### Bide
+
+- Stores damage for 2-3 turns, returns double
+- Bypasses accuracy check
+- Known bugs: high-byte damage counter bug, non-damaging move counter bug
+
+### Substitute
+
+- Costs 25% of max HP (user faints if HP is exactly 25%)
+- Blocks most status moves
+- Does NOT block: sleep, paralysis from status moves
+- Confusion self-hit applies to OPPONENT's substitute (bug)
+- Crash damage from Jump Kick/Hi Jump Kick applies to opponent's substitute (bug)
+
+### Reflect / Light Screen
+
+- Doubles the relevant defense stat during damage calculation
+- **No turn limit in Gen 1** — lasts until the Pokemon switches out or faints
+- Ignored by critical hits
+
+### Conversion (Gen 1 version)
+
+- Changes user's type to **opponent's type** (not based on user's moves like later gens)
+
+### Haze
+
+- Resets ALL stat stages for both Pokemon
+- Cures both Pokemon's status conditions (including freeze — unique to Gen 1)
+- Resets Toxic counter
+- Removes Leech Seed, Reflect, Light Screen, Focus Energy, confusion, disable
+
+### Metronome
+
+- Calls a random move from the entire Gen 1 move pool
+- Cannot call itself or Struggle
+
+---
+
+## 8. Turn Flow
+
+### Turn Order
+
+1. Both players choose action (move or switch)
+2. Switches always execute first (before moves)
+3. Among moves: higher priority goes first, then higher Speed
+4. Speed ties: random 50/50
+
+### Priority Moves in Gen 1
+
+| Move | Priority |
+|------|----------|
+| Quick Attack | +1 |
+| Counter | -1 |
+
+All other moves: priority 0.
+
+### End-of-Turn Order
+
+1. Burn damage (1/16 max HP)
+2. Poison damage (1/16 max HP, or N/16 for Toxic)
+3. Leech Seed drain (1/16 max HP)
+4. Check fainting
+
+Note: The exact ordering of these may vary. The toxic counter bug means burn, poison, and Leech Seed share a counter.
+
+### What Resets on Switch-Out
+
+- Stat stages (all reset to 0)
+- Confusion
+- Toxic counter (reverts to regular poison)
+- Disable
+- Rage state
+- Type changes (Conversion)
+- Trapping/binding
+- Focus Energy
+
+### What Persists on Switch-Out
+
+- Sleep counter (does NOT reset)
+- Primary status (burn, freeze, paralysis, poison, sleep)
+
+---
+
+## 9. Known Bugs Summary
+
+| Bug | Description | Impact |
+|-----|-------------|--------|
+| Ghost/Psychic immunity | Ghost → Psychic = 0x instead of 2x | Psychic type has no real weakness |
+| 1/256 miss | 100% accuracy moves miss 1/256 of the time | Affects all non-Swift moves |
+| Focus Energy | Divides crit rate by 4 instead of multiplying | Move is actively harmful |
+| Badge boost stacking | Badge boosts re-apply on stat stage changes | Stats can compound to 999 |
+| Toxic counter shared | Burn/poison/Leech Seed share damage counter | Burn can escalate like Toxic |
+| Stat overflow | Attack or Defense >= 256 causes divide-by-4 | Can cause division by zero crash |
+| Hyper Beam no recharge on KO | Skips recharge when target faints | Makes Hyper Beam much stronger |
+| Substitute confusion | Self-hit damages opponent's sub | Rare but exploitable |
+| Rage miss loop | Rage can get stuck permanently missing | Effectively kills the Pokemon |
+| Sleep wake can't act | Pokemon can't move on the turn it wakes | Effectively +1 sleep turn |
+
+---
+
+## References
+
+- pret/pokered: https://github.com/pret/pokered
+- Bulbapedia Damage: https://bulbapedia.bulbagarden.net/wiki/Damage
+- Bulbapedia Critical Hit: https://bulbapedia.bulbagarden.net/wiki/Critical_hit
+- Bulbapedia Gen 1 Glitches: https://bulbapedia.bulbagarden.net/wiki/List_of_battle_glitches_in_Generation_I
+- Smogon RBY Mechanics: https://www.smogon.com/rb/articles/rby_mechanics_guide
+- Smogon RBY Trapping: https://www.smogon.com/rb/articles/rby_trapping
+- Smogon RBY Speed: https://www.smogon.com/rb/articles/rby_speed
+- Smogon RBY Crits: https://www.smogon.com/rb/articles/critical_hits
+- Cave of Dragonflies Gen 1 Stats: https://www.dragonflycave.com/mechanics/gen-i-stat-modification/

--- a/specs/reference/gen1-spec-issues.md
+++ b/specs/reference/gen1-spec-issues.md
@@ -1,0 +1,177 @@
+# Gen 1 Spec Issues: 02-gen1.md vs Ground Truth
+
+Every discrepancy between the existing spec and the ground-truth reference.
+Severity: CRITICAL (wrong behavior), MAJOR (missing mechanic), MINOR (cosmetic/clarity).
+
+---
+
+## CRITICAL Issues
+
+### 1. Stat Formula Is Wrong
+**Location:** Section 2, lines 40-61
+**Problem:** The spec uses `2 * baseValue + iv + Math.floor(ev / 4)` which is the modern EV formula. Gen 1 uses Stat Experience with a sqrt:
+```
+floor(((Base + DV) * 2 + floor(ceil(sqrt(statExp)) / 4)) * Level / 100) + 5
+```
+The `iv` should be `DV` (0-15), and `Math.floor(ev / 4)` should be `Math.floor(Math.ceil(Math.sqrt(statExp)) / 4)`.
+**Impact:** Every stat calculation is wrong.
+
+### 2. HP Formula Constant Is Wrong
+**Location:** Section 2, line 60
+**Problem:** HP formula ends with `+ level + 5` but should be `+ level + 10`.
+**Impact:** Every HP calculation is 5 too low.
+
+### 3. Poison Damage Is Completely Wrong
+**Location:** Section 6, lines 470-495 and 892-899
+**Problem:** The spec says:
+- "Regular Poison: no damage" — **WRONG.** Regular poison deals 1/16 max HP per turn.
+- "Badly Poisoned: 1/8 HP damage" — **WRONG.** Toxic starts at 1/16 and escalates by 1/16 each turn (1/16, 2/16, 3/16...).
+- `applyStatusDamage()` says "Regular Poison and Burn do no damage in Gen 1" — **COMPLETELY WRONG.** Both deal 1/16 per turn.
+**Impact:** Core battle mechanic entirely broken.
+
+### 4. Burn Damage Is Wrong
+**Location:** Section 10, line 898
+**Problem:** "Regular Poison and Burn do no damage in Gen 1" is false. Burn deals 1/16 max HP per turn.
+**Impact:** Burn is non-functional.
+
+### 5. Ghost vs Psychic Bug Description Is Wrong
+**Location:** Section 3, lines 109-118
+**Problem:** Spec says Ghost moves do "normal damage (1.0x)" to Psychic. Actually they do **0x (immune)**. The bug is that Ghost → Psychic is coded as immune when it should be super effective.
+**Impact:** Wrong type effectiveness value.
+
+### 6. STAB Missing from Damage Formula
+**Location:** Section 4, lines 148-192
+**Problem:** The damage formula code doesn't include STAB at all. STAB should be applied after the base damage calculation: `damage += floor(damage / 2)` if type matches.
+**Impact:** STAB damage bonus never applied.
+
+### 7. Damage Formula Missing Type Effectiveness Application Details
+**Location:** Section 4
+**Problem:** Type effectiveness is described but not shown in the actual formula code. In Gen 1, it's applied as `floor(damage * 20 / 10)` for SE, `floor(damage * 5 / 10)` for NVE, applied sequentially per defender type.
+**Impact:** Type effectiveness implementation unclear/wrong.
+
+### 8. Type Chart References Steel Type
+**Location:** Section 3, lines 88-105
+**Problem:** The type chart table includes Steel in multiple entries (Fire SE vs Steel, Ground SE vs Steel, etc.). Steel does not exist in Gen 1.
+**Impact:** Type chart has phantom entries.
+
+---
+
+## MAJOR Issues
+
+### 9. Random Factor Range Is Vague
+**Location:** Section 4, line 286
+**Problem:** Spec says "0.85 to 1.00" which is approximate. The actual range is 217-255 out of 255 (39 distinct values). Implementation should use `floor(damage * random(217..255) / 255)`.
+**Impact:** Could lead to incorrect random roll implementation.
+
+### 10. Sleep: Cannot Act on Wake Turn Not Mentioned
+**Location:** Section 6, lines 450-466
+**Problem:** The spec doesn't mention that in Gen 1, a Pokemon **cannot act on the turn it wakes up**. Counter is decremented before action check; when it hits 0, wake but forfeit action.
+**Impact:** Sleep is 1 turn shorter than it should be.
+
+### 11. Freeze Thaw: Haze Not Mentioned
+**Location:** Section 6, lines 426-430
+**Problem:** Spec says freeze only thaws from Fire moves or items. Haze also cures freeze in Gen 1 (unique to Gen 1).
+**Impact:** Missing thaw condition.
+
+### 12. Toxic Counter Bug Not Mentioned
+**Location:** Section 6
+**Problem:** The shared counter between Toxic, burn, poison, and Leech Seed is not documented. Burn can escalate using a prior Toxic counter.
+**Impact:** Missing a notable Gen 1 bug.
+
+### 13. High-Crit Moves Not Mentioned
+**Location:** Section 5
+**Problem:** Spec only covers the base `speed / 512` formula. Doesn't mention that Slash, Razor Leaf, Crabhammer, and Karate Chop have 8x the crit rate (`speed / 64`).
+**Impact:** Four moves have wrong crit rates.
+
+### 14. Counter Only Works on Normal/Fighting Types
+**Location:** Section 9, lines 841-857
+**Problem:** Spec says Counter reflects "Physical moves." Actually Counter only reflects damage from **Normal-type and Fighting-type moves specifically**, not all physical moves.
+**Impact:** Counter works against wrong moves.
+
+### 15. Hyper Beam Recharge Conditions Incomplete
+**Location:** Section 7, lines 583-599
+**Problem:** Spec only mentions "KO" as skipping recharge. Hyper Beam also skips recharge if it **breaks a Substitute** or **misses**.
+**Impact:** Hyper Beam recharges when it shouldn't.
+
+### 16. Self-Destruct/Explosion Defense Halving Not Mentioned
+**Location:** Not in spec
+**Problem:** Self-Destruct and Explosion halve the target's Defense stat during damage calculation, effectively doubling their power. Not mentioned anywhere.
+**Impact:** Missing a core mechanic of two important moves.
+
+### 17. Struggle Mechanics Not Documented
+**Location:** Not in spec
+**Problem:** Struggle in Gen 1: 50 power, Normal type, 50% recoil of damage dealt (NOT 25% of max HP like later gens). Not documented.
+**Impact:** Missing move mechanic.
+
+### 18. Reflect/Light Screen Duration Wrong
+**Location:** Section 10, line 912
+**Problem:** Spec says "Effect lasts for 5 turns." In Gen 1, Reflect and Light Screen have **no turn limit** — they last until the Pokemon switches out or faints.
+**Impact:** Screens expire too early.
+
+### 19. Stat Overflow Handling Not Documented
+**Location:** Not in spec
+**Problem:** If Attack or Defense >= 256 during damage calc, both are divided by 4 mod 256. If either becomes 0 after this, Attack is set to 1, but Defense = 0 causes a division-by-zero crash in the original game.
+**Impact:** Missing edge case that can crash.
+
+### 20. Dragon Type Classification Missing
+**Location:** Section 7, line 544-558
+**Problem:** The physical/special type lists don't include Dragon. Dragon is a **Special** type in Gen 1 (only Dragon Rage exists, but the type itself is Special).
+**Impact:** Dragon moves would use wrong stat.
+
+### 21. Poison Type Is Physical
+**Location:** Section 7, line 549
+**Problem:** Poison is listed under `specialTypes` in the code. Poison is actually a **Physical** type in Gen 1.
+**Wait — let me recheck.** The spec lists Poison in `specialTypes` at line 549. This is **WRONG**. Poison is Physical.
+**Impact:** Poison moves use wrong attack/defense stats.
+
+---
+
+## MINOR Issues
+
+### 22. References to Non-Gen1 Mechanics
+**Location:** Various
+**Problem:** The spec references Dragon Dance (doesn't exist in Gen 1), Espeon (Gen 2), Steel type, abilities, weather. These shouldn't appear in a Gen 1 spec.
+**Impact:** Confusing, suggests mechanics that don't exist.
+
+### 23. Crit Rate Example Math Wrong
+**Location:** Section 5, line 373
+**Problem:** "Crit rate maxes at ~100% for base Speed 100+" is wrong. Base Speed 100 gives 50/256 ≈ 19.5%, nowhere near 100%. Even Speed 255 gives 127/256 ≈ 49.6% for normal moves.
+**Impact:** Misleading example.
+
+### 24. Evasion Formula Has Errors
+**Location:** Section 8, line 684
+**Problem:** For negative stages, formula uses `3 / (3 + stage)` which for stage = -1 gives `3 / 2 = 1.5` (boost, not reduction). Should match the stat stage multiplier table.
+**Impact:** Evasion stages calculated incorrectly.
+
+### 25. DV Terminology
+**Location:** Throughout
+**Problem:** Spec uses "IV" (Individual Value) which is the Gen 3+ term. Gen 1 uses "DV" (Determinant Value). Range is 0-15, not 0-31.
+**Impact:** Confusing terminology, though functionally similar.
+
+### 26. HP DV Derivation Not Documented
+**Location:** Section 2
+**Problem:** HP DV is derived from the parity of the other four DVs, not independently random. This is not mentioned.
+**Impact:** Missing mechanic that affects HP values.
+
+### 27. Confusion Self-Hit Substitute Bug Not Mentioned
+**Location:** Not in spec
+**Problem:** If a confused Pokemon behind a Substitute hits itself, the damage applies to the **opponent's** Substitute instead.
+**Impact:** Missing bug.
+
+### 28. Damage Formula Cap at 997 Not Mentioned
+**Location:** Section 4
+**Problem:** After the base damage calculation (before STAB/type/random), damage is capped at 997.
+**Impact:** Missing cap.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| CRITICAL | 8 |
+| MAJOR | 13 |
+| MINOR | 7 |
+| **Total** | **28** |
+
+The spec needs a substantial rewrite. The stat formula, poison/burn damage, Ghost/Psychic interaction, and missing STAB are the highest-priority fixes.

--- a/specs/reference/gen2-ground-truth.md
+++ b/specs/reference/gen2-ground-truth.md
@@ -1,0 +1,521 @@
+# Gen 2 Ground-Truth Mechanics Reference
+
+> Sources: pret/pokecrystal disassembly, Bulbapedia, Smogon GSC research.
+> This document is the canonical reference for Gen 2 mechanics. If the spec (03-gen2.md) disagrees with this document, this document is correct.
+
+---
+
+## 1. Stat Calculation
+
+### Same DV/Stat Exp System as Gen 1
+
+Gen 2 uses the **exact same** stat calculation system as Gen 1. DVs (0-15), Stat Experience (0-65535), same formulas.
+
+**HP:**
+```typescript
+floor(((Base + DV) * 2 + floor(ceil(sqrt(statExp)) / 4)) * Level / 100) + Level + 10
+```
+
+**Other stats (Attack, Defense, Speed, Sp.Atk, Sp.Def):**
+```typescript
+floor(((Base + DV) * 2 + floor(ceil(sqrt(statExp)) / 4)) * Level / 100) + 5
+```
+
+### Special Stat Split
+
+The major change: Gen 1's single "Special" stat is split into **Sp.Atk** and **Sp.Def**.
+- Both share the same DV (the "Special DV")
+- Both have independent Stat Experience values
+- Both have independent base stats per species
+
+### HP DV Derivation
+
+Same as Gen 1: `HP_DV = (Atk_DV & 1) << 3 | (Def_DV & 1) << 2 | (Spd_DV & 1) << 1 | (Spc_DV & 1)`
+
+### Shiny Determination (Gen 2 Specific)
+
+Based on DVs:
+- Attack DV must be 2, 3, 6, 7, 10, 11, 14, or 15
+- Defense DV must be 10
+- Speed DV must be 10
+- Special DV must be 10
+
+Probability: approximately 1/8192.
+
+### Stat Stage Multipliers
+
+Same table as Gen 1:
+
+| Stage | Multiplier |
+|-------|-----------|
+| -6 | 2/8 |
+| -5 | 2/7 |
+| -4 | 2/6 |
+| -3 | 2/5 |
+| -2 | 2/4 |
+| -1 | 2/3 |
+| 0 | 2/2 |
+| +1 | 3/2 |
+| +2 | 4/2 |
+| +3 | 5/2 |
+| +4 | 6/2 |
+| +5 | 7/2 |
+| +6 | 8/2 |
+
+Applied as: `floor(stat * numerator / denominator)`.
+
+---
+
+## 2. Type Chart (17 Types)
+
+Types: Normal, Fire, Water, Electric, Grass, Ice, Fighting, Poison, Ground, Flying, Psychic, Bug, Rock, Ghost, Dragon, **Dark**, **Steel**.
+
+### Changes from Gen 1
+
+| Change | Gen 1 | Gen 2 |
+|--------|-------|-------|
+| Ghost → Psychic | 0x (immune, bug) | **2x** (super effective, bug fixed) |
+| Bug → Poison | 2x (super effective) | **0.5x** (not very effective) |
+| Poison → Bug | 2x (super effective) | **1x** (neutral) |
+| Ice → Fire | 1x (neutral) | **0.5x** (not very effective) |
+
+### New Type Interactions
+
+**Dark type:**
+- Super effective against: Psychic, Ghost
+- Not very effective against: Fighting, Dark, Steel
+- Immune to: Psychic (attacking Dark)
+- Weak to: Fighting, Bug
+
+**Steel type:**
+- Super effective against: Ice, Rock
+- Not very effective against: Fire, Water, Electric, Steel
+- Immune to: Poison (attacking Steel)
+- Weak to: Fire, Fighting, Ground
+- Resists: Normal, Flying, Rock, Bug, Ghost, Steel, Grass, Psychic, Ice, Dragon, Dark
+
+### Immunities
+
+- Normal → Ghost: 0x
+- Ghost → Normal: 0x
+- Electric → Ground: 0x
+- Ground → Flying: 0x
+- Psychic → Dark: 0x
+- Poison → Steel: 0x
+- Fighting → Ghost: 0x
+
+### Physical vs Special (by type)
+
+**Physical:** Normal, Fighting, Flying, **Poison**, Ground, Rock, Bug, Ghost, **Steel**
+**Special:** Fire, Water, Electric, Grass, Ice, Psychic, Dragon, **Dark**
+
+Note: Poison is PHYSICAL. Dark is SPECIAL. Same type-based split as Gen 1, with the two new types assigned.
+
+---
+
+## 3. Damage Formula
+
+### Complete Order of Operations
+
+The base formula is identical to Gen 1:
+
+```
+1. Determine effective level (double if critical hit — see crit section for caveats)
+2. Look up Attack and Defense stats:
+   - If crit: conditional behavior (see crit section)
+   - If not crit: apply stat stages, Reflect/Light Screen
+   - If burned and move is physical: halve Attack stat
+3. Handle stat overflow: same as Gen 1 (if Atk or Def >= 256, divide both by 4 mod 256)
+4. Base damage = floor(floor(floor(level * 2 / 5 + 2) * power * attack / defense) / 50) + 2
+5. Cap base damage at 997
+6. STAB: if move type matches attacker type, damage += floor(damage / 2)
+7. Type effectiveness: applied sequentially per defender type
+   - SE: damage = floor(damage * 20 / 10)
+   - NVE: damage = floor(damage * 5 / 10)
+   - Immune: damage = 0
+8. If damage == 0 and not immune: damage = 1
+9. Random factor: damage = floor(damage * random(217..255) / 255)
+10. If final damage == 0 and not immune: damage = 1
+```
+
+### Weather Modifiers
+
+Applied as multipliers on the damage:
+- **Rain Dance:** Water moves ×1.5, Fire moves ×0.5
+- **Sunny Day:** Fire moves ×1.5, Water moves ×0.5
+- **Sandstorm:** No direct damage modifier (only deals end-of-turn damage)
+
+Weather modifiers are applied after STAB but before random factor.
+
+### Held Item Damage Modifiers
+
+Type-boosting held items give **1.1x (10%) boost** in Gen 2:
+- Charcoal (Fire), Mystic Water (Water), Magnet (Electric), Miracle Seed (Grass), NeverMeltIce (Ice), BlackBelt (Fighting), Poison Barb (Poison), Soft Sand (Ground), Sharp Beak (Flying), TwistedSpoon (Psychic), SilverPowder (Bug), Hard Stone (Rock), Spell Tag (Ghost), Dragon Fang (Dragon), BlackGlasses (Dark), Metal Coat (Steel), Silk Scarf/Pink Bow (Normal — Pink Bow is 1.1x in Gen 2)
+
+Species-specific items:
+- **Light Ball** (Pikachu): doubles Sp.Atk
+- **Thick Club** (Cubone/Marowak): doubles Attack
+- **Metal Powder** (Ditto): doubles Defense when untransformed
+
+### Self-Destruct / Explosion
+
+Same as Gen 1: target's Defense is halved during damage calculation. User faints regardless.
+
+---
+
+## 4. Critical Hits
+
+### Stage-Based System (New in Gen 2)
+
+Gen 2 replaced Gen 1's speed-based crit formula with a **threshold system**:
+
+| Crit Stage | Threshold (T) | Probability |
+|-----------|---------------|-------------|
+| 0 (base) | 17 | 17/256 ≈ 6.64% |
+| +1 | 32 | 32/256 = 12.5% |
+| +2 | 64 | 64/256 = 25% |
+| +3 | 85 | 85/256 ≈ 33.2% |
+| +4 | 128 | 128/256 = 50% |
+
+Crit occurs if `random(0..255) < threshold`.
+
+**Important:** These are NOT exact fractions (1/16, 1/8, 1/4). The threshold 17 gives 17/256, not 16/256.
+
+### Crit Stage Sources
+
+| Source | Stage Bonus |
+|--------|------------|
+| High-crit moves (Slash, Razor Leaf, Crabhammer, Cross Chop, Karate Chop, Aeroblast) | +1 |
+| Focus Energy / Dire Hit | +1 |
+| Scope Lens (held item) | +1 |
+| Stick (Farfetch'd held item) | +2 |
+| Lucky Punch (Chansey held item) | +2 |
+
+### Focus Energy Fix
+
+**Fixed in Gen 2.** Focus Energy correctly adds +1 crit stage (not +2 as some sources claim — verify against pokecrystal). The Gen 1 divide-by-4 bug is gone.
+
+### Crit Damage Behavior
+
+Crits **double the level** in the damage formula (same mechanical approach as Gen 1).
+
+**Stat stage interaction** (unique to Gen 2):
+- If the target's defense stage modifier is greater than or equal to the attacker's attack stage modifier: crit ignores ALL stat stage changes on both sides, and ignores Reflect/Light Screen
+- If the attacker's attack stage modifier is greater: stat stages apply normally even for crits
+
+This means crits conditionally ignore stat changes — they ignore unfavorable situations for the attacker but keep favorable ones.
+
+---
+
+## 5. Accuracy
+
+### Formula
+
+Same as Gen 1: `threshold = floor(moveAccuracy * accStageMultiplier / evaStageMultiplier)`
+
+### 1/256 Miss Bug — Partially Fixed
+
+- If the computed threshold = 255 or higher (i.e., 100% accuracy with no stage modifiers), the move **always hits** (no random check)
+- If threshold < 255 (accuracy modified by stages), the 1/256 glitch can still occur
+- Swift still bypasses the accuracy check entirely
+
+### OHKO Moves
+
+- Fail if user's level < target's level (changed from Speed comparison in Gen 1)
+- Base accuracy: 30%
+- Accuracy increases by 1% per level the user is above the target
+- Not affected by accuracy/evasion stage modifiers
+
+---
+
+## 6. Status Conditions
+
+### Sleep
+
+- **Duration:** 1-7 turns (random)
+- **CAN act on wake turn** (unlike Gen 1 where you couldn't)
+- Sleep counter decremented at the start of the turn; if it hits 0, wake up AND act
+- Sleep counter does NOT reset on switch (persists across switches)
+- Sleep Talk and Snore can be used while asleep (new in Gen 2)
+
+### Freeze
+
+- **Natural thaw: 25/256 per turn** (≈9.77%, NOT 20%)
+- Checked at the start of the turn; if thaw, Pokemon CAN act
+- Also thaws from: damaging Fire-type moves, Flame Wheel (self-thaw), Sacred Fire (self-thaw)
+- Haze no longer cures freeze (Gen 1 only)
+- Ice-type Pokemon cannot be frozen (immunity added in Gen 2)
+
+### Burn
+
+- **1/8 max HP damage per turn** (increased from Gen 1's 1/16)
+- **Halves Attack stat** (applied to the stat directly, not as a damage modifier)
+- Fire-type Pokemon cannot be burned (immunity added in Gen 2)
+
+### Poison (Regular)
+
+- **1/8 max HP damage per turn** (same as Gen 1)
+- Poison-type and Steel-type Pokemon cannot be poisoned
+
+### Toxic (Bad Poison)
+
+- Starts at 1/16 max HP, escalates by 1/16 each turn (N/16 where N = turn count)
+- **Counter resets on switch** (reverts to regular poison in Gen 2)
+- The Gen 1 toxic counter bug (shared with burn/Leech Seed) is **fixed in Gen 2**
+
+### Paralysis
+
+- 25% chance (63/256) of full paralysis each turn
+- Speed quartered (×0.25)
+- Electric-type Pokemon CAN be paralyzed in Gen 2 (no immunity until Gen 6)
+
+### Confusion
+
+- Duration: 2-5 turns
+- 50% chance to hit self each turn
+- Self-hit: 40 power, typeless, physical, uses own Attack/Defense, no crit
+- Clears on switch-out
+
+---
+
+## 7. Held Items
+
+### Key Battle Items
+
+| Item | Effect | Timing |
+|------|--------|--------|
+| Leftovers | Recover 1/16 max HP | End of turn |
+| Scope Lens | +1 crit stage | Passive |
+| King's Rock | 10% flinch on any damaging move | On hit |
+| Quick Claw | ~23.4% chance to go first (60/256) | Start of turn |
+| Focus Band | 12% chance to survive lethal hit at 1 HP | On hit |
+| Bright Powder | Reduces opponent's accuracy by ~6% | Passive |
+| Light Ball | Doubles Pikachu's Sp.Atk | Passive |
+| Thick Club | Doubles Cubone/Marowak's Attack | Passive |
+| Metal Powder | Doubles Ditto's Defense (untransformed) | Passive |
+| Berry | Restores 10 HP when HP ≤ 50% | Auto |
+| Gold Berry | Restores 30 HP when HP ≤ 50% | Auto |
+| PSNCureBerry | Cures poison | Auto |
+| PRZCureBerry | Cures paralysis | Auto |
+| Ice Berry | Cures burn | Auto |
+| Mint Berry | Cures sleep | Auto |
+| MiracleBerry | Cures any status | Auto |
+| Bitter Berry | Cures confusion | Auto |
+
+**Important:** Gen 2 does NOT use Cheri Berry, Pecha Berry, Lum Berry, etc. Those are Gen 3+ berry names.
+
+### Type-Boosting Items
+
+All give **1.1x (10%) boost** to matching type moves. See §3 for full list.
+
+---
+
+## 8. Weather
+
+### Rain Dance
+
+- Duration: 5 turns
+- Water moves: ×1.5 damage
+- Fire moves: ×0.5 damage
+- Thunder: bypasses accuracy check (always hits)
+- SolarBeam: halved power (60 instead of 120)
+- Moonlight/Morning Sun: restores 1/4 max HP (instead of 1/2)
+
+### Sunny Day
+
+- Duration: 5 turns
+- Fire moves: ×1.5 damage
+- Water moves: ×0.5 damage
+- SolarBeam: charges instantly (no charge turn)
+- Moonlight/Morning Sun: restores 3/4 max HP
+- Synthesis: restores 3/4 max HP
+
+### Sandstorm
+
+- Duration: 5 turns
+- Deals 1/8 max HP damage to non-Rock/Ground/Steel Pokemon at end of turn
+- Does NOT boost Rock-type Sp.Def (that's Gen 4+)
+
+---
+
+## 9. Move Mechanics
+
+### New Priority Moves
+
+| Move | Priority | Notes |
+|------|----------|-------|
+| Protect / Detect | +3 | Blocks most moves for one turn |
+| Endure | +3 | Survives at 1 HP |
+| Quick Attack | +1 | Same as Gen 1 |
+| Mach Punch | +1 | New Fighting priority move |
+| ExtremeSpeed | +1 | New Normal priority move |
+| Vital Throw | -1 | Never misses, goes last |
+| Counter | -1 | Same as Gen 1 |
+| Mirror Coat | -1 | Reflects special damage (new) |
+| Roar / Whirlwind | -1 | Forces switch (now works on trainers) |
+
+### Protect / Detect
+
+- First use: always succeeds
+- Success rate: `1/(X)` where X starts at 1 and multiplies by 3 each consecutive use
+  - Use 1: 100%, Use 2: ~33% (255/256), Use 3: ~11%, Use 4: ~4%
+- Counter resets when a different move is used
+- X caps at 255 (not 729 — verify against pokecrystal)
+
+### Pursuit
+
+- Normal priority (0)
+- If the target is switching out on the same turn: Pursuit executes BEFORE the switch at **double power** (80 instead of 40)
+- If target is not switching: executes normally at 40 power
+
+### Baton Pass
+
+Passes to the replacement:
+- All stat stage changes (+/- Attack, Defense, etc.)
+- Substitute (and its remaining HP)
+- Mean Look/Spider Web trapping
+- Confusion
+- Leech Seed
+- Focus Energy
+- Curse (Ghost-type)
+- Perish Song countdown
+
+Does NOT pass: primary status conditions (burn, sleep, etc.)
+
+### Spikes
+
+- Entry hazard: damages Pokemon switching in
+- 1/8 max HP damage on switch-in
+- Only 1 layer in Gen 2 (no stacking until Gen 3)
+- Does not affect Flying types
+- Removed by Rapid Spin
+
+### Thief
+
+- 60 power, Dark type, 100% accuracy
+- Steals opponent's held item (attacker gains it)
+- Only steals if attacker has no held item
+- Cannot steal mail items
+
+### Rapid Spin
+
+- 20 power, Normal type, 100% accuracy
+- Removes: Spikes, Leech Seed, binding moves (Wrap/Bind/etc.) from user's side
+
+### Perish Song
+
+- All Pokemon on the field receive a 3-turn perish counter
+- After 3 turns, if still on the field, the Pokemon faints
+- Counter ticks down at end of each turn
+- Switching resets the counter (Pokemon is safe)
+- Soundproof blocks it (but no abilities in Gen 2)
+
+### Mean Look / Spider Web
+
+- Prevents target from switching
+- Effect ends when user switches out
+- Baton Pass passes the trapping effect
+
+### Return / Frustration
+
+- Return: power = friendship / 2.5 (max 102 at 255 friendship)
+- Frustration: power = (255 - friendship) / 2.5 (max 102 at 0 friendship)
+
+### Reflect / Light Screen
+
+- Duration: **5 turns** (changed from Gen 1's permanent until switch)
+- Doubles Defense (Reflect) or Sp.Def (Light Screen) during damage calc
+- Ignored by critical hits
+
+### Counter / Mirror Coat
+
+- Counter: reflects **physical** damage at 2x (priority -1)
+- Mirror Coat: reflects **special** damage at 2x (priority -1, new in Gen 2)
+- In Gen 2, Counter works against any physical-type move (including Dark, Ghost, etc.)
+
+### Hyper Beam
+
+- Same as Gen 1: skips recharge on KO
+- Also skips recharge if it misses
+- No longer skips recharge on Substitute break (changed from Gen 1 — verify)
+
+### Trapping Moves (Wrap, Bind, Fire Spin, Clamp, Whirlpool)
+
+- Nerfed from Gen 1: target CAN attack while trapped (just can't switch)
+- Duration: 2-5 turns
+- Deal 1/16 max HP per turn (verified)
+- User is NOT locked into the move (can choose different moves)
+
+---
+
+## 10. End-of-Turn Order
+
+The exact end-of-turn order in Gen 2 (GSC):
+
+```
+1. Leftovers recovery (1/16 max HP)
+2. Burn damage (1/8 max HP)
+3. Poison damage (1/8 max HP) / Toxic damage (N/16 max HP)
+4. Leech Seed drain (1/8 max HP, heals the seeder)
+5. Nightmare damage (1/4 max HP, only while asleep)
+6. Curse damage (1/4 max HP, from Ghost-type Curse)
+7. Sandstorm damage (1/8 max HP for non-Rock/Ground/Steel)
+8. Perish Song countdown (decrement, faint at 0)
+9. Weather turn decrement
+10. Check fainting
+```
+
+**Critical: Leftovers triggers BEFORE status damage.** This is competitively significant — a Pokemon can heal from Leftovers and then take burn/poison damage, potentially surviving when it otherwise wouldn't.
+
+---
+
+## 11. Switching Mechanics
+
+### What Resets on Switch-Out
+
+- Stat stages (all reset to 0)
+- Confusion
+- Toxic counter (reverts to regular poison)
+- Trapping (Wrap, Mean Look, etc.)
+- Disable
+- Encore
+- Attract
+- Nightmare
+- Torment (doesn't exist in Gen 2)
+
+### What Persists
+
+- Primary status (burn, freeze, paralysis, poison, sleep)
+- Sleep counter (does NOT reset)
+- PP usage
+
+### Entry Effects on Switch-In
+
+- Spikes damage (1/8 max HP, if not Flying-type)
+- Held berry activation (if applicable)
+
+---
+
+## 12. Known Bugs & Quirks
+
+| Bug/Quirk | Description |
+|-----------|-------------|
+| 1/256 miss (partial) | Still exists for modified accuracy < 255 |
+| Belly Drum + stat overflow | If Belly Drum sets Attack to exactly 999, badge boost can overflow |
+| Present heal | Present can heal the opponent (random damage/healing move) |
+| Beat Up | Each hit uses a different party member's Attack stat |
+| Thick Club + Transform | If Ditto transforms into Cubone/Marowak and holds Thick Club, gets double Attack |
+| Struggle | 50 power, Normal type, 1/4 max HP recoil (changed from Gen 1's 50% damage dealt) — VERIFY this |
+| Sleep Talk | Can call any move including two-turn moves (but won't charge) |
+
+---
+
+## References
+
+- pret/pokecrystal: https://github.com/pret/pokecrystal
+- Bulbapedia Damage (Gen II): https://bulbapedia.bulbagarden.net/wiki/Damage
+- Bulbapedia Critical Hit: https://bulbapedia.bulbagarden.net/wiki/Critical_hit
+- Bulbapedia Status Conditions: https://bulbapedia.bulbagarden.net/wiki/Status_condition
+- Smogon GSC Mechanics: https://www.smogon.com/forums/threads/gsc-mechanics.3542417/
+- Smogon GSC Research Thread: https://www.smogon.com/forums/threads/gsc-research-thread.67609/
+- Smogon GSC Status Guide: https://www.smogon.com/gs/articles/status

--- a/specs/reference/gen2-spec-issues.md
+++ b/specs/reference/gen2-spec-issues.md
@@ -1,0 +1,189 @@
+# Gen 2 Spec Issues: 03-gen2.md vs Ground Truth
+
+Every discrepancy between the existing spec and the ground-truth reference.
+Severity: CRITICAL (wrong behavior), MAJOR (missing mechanic), MINOR (cosmetic/clarity).
+
+---
+
+## CRITICAL Issues
+
+### 1. Stat Formula Is Wrong
+**Location:** Section 2, lines 37-38
+**Problem:** Uses `2 * base + DV + EV / 4` but should use `(Base + DV) * 2 + floor(ceil(sqrt(statExp)) / 4)`. Same bug as Gen 1 spec — wrong order of operations and missing sqrt for stat experience.
+**Impact:** Every stat calculation is wrong.
+
+### 2. HP Formula Constant Is Wrong
+**Location:** Section 2, line 37
+**Problem:** HP formula ends with `+ level + 5` but should be `+ level + 10`.
+**Impact:** Every HP calculation is 5 too low.
+
+### 3. Freeze Thaw Chance Is Wrong
+**Location:** Section 8, line 522
+**Problem:** Spec says "20% chance to thaw each turn." Actual is **25/256 ≈ 9.77%**. This is a massive difference — 20% vs ~10%.
+**Impact:** Frozen Pokemon thaw roughly twice as often as they should.
+
+### 4. Poison Type Listed as Special
+**Location:** Section 4, line 219 and Section 9, line 544, line 850
+**Problem:** Poison is listed under `SPECIAL_TYPES`. Poison is **Physical** in Gen 2.
+**Impact:** All Poison-type moves use wrong stat pair (Sp.Atk/Sp.Def instead of Attack/Defense).
+
+### 5. Leech Seed Missing from End-of-Turn
+**Location:** Section 11, line 768-769
+**Problem:** Spec says "Leech Seed: Not present in Gen 2." **Leech Seed has existed since Gen 1.** It absolutely exists in Gen 2 and deals 1/8 max HP per turn.
+**Impact:** Entire mechanic missing.
+
+### 6. Leftovers Timing Wrong
+**Location:** Section 11, line 771-777
+**Problem:** Spec has Leftovers at Step 4 (after status damage). In Gen 2, **Leftovers triggers BEFORE burn/poison damage** (Step 1 of end-of-turn). This is competitively significant.
+**Impact:** Pokemon survive/faint incorrectly at low HP.
+
+### 7. Damage Formula Missing Integer Truncation
+**Location:** Section 4, line 182
+**Problem:** The formula `((((2 * level / 5 + 2) * move.power * atkStat) / defStat) / 50) + 2` has no `Math.floor()` calls. Every intermediate step needs floor truncation.
+**Impact:** Damage calculations can be off by several points.
+
+### 8. Random Factor Implementation Wrong
+**Location:** Section 4, lines 201-203
+**Problem:** Spec uses `85 + Math.floor(Math.random() * 16)` giving integers 85-100 divided by 100. Actual Gen 2 uses `random(217..255) / 255` which gives different values (217/255 = 0.851, not 85/100 = 0.85).
+**Impact:** Slight damage calculation errors.
+
+---
+
+## MAJOR Issues
+
+### 9. Critical Hit Thresholds Are Approximate
+**Location:** Section 5, lines 261-266
+**Problem:** Spec uses `1/16, 1/8, 1/4, 1/2` but actual Gen 2 thresholds are **17/256, 32/256, 64/256, 85/256, 128/256**. The base rate 17/256 ≈ 6.64%, not 6.25% (1/16). Stage 3 is 85/256 ≈ 33.2%, not 50% (1/2).
+**Impact:** Crit rates off for every stage.
+
+### 10. Critical Hit Stat Interaction Not Documented
+**Location:** Section 5
+**Problem:** Gen 2 crits have conditional stat stage behavior: if defender's stage ≥ attacker's stage, ignore all stages. If attacker's stage > defender's, keep stages. This is completely undocumented.
+**Impact:** Crit damage calculated incorrectly in many scenarios.
+
+### 11. Sleep: Can Act on Wake Turn Not Mentioned
+**Location:** Section 8, lines 476-478
+**Problem:** Spec doesn't mention that Gen 2 Pokemon CAN act on the turn they wake up (unlike Gen 1 where they couldn't). This is a significant competitive change.
+**Impact:** Sleep is effectively 1 turn longer than it should be.
+
+### 12. Type Chart Has Fairy References
+**Location:** Section 3, lines 99, 104, 105, 112, 113, 114
+**Problem:** Multiple type entries reference "Fairy" type which doesn't exist until Gen 6. Needs removal.
+**Impact:** Phantom type interactions.
+
+### 13. Steel Weaknesses Wrong
+**Location:** Section 3, line 123
+**Problem:** Spec says Steel is weak to "Fire, Water, Electric, Ground." Water and Electric are NOT super effective vs Steel. Steel's weaknesses are **Fire, Fighting, Ground**.
+**Impact:** Two incorrect type matchups.
+
+### 14. Type-Boosting Items Wrong Multiplier
+**Location:** Section 6, line 342
+**Problem:** Comments say "+20%" but Gen 2 type-boosting items give **1.1x (10%)**. The 1.2x (20%) multiplier is Gen 4+.
+**Impact:** Type-boosted moves do 10% too much damage.
+
+### 15. Wrong Berry Names
+**Location:** Section 6, lines 315-322
+**Problem:** Uses Gen 3+ berry names (Cheri Berry, Pecha Berry). Gen 2 uses PSNCureBerry, PRZCureBerry, Mint Berry, Ice Berry, etc. Also references Lum Berry (lines 517, 532) which is Gen 3+.
+**Impact:** Wrong item names, won't match data.
+
+### 16. Stat Boost Berries Don't Exist in Gen 2
+**Location:** Section 6, lines 326-336
+**Problem:** Pomeg/Kelpsy/Qualot/Hondew/Grepa/Tamato berries don't exist in Gen 2. These are Gen 3+ berries that reduce EVs.
+**Impact:** Phantom items.
+
+### 17. Burn Applied as Post-Modifier
+**Location:** Section 4, lines 206-208
+**Problem:** Burn is applied after the random factor. Burn should halve the Attack stat BEFORE damage calculation begins, not as a damage modifier at the end.
+**Impact:** Burn damage calculation order wrong.
+
+### 18. Protect Success Formula Wrong
+**Location:** Section 9, line 557
+**Problem:** Spec says "50% on second use." Actual is 1/3 (~33%) — the denominator multiplies by 3 each use, not 2.
+**Impact:** Protect succeeds too often on repeated use.
+
+### 19. Trapping Moves Not Updated for Gen 2
+**Location:** Not in spec
+**Problem:** Gen 2 massively nerfed trapping moves from Gen 1. Target CAN attack while trapped (just can't switch). User is NOT locked into the move. This is not documented.
+**Impact:** Trapping moves behave like Gen 1 (way too strong).
+
+### 20. Thunder/SolarBeam Weather Interactions Missing
+**Location:** Section 7
+**Problem:** Thunder has perfect accuracy in Rain. SolarBeam charges instantly in Sun and has halved power in Rain. Neither documented.
+**Impact:** Missing weather-move interactions.
+
+### 21. Reflect/Light Screen Duration Wrong
+**Location:** Not explicitly stated
+**Problem:** Gen 2 Reflect/Light Screen last 5 turns (changed from Gen 1's permanent). Not clearly documented.
+**Impact:** Screens may last wrong duration.
+
+### 22. OHKO Mechanics Changed
+**Location:** Not in spec
+**Problem:** Gen 2 OHKO moves use level comparison (fail if user < target level), not Speed comparison like Gen 1. This isn't documented.
+**Impact:** OHKO moves use wrong comparison.
+
+---
+
+## MINOR Issues
+
+### 23. Wake-Up Slap Doesn't Exist
+**Location:** Section 8, line 479
+**Problem:** "Wake-Up Slap is a new move that hits harder vs. Sleep" — Wake-Up Slap was introduced in Gen 4, not Gen 2.
+**Impact:** Non-existent move referenced.
+
+### 24. Assault Vest Referenced
+**Location:** Section 6, line 379
+**Problem:** Assault Vest is Gen 6+, not Gen 2.
+**Impact:** Non-existent item referenced.
+
+### 25. Shiny Determination Algorithm Incomplete
+**Location:** Section 2, lines 51-73
+**Problem:** The shiny check code is vague and says "use Bulbapedia's exact algorithm." Should document the actual DV requirements: Atk DV in {2,3,6,7,10,11,14,15}, Def/Spd/Spc DVs all = 10.
+**Impact:** Shiny check not implementable from spec.
+
+### 26. Missing Nightmare and Curse Mechanics
+**Location:** Not in spec
+**Problem:** Nightmare (1/4 max HP while asleep) and Ghost-type Curse (1/4 max HP per turn, costs 1/2 user HP) are not documented, but they appear in end-of-turn.
+**Impact:** Missing mechanics.
+
+### 27. Baton Pass Details Incomplete
+**Location:** Section 9, line 578
+**Problem:** "Deals damage; if opponent switches, damage is doubled" — this describes Pursuit, not Baton Pass. Baton Pass needs its own section listing what it passes.
+**Impact:** Key competitive mechanic underdocumented.
+
+### 28. Counter Works Differently in Gen 2
+**Location:** Not documented
+**Problem:** In Gen 2, Counter reflects damage from any physical-type move (based on the type's physical/special classification). This is broader than Gen 1's Normal/Fighting only.
+**Impact:** Counter interacts with wrong moves.
+
+### 29. HP DV Derivation Not Documented
+**Location:** Section 2
+**Problem:** Same as Gen 1 — HP DV derived from parity of other DVs, not documented.
+**Impact:** Missing mechanic.
+
+### 30. Breeding DV Inheritance Wrong
+**Location:** Section 10, lines 653-656
+**Problem:** Code shows 50/50 random inheritance per stat. Actual Gen 2 breeding: Attack DV random, Defense DV from one parent, Speed/Special from one parent. It's more complex than shown.
+**Impact:** Wrong breeding implementation.
+
+### 31. Pokérus Doubles Stat Exp, Not +50% EXP
+**Location:** Section 10, lines 724-726
+**Problem:** Spec says "+50% EXP while infected." Pokérus actually **doubles stat experience gain**, not regular EXP gain.
+**Impact:** Wrong Pokérus effect.
+
+### 32. Sandstorm Damage in Wrong End-of-Turn Position
+**Location:** Section 11
+**Problem:** Spec has Sandstorm as Step 1 (before status damage). In the ground truth order, Sandstorm is Step 7 (after Leech Seed, Nightmare, Curse).
+**Impact:** Sandstorm timing wrong.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| CRITICAL | 8 |
+| MAJOR | 14 |
+| MINOR | 10 |
+| **Total** | **32** |
+
+The Gen 2 spec shares many of the same fundamental issues as Gen 1 (stat formula, HP constant, missing truncation) plus has numerous Gen 2-specific errors (freeze thaw rate, Leftovers timing, Poison type classification, wrong item names/multipliers).


### PR DESCRIPTION
## Summary

- Copies 4 audit artifact documents from local planning directory into `specs/reference/` for permanent archival in the repo
- Adds a `README.md` explaining these are research artifacts, not authoritative specs
- These documents are useful for understanding what was investigated, what was found, and why decisions were made

## Background

During audit work on Gen 1 and Gen 2 mechanics, ground-truth reference documents and spec-issue tracking files were created outside the repo. This PR archives them so future contributors can reference them when working on those generations.

The findings from these documents were already applied:
- Gen 1 findings (28 total) → applied via PR #30
- Gen 2 findings (32 total) → applied via PR #29

The authoritative specs remain in `specs/battle/` — these reference documents are supplementary research artifacts only.

## Files Added

- `specs/reference/gen1-ground-truth.md` — Verified Gen 1 mechanics findings
- `specs/reference/gen2-ground-truth.md` — Verified Gen 2 mechanics findings
- `specs/reference/gen1-spec-issues.md` — Gen 1 spec issues found during audit
- `specs/reference/gen2-spec-issues.md` — Gen 2 spec issues found during audit
- `specs/reference/README.md` — Explains the purpose and scope of this directory

## Test plan

- [ ] Docs-only change — no typecheck or test required
- [ ] Biome check run (markdown files are not linted by Biome)
- [ ] Verify files are readable and correctly placed under `specs/reference/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Closes: N/A