### PR TITLE
docs: fix PR workflow — no-issue marker required, gh pr edit workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ Effort is session-wide (no per-agent control). Default: `high` (set in `~/.claud
 
 - **Always run `/review` before creating a PR** — mandatory. Runs falcon (correctness), kestrel (architecture), and sentinel (security) locally. Do not depend on CodeRabbit/Qodo — they can be rate-limited.
 - **Always run `/version` before creating a PR** — mandatory for any branch touching `packages/`. See Package Versioning above.
-- **Link issues in PR body**: if the branch fixes a GitHub issue, include `Closes #<number>` (or `Fixes #<number>`) in the PR body. GitHub auto-closes the issue when the PR merges. No issue? Leave it out — don't fabricate links.
+- **Link issues in PR body**: if the branch fixes a GitHub issue, include `Closes #<number>` (or `Fixes #<number>`) in the PR body. GitHub auto-closes the issue when the PR merges. No related issue (pure chore/docs/tooling)? Add `Closes: N/A` — the `check-issue-link` CI workflow requires either a closing reference or an explicit no-issue marker and will fail otherwise.
 - Use **`/babysit-pr`** for all PR monitoring (waiting for CI, reviewer comments, following up after fixes). Do NOT use manual polling.
 - **`/babysit-pr` auto-merges by default** and self-polls until complete — no `/loop` wrapper needed. Use `--no-merge` to require confirmation before merging.
 - **Act autonomously.** When handling a PR, agents should:
@@ -281,6 +281,7 @@ Effort is session-wide (no per-agent control). Default: `high` (set in `~/.claud
 - **After `gh pr merge --auto`**: always verify with `gh pr view <number> --json state` — the command produces no output on success
 - **CodeRabbit and Qodo are advisory only** — not required checks. Do not block merge on them. Required checks: `build`, `test`, `typecheck`, `lint`
 - **`gh pr checks` exit code 8 means pending**, not failure
+- **`gh pr edit` is broken for body edits** — it calls the deprecated GitHub Projects (classic) API and errors even when only updating `--body`. Use `gh api PATCH /repos/{owner}/{repo}/pulls/{number} --field body="..."` instead whenever you need to edit a PR body after creation.
 
 ### Pre-Push Validation (Mandatory)
 


### PR DESCRIPTION
## Summary

Two corrections to the PR Workflow section of `CLAUDE.md` discovered during PR #76 babysitting:

- **No-issue PRs**: Previous guidance said "No issue? Leave it out" — but the `check-issue-link` CI workflow *requires* either `Closes #N` or an explicit no-issue marker. Changed to: add `Closes: N/A` for pure chore/docs/tooling PRs.
- **`gh pr edit` broken**: `gh pr edit --body "..."` calls the deprecated GitHub Projects (classic) API and errors even when only editing the body. Documented the workaround: use `gh api PATCH /repos/{owner}/{repo}/pulls/{number} --field body="..."` instead.

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR workflow guidance to require explicit "Closes: N/A" marker when no related issue exists
  * Expanded escalation and proactive-fix guidance with additional scenarios and recommended actions
  * Added troubleshooting note regarding a limitation and recommended workaround for PR body edits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->