### PR TITLE
fix: skip constructor in BattleEngine.deserialize() via Object.create (#79)

### DIFF
--- a/packages/battle/package.json
+++ b/packages/battle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pokemon-lib-ts/battle",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -414,7 +414,14 @@ export class BattleEngine implements BattleEventEmitter {
     });
   }
 
-  /** Restore a battle from serialized state */
+  /** Restore a battle from serialized state.
+   *
+   * Uses Object.create to skip the constructor entirely — avoids wasteful
+   * stat recalculation, HP reset, and event emission that would be immediately
+   * overwritten. The serialized state already contains all computed values.
+   *
+   * Fix for: https://github.com/uehlbran/pokemon-lib-ts/issues/79
+   */
   static deserialize(
     data: string,
     ruleset: GenerationRuleset,
@@ -431,18 +438,34 @@ export class BattleEngine implements BattleEventEmitter {
       return value;
     }) as BattleState;
 
-    // Create a minimal config to construct the engine
-    const config: BattleConfig = {
-      generation: parsed.generation,
-      format: parsed.format,
-      teams: [parsed.sides[0].team, parsed.sides[1].team],
-      seed: 0, // Seed doesn't matter — we restore the RNG state
-    };
+    // Create the engine instance without running the constructor.
+    // This avoids: (1) stat recalculation, (2) HP reset to max,
+    // (3) requiring DataManager to have species data loaded.
+    const engine = Object.create(BattleEngine.prototype) as BattleEngine;
 
-    const engine = new BattleEngine(config, ruleset, dataManager);
-
-    // Overwrite the engine state with the deserialized state
-    Object.assign(engine.state, parsed);
+    // Initialize all instance fields. Uses Object.defineProperties to set
+    // private/readonly fields without requiring type casts to `any`.
+    Object.defineProperties(engine, {
+      state: { value: parsed, writable: false, enumerable: true, configurable: false },
+      ruleset: { value: ruleset, writable: false, enumerable: false, configurable: false },
+      dataManager: { value: dataManager, writable: false, enumerable: false, configurable: false },
+      listeners: { value: new Set(), writable: true, enumerable: false, configurable: false },
+      eventLog: { value: [], writable: true, enumerable: false, configurable: false },
+      pendingActions: { value: new Map(), writable: true, enumerable: false, configurable: false },
+      pendingSwitches: { value: new Map(), writable: true, enumerable: false, configurable: false },
+      sidesNeedingSwitch: {
+        value: new Set(),
+        writable: true,
+        enumerable: false,
+        configurable: false,
+      },
+      faintedPokemonThisTurn: {
+        value: new Set(),
+        writable: true,
+        enumerable: false,
+        configurable: false,
+      },
+    });
 
     return engine;
   }

