### PR TITLE
fix(ci): enforce correct issue-closing syntax — 6-layer defense

### DIFF
--- a/.claude/hooks/enforce-review-gate.sh
+++ b/.claude/hooks/enforce-review-gate.sh
@@ -35,5 +35,29 @@ if [ "$HEAD" != "$MARKER_COMMIT" ]; then
   exit 2
 fi
 
+# Check for orphaned issue references in the --body value only.
+# Extract the value after --body (handles: --body "text" and --body $'text').
+# We only scan the body argument itself to avoid false positives on command descriptions.
+BODY_VALUE=$(printf '%s' "$COMMAND" | sed -n "s/.*--body[[:space:]]\+'\([^']*\)'.*/\1/p")
+if [ -z "$BODY_VALUE" ]; then
+  BODY_VALUE=$(printf '%s' "$COMMAND" | sed -n 's/.*--body[[:space:]]\+"\([^"]*\)".*/\1/p')
+fi
+
+if [ -n "$BODY_VALUE" ]; then
+  # Pattern: closing keyword + #N followed by ", #M" or " #M" (orphaned ref after first).
+  if printf '%s\n' "$BODY_VALUE" | grep -qiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+([[:space:]]*,[[:space:]]*|[[:space:]]+)#[0-9]+'; then
+    echo "BLOCKED: PR body contains orphaned issue references." >&2
+    echo "" >&2
+    echo "  WRONG: Closes #50, #80, #85   (only closes #50)" >&2
+    echo "  WRONG: Closes #50 #80 #85     (only closes #50)" >&2
+    echo "" >&2
+    echo "  RIGHT: one keyword per issue, one per line:" >&2
+    echo "    Closes #50" >&2
+    echo "    Closes #80" >&2
+    echo "    Closes #85" >&2
+    exit 2
+  fi
+fi
+
 # Valid — allow PR creation
 exit 0

--- a/.claude/rules/issue-closing-syntax.md
+++ b/.claude/rules/issue-closing-syntax.md
@@ -1,0 +1,43 @@
+# Issue Closing Syntax
+
+GitHub only auto-closes an issue when the closing keyword (`Closes`, `Fixes`, `Resolves`)
+immediately precedes **that specific issue number**. Comma-separated or space-separated lists
+after a single keyword only close the first issue — the rest are merely "referenced."
+
+## Required Format
+
+```
+Closes #50
+Closes #80
+Closes #85
+```
+
+**One keyword per issue. One issue per line.**
+
+## Wrong Formats (do not use)
+
+```
+Closes #50, #80, #85   ← GitHub closes #50 only
+Closes #50 #80 #85     ← GitHub closes #50 only
+Closes: #50, #80       ← GitHub closes #50 only
+```
+
+## No Related Issue
+
+If the PR has no tracked issue, add this to the Related Issue section:
+
+```
+Closes: N/A
+```
+
+The `check-issue-link` CI workflow requires either a valid closing reference or an explicit
+no-issue marker and will block merge otherwise.
+
+## Variants
+
+All three keywords work identically:
+- `Closes #N`
+- `Fixes #N`
+- `Resolves #N`
+
+Case-insensitive: `closes`, `Closes`, `CLOSES` all work.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,15 @@
 
 ## Related Issue
 <!-- Bug fix or feature? Link the issue. Use "Closes #N" to auto-close on merge. -->
-<!-- No related issue? Write "N/A" and briefly explain why. -->
+<!-- No related issue? Write "Closes: N/A" and briefly explain why. -->
+<!--
+  WRONG: Closes #50, #80, #85   <- GitHub only closes #50; the rest are merely referenced
+  WRONG: Closes #50 #80 #85     <- same problem — only #50 is closed
+  RIGHT: one keyword per issue, one issue per line:
+    Closes #50
+    Closes #80
+    Closes #85
+-->
 Closes #
 
 ## Changes

--- a/.github/workflows/check-issue-link.yml
+++ b/.github/workflows/check-issue-link.yml
@@ -17,23 +17,61 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # Pass if body contains a closing keyword + issue number
-          if echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+'; then
-            echo "Issue reference found."
-            exit 0
-          fi
-
           # Pass if explicitly marked as no-issue (pure tooling/docs/chore)
           if echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves)[[:space:]]*:[[:space:]]*n/?a|no.?issue|not.?applicable'; then
             echo "Explicitly marked as no related issue."
             exit 0
           fi
 
