### PR TITLE
docs(gen2): add 4 missing mechanics — damage cap, stat overflow, Self-Destruct halving, 1/256 miss

### DIFF
--- a/specs/battle/03-gen2.md
+++ b/specs/battle/03-gen2.md
@@ -295,6 +295,8 @@ function getWeatherModifier(moveType: PokemonType, weather: Weather | null): num
 - **Rounding**: `Math.floor()` is applied at every intermediate step — do not accumulate floating point and round once at the end
 - **Random factor**: `random(217..255) / 255` (approximately 85.1%–100%), not 85/100–100/100
 - **Burn**: Halves the Attack stat value before the damage formula runs; it is not a post-damage multiplier
+- **Pre-random cap**: Cap base damage at 997 before applying the random factor. If pre-random damage > 997, use 997. This matches Gen 1 behavior and prevents overflow in edge cases with very high stats.
+- **Stat overflow**: If the attacking stat (Atk or SpA) or defending stat (Def or SpD) used in the formula is ≥ 256, divide **both** stats by 4 (integer division) before the damage formula runs. Same as Gen 1 — this is the original game's overflow handling for extreme stat values.
 
 ### Item Modifiers in Damage Calculation
 
@@ -745,6 +747,50 @@ Baton Pass transfers the following from the user to the incoming replacement:
 - Focus Energy
 - Curse (if Ghost-type Curse was used)
 - Perish Song countdown
+
+#### Self-Destruct and Explosion — Defense Halving
+
+Same behavior as Gen 1: when Self-Destruct or Explosion is used, the **target's Defense stat is halved** (integer division) before the damage formula runs. This is not a stat stage change — it is a temporary halving applied only during that move's damage calculation.
+
+```typescript
+function calculateExplosionDamage(
+  attacker: Pokémon,
+  defender: Pokémon,
+  move: Move, // Self-Destruct or Explosion
+): number {
+  // Temporarily halve defender's defense for this calculation only
+  const effectiveDef = Math.floor(defender.stats.DEF / 2);
+  // ... rest of damage formula using effectiveDef instead of defender.stats.DEF
+}
+```
+
+#### Accuracy and the 1/256 Miss Bug (Partial Fix)
+
+Gen 2 partially fixed the 1/256 miss bug from Gen 1:
+
+- **Always-hit case**: If a move has **100% base accuracy** and **no accuracy/evasion stage modifiers** are active, the move always hits. The 1/256 miss cannot occur.
+- **Glitch still applies**: If accuracy has been modified (any stage changes to accuracy or evasion), or if the move's base accuracy is less than 100%, the 1/256 miss glitch still applies. The accuracy byte can end up at 255, which in Gen 2's 0-255 roll system means a 1/256 miss chance remains.
+
+```typescript
+function accuracyCheck(
+  move: Move,
+  attacker: Pokémon,
+  defender: Pokémon,
+): boolean {
+  const accStage = attacker.battleStats.accuracyStage;
+  const evaStage = defender.battleStats.evasionStage;
+
+  // Gen 2 partial fix: 100% accuracy moves with no stage modifiers always hit
+  if (move.accuracy === 100 && accStage === 0 && evaStage === 0) {
+    return true; // Always hits — no 1/256 miss
+  }
+
+  // Otherwise, apply standard accuracy calculation (1/256 glitch still applies)
+  const accuracyValue = computeAccuracyValue(move, accStage, evaStage);
+  const roll = Math.floor(Math.random() * 256);
+  return roll < accuracyValue; // If accuracyValue is 255, still 1/256 miss chance
+}
+```
 
 ### Move Pool Changes
 


### PR DESCRIPTION
## Summary

Adds 4 mechanics to `specs/battle/03-gen2.md` that are documented in the Gen 1 spec and confirmed in ground-truth research but were missing from the Gen 2 spec:

- **Pre-random damage cap at 997**: Base damage is capped at 997 before applying the random factor, preventing overflow with very high stats. Matches Gen 1 behavior.
- **Stat overflow handling**: If Atk/SpA or Def/SpD used in the damage formula is ≥ 256, both stats are divided by 4 (integer division) before the formula runs. Same as Gen 1's original overflow handling.
- **Self-Destruct/Explosion defense halving**: The target's Defense stat is halved (integer division) before damage calculation when these moves are used — not a stat stage change, just a temporary calculation modifier. Same as Gen 1.
- **1/256 miss bug (partial fix)**: Gen 2 partially fixed the Gen 1 glitch. Moves with 100% base accuracy and no active accuracy/evasion stage modifiers always hit. The 1/256 miss chance still applies when any stage modifiers are active or base accuracy < 100%.

## Test plan

- [ ] Verify damage cap note is under Section 4 "Damage Formula Notes"
- [ ] Verify stat overflow note is under Section 4 "Damage Formula Notes"
- [ ] Verify Self-Destruct subsection is in Section 10 before "Move Pool Changes"
- [ ] Verify 1/256 miss subsection is in Section 10 before "Move Pool Changes"
- [ ] Docs-only change — no typecheck or test run needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #57
Closes #58
Closes #59
Closes #60