### PR TITLE
docs(source-authority): split Gen 4 from Gen 5-9 in source authority hierarchy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,16 @@ When implementing mechanics, use the following per-gen hierarchy (highest author
 3. Bulbapedia
 4. Our specs
 
-**Gen 4–9:**
+**Gen 4 (Diamond/Pearl/Platinum/HeartGold/SoulSilver):**
+1. `pret/pokeplatinum` or `pret/pokeheartgold` — where the specific function has been decompiled to C with a byte-perfect match. Both repos are ~75% decompiled; verify the battle-relevant function is in C (not `.s` assembly stubs) before citing.
+2. Pokemon Showdown (Gen 4 mod) — primary fallback and authority for anything not yet decompiled
+3. Bulbapedia (cross-reference for edge cases)
+4. Smogon research threads (for disputed mechanics with cartridge testing)
+5. Our specs
+
+> **Note**: hg-engine (BluRosie/hg-engine) is a modding framework built on top of the HGSS ROM, not a disassembly. It must **never** be used as a source reference — it reflects modding conventions, not cartridge behavior.
+
+**Gen 5–9:**
 1. Pokemon Showdown — primary authority (no complete disassemblies exist)
 2. Bulbapedia (cross-reference for edge cases)
 3. Smogon research threads (for disputed mechanics with cartridge testing)
@@ -146,7 +155,7 @@ This hierarchy applies to mechanics and formulas. For raw data (species stats, m
 **Ground-truth reference documents:**
 - Currently exist: `specs/reference/gen1-ground-truth.md`, `specs/reference/gen2-ground-truth.md`
 - Will be created per gen as implementation progresses
-- Gen 3 should be sourced from `pret/pokeemerald`; Gen 4–9 primarily from Showdown with Bulbapedia cross-references
+- Gen 3 should be sourced from `pret/pokeemerald`; Gen 4 from `pret/pokeplatinum`/`pret/pokeheartgold` (where decompiled) with Showdown fallback; Gen 5–9 primarily from Showdown with Bulbapedia cross-references
 
 When implementing a gen-specific mechanic, check the ground-truth reference first. If none exists for that gen, fall through to the hierarchy directly.
 
@@ -190,7 +199,7 @@ Every PR requires local review before push plus a human approver:
 - **CodeRabbit** — inline comments, PR summary, security scan (advisory, bonus). Config: `.coderabbit.yaml`
 - **Qodo PR-Agent** — structured review (advisory, best-effort — may be rate-limited). GitHub Action.
 - **Claude Code** — deep local review via `pokemon-reviewer` subagent. Runs on push via `git pushreview`. Posts findings to PR as comments (advisory).
-- **Human** — required approval (1 reviewer). Final say on architecture and correctness.
+- **Human** — final say on architecture and correctness. Human review is a process rule enforced via CLAUDE.md, not a branch protection setting.
 
 AI reviews are advisory (comments only, never formal approvals). See `.github/AI_REVIEWERS.md` for interaction commands.
 

--- a/specs/claude-code-cartridge-compliance-system.md
+++ b/specs/claude-code-cartridge-compliance-system.md
@@ -4,7 +4,7 @@
 
 Build an automated cartridge compliance system that mechanically proves each generation matches its source-of-truth implementation. This is one unified system — oracle validation, compliance tracking, CI reporting, and a `/compliance` subagent command.
 
-**Critical design principle**: Oracles (`@pkmn/data`, `@smogon/calc`, `@pkmn/sim`) are **sanity checks**, not authorities. They catch regressions and flag discrepancies. The actual authorities are pret disassemblies (Gen 1-3), Bulbapedia (for documented cartridge mechanics), and Showdown source (Gen 4-9 where no decomp exists). When an oracle disagrees with us, we investigate — we don't auto-correct to match the oracle.
+**Critical design principle**: Oracles (`@pkmn/data`, `@smogon/calc`, `@pkmn/sim`) are **sanity checks**, not authorities. They catch regressions and flag discrepancies. The actual authorities are pret disassemblies (Gen 1-3), pret decomps where available (Gen 4), Bulbapedia (for documented cartridge mechanics), and Showdown source (Gen 5-9 where no decomp exists). When an oracle disagrees with us, we investigate — we don't auto-correct to match the oracle.
 
 ---
 
@@ -752,7 +752,7 @@ Add at the top of `specs/SPEC-STATUS.md`:
 
 Update VERIFIED definition:
 ```markdown
-| **VERIFIED** | Audited against primary source authority (pret for Gen 1-3, Showdown + Bulbapedia for Gen 4-9). Feeds the "Spec Verified" criterion in the compliance suite. |
+| **VERIFIED** | Audited against primary source authority (pret for Gen 1-3, pret decomps where available for Gen 4, Showdown + Bulbapedia for Gen 5-9). Feeds the "Spec Verified" criterion in the compliance suite. |
 ```
 
 ---


### PR DESCRIPTION
## Summary

Source authority docs were incorrectly treating Gen 4 the same as Gen 5-9 ("no complete disassemblies exist"). Both `pret/pokeplatinum` and `pret/pokeheartgold` are ~75% decompiled to C and should be used where available.

- **`CLAUDE.md`**: Add dedicated Gen 4 section with `pret/pokeplatinum`/`pret/pokeheartgold` as primary source (where decompiled to C), Showdown Gen 4 mod as fallback. Add hg-engine warning (modding framework, not decomp — never use as source reference)
- **`CLAUDE.md`**: Update "Gen 4-9" → "Gen 5-9" throughout; update ground-truth reference docs line
- **`CLAUDE.md`**: Clarify Human review is a process rule enforced via CLAUDE.md, not a branch protection setting
- **`specs/claude-code-cartridge-compliance-system.md`**: Update critical design principle and VERIFIED definition to reflect Gen 4 split

These changes were originally made on `fix/gen3-spatk-items-#134-#135-#137` (wrong branch) and are now properly landed here.

## Test plan

- [ ] Verify CLAUDE.md Gen 4 section references pret/pokeplatinum and pret/pokeheartgold
- [ ] Verify hg-engine warning is present
- [ ] Verify "Gen 4-9" no longer appears in Source Authority section (should be "Gen 4" + "Gen 5-9")
- [ ] Verify spec file updated to match

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal process documentation for mechanics verification and sourcing standards across game generations.

* **Chores**
  * Refined source authority hierarchy and compliance specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->