-          echo "PR body must include a closing reference (e.g. 'Closes #42') or mark as no-issue."
-          echo ""
-          echo "If this PR fixes a tracked bug or implements a tracked feature:"
-          echo "  Add 'Closes #N' to the PR body so GitHub auto-closes the issue on merge."
-          echo ""
-          echo "If this PR has no related issue (pure chore, docs, tooling):"
-          echo "  Add 'Closes: N/A' to the Related Issue section and explain why."
-          exit 1
+          # Require at least one properly-formed closing reference
+          if ! echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+'; then
+            echo "ERROR: PR body must include a closing reference or a no-issue marker."
+            echo ""
+            echo "To auto-close a tracked issue on merge:"
+            echo "  RIGHT:  Closes #50"
+            echo "  RIGHT:  Closes #80"
+            echo ""
+            echo "No related issue? Add 'Closes: N/A' to the Related Issue section."
+            exit 1
+          fi
+
+          # Detect orphaned issue references.
+          # An orphaned ref is a #N on a closing-keyword line that lacks its own keyword prefix.
+          # Example: "Closes #50, #80" — only #50 is closed; #80 is merely referenced.
+          ORPHAN_FOUND=false
+          ORPHAN_LINES=""
+
+          while IFS= read -r line; do
+            # Only inspect lines that contain a closing keyword
+            if echo "$line" | grep -qiE '(closes|fixes|resolves)'; then
+              # Count closing keyword+issue pairs on this line
+              KEYWORD_PAIRS=$(echo "$line" | grep -oiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+' | wc -l)
+              # Count ALL issue refs (#N) on this line
+              ALL_REFS=$(echo "$line" | grep -oE '#[0-9]+' | wc -l)
+
+              if [ "$ALL_REFS" -gt "$KEYWORD_PAIRS" ]; then
+                ORPHAN_FOUND=true
+                ORPHAN_LINES="${ORPHAN_LINES}  ${line}\n"
+              fi
+            fi
+          done <<< "$PR_BODY"
+
+          if [ "$ORPHAN_FOUND" = "true" ]; then
+            echo "ERROR: Orphaned issue references detected. GitHub only auto-closes the FIRST"
+            echo "issue after a closing keyword. Each issue needs its own keyword."
+            echo ""
+            echo "Offending line(s):"
+            printf '%b' "$ORPHAN_LINES"
+            echo ""
+            echo "WRONG:  Closes #50, #80, #85   <- only closes #50"
+            echo "WRONG:  Closes #50 #80 #85     <- only closes #50"
+            echo ""
+            echo "RIGHT (one keyword per issue):"
+            echo "  Closes #50"
+            echo "  Closes #80"
+            echo "  Closes #85"
+            exit 1
+          fi
+
+          echo "Issue reference(s) valid."
+          exit 0

--- a/.github/workflows/verify-issue-closures.yml
+++ b/.github/workflows/verify-issue-closures.yml
@@ -1,0 +1,81 @@
+name: Verify Issue Closures
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: read
+  pull-requests: write
+
+jobs:
+  verify-closures:
+    name: "Verify issue auto-closures"
+    # Only run when the PR was merged (not just closed/abandoned)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for GitHub to propagate closures
+        run: sleep 15
+
+      - name: Extract and verify closing references
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Extract issue numbers from closing keyword lines (safe: only digits pass through)
+          CLOSING_ISSUES=$(echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
+
+          if [ -z "$CLOSING_ISSUES" ]; then
+            echo "No closing references found in PR body. Nothing to verify."
+            exit 0
+          fi
+
+          echo "Closing references found: $(echo "$CLOSING_ISSUES" | tr '\n' ' ')"
+
+          STILL_OPEN=""
+          for ISSUE_NUM in $CLOSING_ISSUES; do
+            STATE=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.state' 2>/dev/null || echo "error")
+            if [ "$STATE" = "open" ]; then
+              STILL_OPEN="${STILL_OPEN} #${ISSUE_NUM}"
+            elif [ "$STATE" = "error" ]; then
+              echo "Warning: could not check state of #${ISSUE_NUM}"
+            else
+              echo "#${ISSUE_NUM} is closed. OK."
+            fi
+          done
+
+          if [ -n "$STILL_OPEN" ]; then
+            COMMENT="## Issue Auto-Close Verification Failed
+
+          The following issues were referenced with closing keywords but are **still open** after merge:
+
+          ${STILL_OPEN}
+
+          This usually means the closing keyword syntax was incorrect.
+
+          **Required format** (one keyword per issue):
+          \`\`\`
+          Closes #N
+          Closes #M
+          \`\`\`
+
+          **Wrong formats** (only closes the first issue):
+          \`\`\`
+          Closes #N, #M     <- only closes #N
+          Closes #N #M      <- only closes #N
+          \`\`\`
+
+          Please close the above issue(s) manually."
+
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              --method POST \
+              --field "body=${COMMENT}"
+
+            echo "Alert posted on PR #${PR_NUMBER} for unclosed issues:${STILL_OPEN}"
+            exit 0
+          fi
+
+          echo "All referenced issues confirmed closed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,7 +276,7 @@ Effort is session-wide (no per-agent control). Default: `high` (set in `~/.claud
 
 - **Always run `/review` before creating a PR** — mandatory. Runs falcon (correctness), kestrel (architecture), and sentinel (security) locally. Do not depend on CodeRabbit/Qodo — they can be rate-limited.
 - **Always run `/version` before creating a PR** — mandatory for any branch touching `packages/`. See Package Versioning above.
-- **Link issues in PR body**: if the branch fixes a GitHub issue, include `Closes #<number>` (or `Fixes #<number>`) in the PR body. GitHub auto-closes the issue when the PR merges. No related issue (pure chore/docs/tooling)? Add `Closes: N/A` — the `check-issue-link` CI workflow requires either a closing reference or an explicit no-issue marker and will fail otherwise.
+- **Link issues in PR body**: if the branch fixes a GitHub issue, include `Closes #<number>` (or `Fixes #<number>`) in the PR body. GitHub auto-closes the issue when the PR merges. No related issue (pure chore/docs/tooling)? Add `Closes: N/A` — the `check-issue-link` CI workflow requires either a closing reference or an explicit no-issue marker and will fail otherwise. **CRITICAL SYNTAX**: `Closes #50, #80` only closes #50 — each issue needs its own keyword on its own line. See `.claude/rules/issue-closing-syntax.md`.
 - Use **`/babysit-pr`** for all PR monitoring (waiting for CI, reviewer comments, following up after fixes). Do NOT use manual polling.
 - **`/babysit-pr` auto-merges by default** and self-polls until complete — no `/loop` wrapper needed. Use `--no-merge` to require confirmation before merging.
 - **Act autonomously.** When handling a PR, agents should:


### PR DESCRIPTION
## Summary

PR #122 closed only 1 of 14 referenced issues because the syntax `Closes #50, #80` only auto-closes #50. This PR adds defense-in-depth to prevent recurrence.

**Changes:**
- **L1 — CI workflow**: `check-issue-link.yml` now detects orphaned issue refs: counts all `#N` tokens on closing-keyword lines vs keyword+issue pairs; fails with wrong/right guidance
- **L3 — Hook**: `enforce-review-gate.sh` now scans the `--body` value of `gh pr create` and blocks if orphaned refs found (scoped to `--body` only to avoid false positives)
- **L4 — Post-merge verification**: New `verify-issue-closures.yml` triggers on PR close, waits 15s, checks each referenced issue state, posts alert if any still open
- **L5 — Docs**: CLAUDE.md `CRITICAL SYNTAX` callout + link; PR template wrong/right comment examples; new `.claude/rules/issue-closing-syntax.md` always-loaded agent rule

**L2 (branch protection required check) is Phase 2 — see note below.**

## Phase 2: After This Merges

Add `Issue reference required` to the required status checks once the CI job has run at least once (GitHub needs to have seen the check name):

```bash
gh api repos/uehlbran/pokemon-lib-ts/branches/main/protection \
  --method PUT \
  --input - <<'JSON'
{
  "required_status_checks": {
    "strict": false,
    "contexts": ["build", "test", "typecheck", "lint", "Issue reference required"]
  },
  "enforce_admins": false,
  "required_pull_request_reviews": {"required_approving_review_count": 1},
  "restrictions": null
}
JSON
```

## Test Plan

- [ ] Test PR with comma-separated closes reference — CI `Issue reference required` fails
- [ ] Test PR with one keyword per issue per line — CI passes
- [ ] Test that `Closes: N/A` still passes
- [ ] Verify hook blocks `gh pr create` with a comma-separated body
- [ ] Confirm `verify-issue-closures.yml` runs and reports on next merged PR

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR creation now blocks when issue references use incorrect or multiple orphaned references; users receive corrective guidance.
  * After a PR is merged, an automated check verifies referenced issues are actually closed and posts a summary if any remain open.

* **Documentation**
  * PR template updated with explicit, per-line issue-closing examples and guidance.
  * New guidance document describing the required issue-closing syntax and common wrong formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->