### PR TITLE
fix(gen1): correct Hyper Beam KO check to use post-engine currentHp

### DIFF
--- a/packages/gen1/src/Gen1Ruleset.ts
+++ b/packages/gen1/src/Gen1Ruleset.ts
@@ -307,7 +307,10 @@ export class Gen1Ruleset implements GenerationRuleset {
     // Source: gen1-ground-truth.md §7 — Hyper Beam
     // In Gen 1, Hyper Beam skips recharge if it KOs the target, breaks a Substitute, or misses.
     // The recharge flag on the move is handled by the engine; we signal skip via noRecharge.
-    if (move.flags.recharge && damage >= defender.pokemon.currentHp && damage > 0) {
+    // NOTE: By the time executeMoveEffect is called, the engine has already applied damage to
+    // defender.pokemon.currentHp (clamped to 0 on KO). So a KO is detected by checking currentHp === 0.
+    // We also require damage > 0 to avoid triggering on missed moves (damage = 0).
+    if (move.flags.recharge && damage > 0 && defender.pokemon.currentHp === 0) {
       result.noRecharge = true;
     }
 

--- a/packages/gen1/tests/bug-sweep-fixes.test.ts
+++ b/packages/gen1/tests/bug-sweep-fixes.test.ts
@@ -833,11 +833,13 @@ describe("Bug #101 — Trapping moves use 'bound' volatile key", () => {
 // ============================================================================
 
 describe("Bug #102 — Hyper Beam skips recharge on KO", () => {
-  it("given Hyper Beam damage equals defender's current HP, when executeMoveEffect is called, then noRecharge is true", () => {
+  it("given Hyper Beam KOs the defender, when executeMoveEffect is called post-engine, then noRecharge is true", () => {
     // Source: gen1-ground-truth.md §7 — Hyper Beam skips recharge if it KOs the target.
-    // Arrange — defender has 50 HP, Hyper Beam deals exactly 50 (KO)
+    // The engine applies damage to currentHp BEFORE calling executeMoveEffect, so a KO is
+    // indicated by defender.pokemon.currentHp === 0 at the time executeMoveEffect runs.
+    // Arrange — engine has already reduced defender to 0 HP (was 50, took 50)
     const defender = makeActivePokemon({
-      pokemon: { ...makeActivePokemon().pokemon, currentHp: 50 } as PokemonInstance,
+      pokemon: { ...makeActivePokemon().pokemon, currentHp: 0 } as PokemonInstance,
     });
     const hyperBeam = makeMove({
       id: "hyper-beam",
@@ -855,11 +857,11 @@ describe("Bug #102 — Hyper Beam skips recharge on KO", () => {
     expect(result.noRecharge).toBe(true);
   });
 
-  it("given Hyper Beam damage exceeds defender's current HP, when executeMoveEffect is called, then noRecharge is true", () => {
-    // Overkill case: damage > currentHp still counts as a KO
-    // Arrange
+  it("given Hyper Beam overkills the defender, when executeMoveEffect is called post-engine, then noRecharge is true", () => {
+    // Overkill case: damage > original HP still counts as a KO; engine clamps currentHp to 0.
+    // Arrange — engine has already reduced defender to 0 HP (was 30, took 50)
     const defender = makeActivePokemon({
-      pokemon: { ...makeActivePokemon().pokemon, currentHp: 30 } as PokemonInstance,
+      pokemon: { ...makeActivePokemon().pokemon, currentHp: 0 } as PokemonInstance,
     });
     const hyperBeam = makeMove({
       id: "hyper-beam",
@@ -877,11 +879,12 @@ describe("Bug #102 — Hyper Beam skips recharge on KO", () => {
     expect(result.noRecharge).toBe(true);
   });
 
-  it("given Hyper Beam damage is less than defender's current HP, when executeMoveEffect is called, then noRecharge is not set", () => {
+  it("given Hyper Beam does not KO the defender, when executeMoveEffect is called post-engine, then noRecharge is not set", () => {
     // Source: gen1-ground-truth.md §7 — Hyper Beam only skips recharge on KO.
-    // Arrange — defender survives
+    // The engine has already applied damage; defender.currentHp > 0 means it survived.
+    // Arrange — defender had 200 HP, took 50 damage; engine reduced currentHp to 150
     const defender = makeActivePokemon({
-      pokemon: { ...makeActivePokemon().pokemon, currentHp: 200 } as PokemonInstance,
+      pokemon: { ...makeActivePokemon().pokemon, currentHp: 150 } as PokemonInstance,
     });
     const hyperBeam = makeMove({
       id: "hyper-beam",


### PR DESCRIPTION
## Summary

Corrects a logic error in the Hyper Beam no-recharge-on-KO mechanic from #108 (issue #102).

**Root cause:** The engine applies damage to `defender.pokemon.currentHp` (clamping to 0 on KO) *before* calling `executeMoveEffect`. The previous check — `damage >= defender.pokemon.currentHp` — was evaluated post-damage, so it incorrectly triggered whenever damage exceeded remaining HP, not just on actual KOs.

**Fix:** Changed to `defender.pokemon.currentHp === 0` — the correct post-engine KO indicator. Updated 3 Hyper Beam test assertions to set `currentHp: 0` for KO scenarios, reflecting the actual engine contract.

## Test plan
- [ ] 3 Hyper Beam tests updated to match engine contract (post-damage currentHp)
- [ ] All 538 gen1 tests pass
- [ ] `npm run typecheck` clean
- [ ] `npx @biomejs/biome check --changed --since=main .` clean

Closes: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Hyper Beam's recharge mechanics to correctly identify KO conditions and determine when the move's recharge turn should be skipped based on accurate damage detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->