--- a/packages/battle/tests/engine/deserialize.test.ts
+++ b/packages/battle/tests/engine/deserialize.test.ts
@@ -1,0 +1,228 @@
+import type { DataManager } from "@pokemon-lib-ts/core";
+import { SeededRandom } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import type { BattleConfig } from "../../src/context";
+import { BattleEngine } from "../../src/engine";
+import type { BattleEvent } from "../../src/events";
+import { createTestPokemon } from "../../src/utils";
+import { createMockDataManager } from "../helpers/mock-data-manager";
+import { MockRuleset } from "../helpers/mock-ruleset";
+
+function createTestEngine(overrides?: {
+  seed?: number;
+  ruleset?: MockRuleset;
+  dataManager?: DataManager;
+}): { engine: BattleEngine; ruleset: MockRuleset; events: BattleEvent[] } {
+  const ruleset = overrides?.ruleset ?? new MockRuleset();
+  const dataManager = overrides?.dataManager ?? createMockDataManager();
+  const events: BattleEvent[] = [];
+
+  const team1 = [
+    createTestPokemon(6, 50, {
+      uid: "charizard-1",
+      nickname: "Charizard",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 120,
+      },
+      currentHp: 200,
+    }),
+  ];
+
+  const team2 = [
+    createTestPokemon(9, 50, {
+      uid: "blastoise-1",
+      nickname: "Blastoise",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 80,
+      },
+      currentHp: 200,
+    }),
+  ];
+
+  const config: BattleConfig = {
+    generation: 1,
+    format: "singles",
+    teams: [team1, team2],
+    seed: overrides?.seed ?? 12345,
+  };
+
+  const engine = new BattleEngine(config, ruleset, dataManager);
+  engine.on((e) => events.push(e));
+
+  return { engine, ruleset, events };
+}
+
+describe("BattleEngine.deserialize", () => {
+  it("given a serialized battle state where currentHp is less than maxHp, when deserialized, then currentHp matches the saved value (not recalculated)", () => {
+    // Arrange — create an engine, start it, deal some damage to reduce HP
+    const ruleset = new MockRuleset();
+    const dataManager = createMockDataManager();
+    const { engine } = createTestEngine({ ruleset, dataManager });
+    engine.start();
+
+    // Directly reduce HP to simulate damage taken during a battle
+    // MockRuleset.calculateStats computes HP as: floor((2*78+31)*50/100)+50+10 = 153
+    // Source: MockRuleset.calculateStats formula in mock-ruleset.ts
+    const active = engine.getActive(0)!;
+    const maxHp = active.pokemon.calculatedStats!.hp;
+    const damagedHp = Math.floor(maxHp / 2); // Set to half HP
+    active.pokemon.currentHp = damagedHp;
+
+    // Serialize with the damaged HP
+    const serialized = engine.serialize();
+
+    // Act — deserialize the state
+    const restored = BattleEngine.deserialize(serialized, ruleset, dataManager);
+
+    // Assert — currentHp should be the damaged value, NOT full HP from stat recalculation
+    // Source: The bug is that the old `new BattleEngine(...)` constructor resets
+    // currentHp = calculatedStats.hp (full HP). After fix, deserialized HP should
+    // match the saved value exactly.
+    const restoredActive = restored.getActive(0)!;
+    expect(restoredActive.pokemon.currentHp).toBe(damagedHp);
+    expect(restoredActive.pokemon.currentHp).not.toBe(maxHp);
+  });
+
+  it("given a serialized battle state, when deserialized and a turn is executed, then the battle resumes correctly", () => {
+    // Arrange — create an engine, start it, run one turn, then serialize
+    const ruleset = new MockRuleset();
+    ruleset.setFixedDamage(10);
+    const dataManager = createMockDataManager();
+    const { engine } = createTestEngine({ ruleset, dataManager });
+    engine.start();
+
+    // Run one turn
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    const hpAfterTurn1Side0 = engine.getActive(0)!.pokemon.currentHp;
+    const hpAfterTurn1Side1 = engine.getActive(1)!.pokemon.currentHp;
+    const turnAfterFirst = engine.getState().turnNumber;
+
+    // Serialize after the first turn
+    const serialized = engine.serialize();
+
+    // Act — deserialize and run another turn
+    const restored = BattleEngine.deserialize(serialized, ruleset, dataManager);
+    const restoredEvents: BattleEvent[] = [];
+    restored.on((e) => restoredEvents.push(e));
+
+    restored.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    restored.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Assert — the battle should have advanced one turn from where it was serialized
+    // Source: Turn number increments by 1 per turn — engine state machine invariant
+    expect(restored.getState().turnNumber).toBe(turnAfterFirst + 1);
+
+    // Both sides should have taken additional damage (10 damage from MockRuleset)
+    // Source: MockRuleset.fixedDamage = 10 (set above)
+    const restoredHpSide0 = restored.getActive(0)!.pokemon.currentHp;
+    const restoredHpSide1 = restored.getActive(1)!.pokemon.currentHp;
+    expect(restoredHpSide0).toBe(hpAfterTurn1Side0 - 10);
+    expect(restoredHpSide1).toBe(hpAfterTurn1Side1 - 10);
+
+    // Should have emitted events for the second turn
+    const damageEvents = restoredEvents.filter((e) => e.type === "damage");
+    expect(damageEvents.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("given a serialized state with a specific PRNG state, when deserialized, then PRNG continues from that exact state", () => {
+    // Arrange — create two engines with the same seed, advance one by some RNG calls
+    const ruleset = new MockRuleset();
+    const dataManager = createMockDataManager();
+    const { engine } = createTestEngine({ seed: 42, ruleset, dataManager });
+    engine.start();
+
+    // Run a turn to advance the PRNG state
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Capture the PRNG state at this point
+    const rngStateBeforeSerialize = engine.getState().rng.getState();
+
+    // Generate the expected next values from a reference RNG with the same state
+    // Source: SeededRandom (Mulberry32) is deterministic — same state produces same sequence
+    const referenceRng = new SeededRandom(0);
+    referenceRng.setState(rngStateBeforeSerialize);
+    const expectedValue1 = referenceRng.next();
+    const expectedValue2 = referenceRng.next();
+
+    // Serialize the battle
+    const serialized = engine.serialize();
+
+    // Act — deserialize and read PRNG values
+    const restored = BattleEngine.deserialize(serialized, ruleset, dataManager);
+    const restoredRngState = restored.getState().rng.getState();
+
+    // Assert — PRNG state should match exactly
+    expect(restoredRngState).toBe(rngStateBeforeSerialize);
+
+    // And the next values from the deserialized RNG should match the reference
+    const actualValue1 = restored.getState().rng.next();
+    const actualValue2 = restored.getState().rng.next();
+    expect(actualValue1).toBe(expectedValue1);
+    expect(actualValue2).toBe(expectedValue2);
+  });
+
+  it("given a serialized battle state where currentHp is 1 (near faint), when deserialized, then currentHp is 1 (not reset to max)", () => {
+    // Arrange — second triangulation case for the HP preservation regression
+    const ruleset = new MockRuleset();
+    const dataManager = createMockDataManager();
+    const { engine } = createTestEngine({ ruleset, dataManager });
+    engine.start();
+
+    // Set HP to 1 (near-faint)
+    const active = engine.getActive(0)!;
+    const maxHp = active.pokemon.calculatedStats!.hp;
+    active.pokemon.currentHp = 1;
+
+    const serialized = engine.serialize();
+
+    // Act
+    const restored = BattleEngine.deserialize(serialized, ruleset, dataManager);
+
+    // Assert — HP should be 1, not maxHp
+    // Source: Same regression as above — constructor would reset to maxHp
+    const restoredActive = restored.getActive(0)!;
+    expect(restoredActive.pokemon.currentHp).toBe(1);
+    expect(restoredActive.pokemon.currentHp).not.toBe(maxHp);
+  });
+
+  it("given a deserialized engine, when on() is called, then listeners receive events", () => {
+    // Arrange — verify that the deserialized engine initializes listeners correctly
+    const ruleset = new MockRuleset();
+    const dataManager = createMockDataManager();
+    const { engine } = createTestEngine({ ruleset, dataManager });
+    engine.start();
+
+    const serialized = engine.serialize();
+
+    // Act
+    const restored = BattleEngine.deserialize(serialized, ruleset, dataManager);
+    const events: BattleEvent[] = [];
+    restored.on((e) => events.push(e));
+
+    // Run a turn to trigger events
+    restored.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    restored.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Assert — listener should have received events
+    // Source: Engine emits events for every turn action — this verifies that
+    // deserialized engines have a working listener set
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    const hasDamageEvent = events.some((e) => e.type === "damage");
+    expect(hasDamageEvent).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces `new BattleEngine(...)` + `Object.assign` with `Object.create(BattleEngine.prototype)` + `Object.defineProperties` in `deserialize()` to avoid unnecessary stat calculation, HP reset, and event emission
- Uses `Object.defineProperties` to initialize private fields without `as any` casts
- Adds 5 targeted tests for deserialization correctness (HP preservation, round-trip resume, PRNG continuity, listener initialization)
- Patch bump: battle 0.9.0 -> 0.9.1

Closes #79

## Test plan
- [x] Deserialized HP matches saved value (half HP), not recalculated max HP
- [x] Deserialized HP matches saved value (1 HP / near-faint), not recalculated max HP
- [x] Battle can resume after deserialization — turn number advances, damage applies correctly
- [x] PRNG continues from the serialized state — same state value, same next values
- [x] Deserialized engine listeners work — events are received after `on()` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Battle save/load functionality now correctly preserves current HP, turn progression, and random state when resuming saved games, ensuring consistent battle states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->