### PR TITLE
feat(battle): two-turn move + gravity engine infrastructure (Part 8 Wave 1)

### DIFF
--- a/.changeset/gen4-part8-engine-infra.md
+++ b/.changeset/gen4-part8-engine-infra.md
@@ -1,0 +1,13 @@
+---
+"@pokemon-lib-ts/core": patch
+"@pokemon-lib-ts/battle": minor
+---
+
+Add two-turn move and gravity engine infrastructure (Part 8 Wave 1)
+
+- Add semi-invulnerable volatile statuses (flying, underground, underwater, shadow-force-charging, charging) to core VolatileStatus type
+- Add forcedMove field to ActivePokemon for two-turn move lock-in
+- Add canHitSemiInvulnerable method to GenerationRuleset interface
+- Add forcedMoveSet and gravitySet fields to MoveEffectResult
+- Add gravity-countdown to EndOfTurnEffect union
+- Engine: forced-move override in resolveTurn, getAvailableMoves lockout, semi-invulnerable miss/hit checks, volatile removal on execution turn, gravity activation/countdown/move blocking

--- a/packages/battle/src/context/types.ts
+++ b/packages/battle/src/context/types.ts
@@ -212,6 +212,18 @@ export interface MoveEffectResult {
   readonly trickRoomSet?: { turnsLeft: number } | null;
   /** Schedule a Future Sight / Doom Desire attack on the target side (Gen 2+) */
   readonly futureAttack?: { moveId: string; turnsLeft: number; sourceSide: 0 | 1 } | null;
+  /** Activate Gravity field effect (Gen 4+) */
+  readonly gravitySet?: boolean;
+  /**
+   * Set a forced move for the next turn (two-turn moves like Fly, Dig, SolarBeam).
+   * The volatile status is applied to the attacker during the charge turn; it is
+   * removed before the forced move executes on the second turn.
+   */
+  readonly forcedMoveSet?: {
+    moveIndex: number;
+    moveId: string;
+    volatileStatus: VolatileStatus;
+  } | null;
 }
 
 /**
@@ -503,7 +515,8 @@ export type EndOfTurnEffect =
   | "flame-orb-activation"
   | "slow-start-countdown"
   | "taunt-countdown"
-  | "disable-countdown";
+  | "disable-countdown"
+  | "gravity-countdown";
 
 /**
  * Configuration object passed to the `BattleEngine` constructor.

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -299,6 +299,34 @@ export class BattleEngine implements BattleEventEmitter {
     const active = this.state.sides[side].active[0];
     if (!active) return [];
 
+    // If the Pokemon has a forced move (two-turn move second turn), only that move is available
+    // Source: Showdown — during the execution turn of a two-turn move, only that move can be selected
+    if (active.forcedMove) {
+      const forcedSlot = active.pokemon.moves[active.forcedMove.moveIndex];
+      if (forcedSlot) {
+        return active.pokemon.moves.map((slot, index) => {
+          const isForcedMove = index === active.forcedMove?.moveIndex;
+          let moveData: MoveData | undefined;
+          try {
+            moveData = this.dataManager.getMove(slot.moveId);
+          } catch {
+            // skip
+          }
+          return {
+            index,
+            moveId: slot.moveId,
+            displayName: moveData?.displayName ?? slot.moveId,
+            type: moveData?.type ?? ("normal" as const),
+            category: moveData?.category ?? ("physical" as const),
+            pp: slot.currentPP,
+            maxPp: slot.maxPP,
+            disabled: !isForcedMove,
+            disabledReason: isForcedMove ? undefined : "Locked into move",
+          };
+        });
+      }
+    }
+
     return active.pokemon.moves.flatMap((slot, index) => {
       let moveData: MoveData | undefined;
       try {
@@ -623,6 +651,16 @@ export class BattleEngine implements BattleEventEmitter {
       }
     }
 
+    // Enforce forced move (two-turn moves): override submitted action
+    // Source: Showdown — two-turn moves force the second-turn action
+    for (let side = 0 as 0 | 1; side <= 1; side = (side + 1) as 0 | 1) {
+      const active = this.getActive(side);
+      if (active && active.pokemon.currentHp > 0 && active.forcedMove) {
+        actions[side] = { type: "move", side, moveIndex: active.forcedMove.moveIndex };
+        active.forcedMove = null;
+      }
+    }
+
     // Reset per-turn faint deduplication set so a new faint on a new turn is
     // correctly recorded (fixes #78 — duplicate faint events across checkMidTurnFaints calls).
     this.faintedPokemonThisTurn.clear();
@@ -847,6 +885,27 @@ export class BattleEngine implements BattleEventEmitter {
       actor.consecutiveProtects = 0;
     }
 
+    // Remove semi-invulnerable volatile from attacker on the second (execution) turn
+    // of a two-turn move. The volatile was applied during the charge turn; it must be
+    // removed before damage calculation so the attacker is targetable again.
+    // Source: Showdown — semi-invulnerable status cleared at move execution start
+    const semiInvulnerableVolatiles: readonly import("@pokemon-lib-ts/core").VolatileStatus[] = [
+      "flying",
+      "underground",
+      "underwater",
+      "shadow-force-charging",
+    ];
+    for (const vol of semiInvulnerableVolatiles) {
+      if (actor.volatileStatuses.has(vol)) {
+        actor.volatileStatuses.delete(vol);
+        break; // A Pokemon can only have one semi-invulnerable volatile at a time
+      }
+    }
+    // Also remove the non-semi-invulnerable charge volatile (SolarBeam, Skull Bash, etc.)
+    if (actor.volatileStatuses.has("charging")) {
+      actor.volatileStatuses.delete("charging");
+    }
+
     // Find the target
     const defenderSide = action.side === 0 ? 1 : 0;
     const defender = this.getActive(defenderSide as 0 | 1);
@@ -861,6 +920,27 @@ export class BattleEngine implements BattleEventEmitter {
       actor.lastMoveUsed = moveData.id;
       actor.movedThisTurn = true;
       return;
+    }
+
+    // Semi-invulnerable check: if the defender is in a semi-invulnerable state
+    // (Fly, Dig, Dive, Shadow Force), most moves auto-miss unless the ruleset
+    // says otherwise (e.g., Thunder can hit flying targets, Earthquake hits underground).
+    // Source: Showdown sim/battle-actions.ts — semi-invulnerable immunity checks
+    for (const vol of semiInvulnerableVolatiles) {
+      if (defender.volatileStatuses.has(vol)) {
+        if (!this.ruleset.canHitSemiInvulnerable(moveData.id, vol)) {
+          this.emit({
+            type: "move-miss",
+            side: action.side,
+            pokemon: getPokemonName(actor),
+            move: moveData.id,
+          });
+          actor.lastMoveUsed = moveData.id;
+          actor.movedThisTurn = true;
+          return;
+        }
+        break; // Only one semi-invulnerable volatile at a time
+      }
     }
 
     // Accuracy check
@@ -1335,6 +1415,16 @@ export class BattleEngine implements BattleEventEmitter {
       }
     }
 
+    // Gravity check — prevents moves with the gravity flag (Fly, Bounce, etc.)
+    // Source: Showdown Gen 4 mod — Gravity disables gravity-flagged moves
+    if (this.state.gravity.active && move.flags.gravity) {
+      this.emit({
+        type: "message",
+        text: `${getPokemonName(actor)} can't use ${move.displayName} because of gravity!`,
+      });
+      return false;
+    }
+
     // Taunt check — prevents status moves (runtime enforcement, mirrors getAvailableMoves check)
     // Source: Bulbapedia — "Taunt prevents the target from using status moves"
     if (actor.volatileStatuses.has("taunt") && move.category === "status") {
@@ -1628,6 +1718,31 @@ export class BattleEngine implements BattleEventEmitter {
           text: `${getPokemonName(attacker)} foresaw an attack!`,
         });
       }
+    }
+
+    // Forced move set (two-turn moves: Fly, Dig, Dive, SolarBeam, etc.)
+    // Source: Showdown — two-turn moves set forcedMove on charge turn; volatile applied immediately
+    if (result.forcedMoveSet) {
+      attacker.forcedMove = {
+        moveIndex: result.forcedMoveSet.moveIndex,
+        moveId: result.forcedMoveSet.moveId,
+      };
+      attacker.volatileStatuses.set(result.forcedMoveSet.volatileStatus, {
+        turnsLeft: 1,
+      });
+      this.emit({
+        type: "volatile-start",
+        side: attackerSide,
+        pokemon: getPokemonName(attacker),
+        volatile: result.forcedMoveSet.volatileStatus,
+      });
+    }
+
+    // Gravity set (Gen 4+)
+    // Source: Showdown Gen 4 mod — Gravity lasts 5 turns, grounds all Pokemon
+    if (result.gravitySet) {
+      this.state.gravity = { active: true, turnsLeft: 5 };
+      this.emit({ type: "message", text: "Gravity intensified!" });
     }
 
     // Self-faint (Explosion / Self-Destruct)
@@ -2200,6 +2315,18 @@ export class BattleEngine implements BattleEventEmitter {
                   volatile: "disable",
                 });
               }
+            }
+          }
+          break;
+        }
+        case "gravity-countdown": {
+          // Gravity field countdown — deactivate when turnsLeft reaches 0
+          // Source: Showdown Gen 4 mod — Gravity lasts 5 turns
+          if (this.state.gravity.active) {
+            this.state.gravity.turnsLeft--;
+            if (this.state.gravity.turnsLeft <= 0) {
+              this.state.gravity.active = false;
+              this.emit({ type: "message", text: "Gravity returned to normal!" });
             }
           }
           break;

--- a/packages/battle/src/ruleset/BaseRuleset.ts
+++ b/packages/battle/src/ruleset/BaseRuleset.ts
@@ -10,6 +10,7 @@ import type {
   SeededRandom,
   StatBlock,
   TypeChart,
+  VolatileStatus,
 } from "@pokemon-lib-ts/core";
 import { ALL_NATURES, DataManager, getStatStageMultiplier } from "@pokemon-lib-ts/core";
 import type {
@@ -267,6 +268,15 @@ export abstract class BaseRuleset implements GenerationRuleset {
       messages: [],
     };
     return result;
+  }
+
+  /**
+   * Default: no moves can hit a semi-invulnerable target.
+   * Gen 3+ rulesets override to allow specific moves (e.g., Thunder hits flying).
+   * Source: Showdown sim/battle-actions.ts — semi-invulnerable immunity checks
+   */
+  canHitSemiInvulnerable(_moveId: string, _volatile: VolatileStatus): boolean {
+    return false;
   }
 
   // Burn: Gen 7+ default (1/16 max HP); Gen 3-6 must override (1/8 max HP)

--- a/packages/battle/src/ruleset/GenerationRuleset.ts
+++ b/packages/battle/src/ruleset/GenerationRuleset.ts
@@ -9,6 +9,7 @@ import type {
   SeededRandom,
   StatBlock,
   TypeChart,
+  VolatileStatus,
 } from "@pokemon-lib-ts/core";
 import type {
   AbilityContext,
@@ -104,6 +105,17 @@ export interface MoveSystem {
    * Handles secondary effects, stat changes, status infliction.
    */
   executeMoveEffect(context: MoveEffectContext): MoveEffectResult;
+  /**
+   * Check whether a move can hit a target in a semi-invulnerable state.
+   * E.g., Thunder/Hurricane can hit "flying", Earthquake can hit "underground",
+   * Surf can hit "underwater". Returns false by default — most moves miss.
+   *
+   * Gen 1 has no two-turn semi-invulnerable moves in the Gen 3+ sense
+   * (Fly/Dig exist but engine handles them differently), so Gen 1 returns false.
+   *
+   * Source: Showdown sim/battle-actions.ts — semi-invulnerable immunity checks
+   */
+  canHitSemiInvulnerable(moveId: string, volatile: VolatileStatus): boolean;
 }
 
 /**

--- a/packages/battle/src/state/BattleSide.ts
+++ b/packages/battle/src/state/BattleSide.ts
@@ -111,6 +111,12 @@ export interface ActivePokemon {
   isTerastallized: boolean;
   /** Active Tera Type after terastallization, or `null` if not terastallized (Gen 9) */
   teraType: PokemonType | null;
+  /**
+   * Forced move for the next turn (two-turn moves like Fly, Dig, SolarBeam).
+   * When set, the engine overrides the submitted action with this move on the next turn.
+   * Cleared after the forced move executes.
+   */
+  forcedMove: { moveIndex: number; moveId: string } | null;
 }
 
 /**

--- a/packages/battle/src/utils/BattleHelpers.ts
+++ b/packages/battle/src/utils/BattleHelpers.ts
@@ -58,6 +58,7 @@ export function createActivePokemon(
     dynamaxTurnsLeft: 0,
     isTerastallized: false,
     teraType: null,
+    forcedMove: null,
   };
 }
 

--- a/packages/battle/tests/engine/gravity.test.ts
+++ b/packages/battle/tests/engine/gravity.test.ts
@@ -1,0 +1,234 @@
+import type { PokemonInstance } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import type { BattleConfig, MoveEffectContext, MoveEffectResult } from "../../src/context";
+import { BattleEngine } from "../../src/engine";
+import type { BattleEvent } from "../../src/events";
+import { createTestPokemon } from "../../src/utils";
+import { createMockDataManager } from "../helpers/mock-data-manager";
+import { MockRuleset } from "../helpers/mock-ruleset";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function createEngine(overrides?: {
+  seed?: number;
+  team1?: PokemonInstance[];
+  team2?: PokemonInstance[];
+  ruleset?: MockRuleset;
+}) {
+  const ruleset = overrides?.ruleset ?? new MockRuleset();
+  const dataManager = createMockDataManager();
+  const events: BattleEvent[] = [];
+
+  const team1 = overrides?.team1 ?? [
+    createTestPokemon(6, 50, {
+      uid: "charizard-1",
+      nickname: "Charizard",
+      moves: [
+        { moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 },
+        { moveId: "fly", currentPP: 15, maxPP: 15, ppUps: 0 },
+      ],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 120,
+      },
+      currentHp: 200,
+    }),
+  ];
+
+  const team2 = overrides?.team2 ?? [
+    createTestPokemon(9, 50, {
+      uid: "blastoise-1",
+      nickname: "Blastoise",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 80,
+      },
+      currentHp: 200,
+    }),
+  ];
+
+  const config: BattleConfig = {
+    generation: 1,
+    format: "singles",
+    teams: [team1, team2],
+    seed: overrides?.seed ?? 12345,
+  };
+
+  const engine = new BattleEngine(config, ruleset, dataManager);
+  engine.on((e) => events.push(e));
+
+  return { engine, ruleset, events, dataManager };
+}
+
+// ─── Gravity Engine Infrastructure Tests ──────────────────────────────────────
+
+describe("gravity engine infrastructure", () => {
+  describe("given gravitySet in move effect result, when processEffectResult runs, then state.gravity is set to active with 5 turns", () => {
+    it("sets gravity active=true and turnsLeft=5, and emits 'Gravity intensified!' message", () => {
+      // Arrange: configure executeMoveEffect to return gravitySet=true on the first call
+      // Source: Showdown Gen 4 mod — Gravity lasts 5 turns
+      const ruleset = new MockRuleset();
+      let callCount = 0;
+      const origExecute = ruleset.executeMoveEffect.bind(ruleset);
+      ruleset.executeMoveEffect = (context: MoveEffectContext): MoveEffectResult => {
+        callCount++;
+        if (callCount === 1 && context.attacker.pokemon.uid === "charizard-1") {
+          return {
+            statusInflicted: null,
+            volatileInflicted: null,
+            statChanges: [],
+            recoilDamage: 0,
+            healAmount: 0,
+            switchOut: false,
+            messages: [],
+            gravitySet: true,
+          };
+        }
+        return origExecute(context);
+      };
+
+      const { engine, events } = createEngine({ ruleset });
+      engine.start();
+
+      // Act: submit moves — Charizard's move triggers gravitySet
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: gravity should be active with 5 turns
+      const state = engine.getState();
+      expect(state.gravity.active).toBe(true);
+      expect(state.gravity.turnsLeft).toBe(5);
+
+      // Assert: "Gravity intensified!" message emitted
+      const gravityMessages = events.filter(
+        (e) => e.type === "message" && "text" in e && e.text === "Gravity intensified!",
+      );
+      expect(gravityMessages.length).toBe(1);
+    });
+  });
+
+  describe("given gravity active, when gravity-countdown end-of-turn effect processed, then turnsLeft decremented by 1", () => {
+    it("decrements turnsLeft from 5 to 4 after one turn", () => {
+      // Arrange: configure ruleset to include gravity-countdown in end-of-turn order
+      // and set gravity via the first move's effect
+      // Source: Showdown Gen 4 mod — Gravity countdown decrements each turn
+      const ruleset = new MockRuleset();
+      let callCount = 0;
+      const origExecute = ruleset.executeMoveEffect.bind(ruleset);
+      ruleset.executeMoveEffect = (context: MoveEffectContext): MoveEffectResult => {
+        callCount++;
+        if (callCount === 1 && context.attacker.pokemon.uid === "charizard-1") {
+          return {
+            statusInflicted: null,
+            volatileInflicted: null,
+            statChanges: [],
+            recoilDamage: 0,
+            healAmount: 0,
+            switchOut: false,
+            messages: [],
+            gravitySet: true,
+          };
+        }
+        return origExecute(context);
+      };
+
+      // Override getEndOfTurnOrder to include gravity-countdown
+      ruleset.getEndOfTurnOrder = () => ["gravity-countdown"];
+
+      const { engine } = createEngine({ ruleset });
+      engine.start();
+
+      // Act: turn 1 — sets gravity (turnsLeft=5), end-of-turn decrements to 4
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: after 1 end-of-turn, turnsLeft should be 4
+      const state = engine.getState();
+      expect(state.gravity.active).toBe(true);
+      expect(state.gravity.turnsLeft).toBe(4);
+    });
+  });
+
+  describe("given gravity active for 5 turns, when the 5th gravity-countdown runs, then gravity deactivates", () => {
+    it("deactivates gravity and emits 'Gravity returned to normal!' when turnsLeft reaches 0", () => {
+      // Arrange: set gravity directly to turnsLeft=1 (simulating 4 turns already passed)
+      // Source: Showdown Gen 4 mod — Gravity ends after 5 turns
+      const ruleset = new MockRuleset();
+      ruleset.getEndOfTurnOrder = () => ["gravity-countdown"];
+
+      const { engine, events } = createEngine({ ruleset });
+      engine.start();
+
+      // Directly set gravity to its last turn
+      const state = engine.getState();
+      (state as { gravity: { active: boolean; turnsLeft: number } }).gravity = {
+        active: true,
+        turnsLeft: 1,
+      };
+
+      // Act: run a turn — the end-of-turn gravity-countdown should decrement 1 -> 0
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: gravity should be deactivated
+      expect(state.gravity.active).toBe(false);
+      expect(state.gravity.turnsLeft).toBe(0);
+
+      // Assert: "Gravity returned to normal!" message emitted
+      const normalMessages = events.filter(
+        (e) => e.type === "message" && "text" in e && e.text === "Gravity returned to normal!",
+      );
+      expect(normalMessages.length).toBe(1);
+    });
+  });
+
+  describe("given gravity active, when Pokemon tries to use a move with flags.gravity=true, then the move is blocked", () => {
+    it("emits a message about gravity preventing the move and does not deal damage", () => {
+      // Arrange: activate gravity, then have Charizard try to use Fly (gravity flag = true)
+      // Source: Showdown Gen 4 mod — Gravity disables Fly, Bounce, etc.
+      const { engine, events } = createEngine();
+      engine.start();
+
+      // Directly set gravity active
+      const state = engine.getState();
+      (state as { gravity: { active: boolean; turnsLeft: number } }).gravity = {
+        active: true,
+        turnsLeft: 5,
+      };
+
+      // Act: Charizard tries to use Fly (moveIndex 1, which has gravity: true in mock data)
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 1 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: gravity block message emitted for Charizard's Fly
+      const blockMessages = events.filter(
+        (e) =>
+          e.type === "message" &&
+          "text" in e &&
+          (e.text as string).includes("can't use Fly because of gravity"),
+      );
+      expect(blockMessages.length).toBe(1);
+
+      // Assert: no damage event targeting Blastoise from Fly
+      // (Blastoise may take damage from its own tackle execution, but Fly should not fire)
+      const flyDamageEvents = events.filter(
+        (e) =>
+          e.type === "move-execute" &&
+          "pokemon" in e &&
+          e.pokemon === "Charizard" &&
+          "move" in e &&
+          e.move === "Fly",
+      );
+      expect(flyDamageEvents.length).toBe(0);
+    });
+  });
+});

--- a/packages/battle/tests/engine/two-turn-moves.test.ts
+++ b/packages/battle/tests/engine/two-turn-moves.test.ts
@@ -1,0 +1,338 @@
+import type { PokemonInstance, VolatileStatus } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import type { BattleConfig, MoveEffectContext, MoveEffectResult } from "../../src/context";
+import { BattleEngine } from "../../src/engine";
+import type { BattleEvent } from "../../src/events";
+import { createTestPokemon } from "../../src/utils";
+import { createMockDataManager } from "../helpers/mock-data-manager";
+import { MockRuleset } from "../helpers/mock-ruleset";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function createEngine(overrides?: {
+  seed?: number;
+  team1?: PokemonInstance[];
+  team2?: PokemonInstance[];
+  ruleset?: MockRuleset;
+}) {
+  const ruleset = overrides?.ruleset ?? new MockRuleset();
+  const dataManager = createMockDataManager();
+  const events: BattleEvent[] = [];
+
+  const team1 = overrides?.team1 ?? [
+    createTestPokemon(6, 50, {
+      uid: "charizard-1",
+      nickname: "Charizard",
+      moves: [
+        { moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 },
+        { moveId: "thunderbolt", currentPP: 15, maxPP: 15, ppUps: 0 },
+      ],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 120,
+      },
+      currentHp: 200,
+    }),
+  ];
+
+  const team2 = overrides?.team2 ?? [
+    createTestPokemon(9, 50, {
+      uid: "blastoise-1",
+      nickname: "Blastoise",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 80,
+      },
+      currentHp: 200,
+    }),
+  ];
+
+  const config: BattleConfig = {
+    generation: 1,
+    format: "singles",
+    teams: [team1, team2],
+    seed: overrides?.seed ?? 12345,
+  };
+
+  const engine = new BattleEngine(config, ruleset, dataManager);
+  engine.on((e) => events.push(e));
+
+  return { engine, ruleset, events, dataManager };
+}
+
+// ─── Two-Turn Move Engine Infrastructure Tests ────────────────────────────────
+
+describe("two-turn move engine infrastructure", () => {
+  describe("given a Pokemon using a charge move, when the charge turn executes, then forcedMove is set and volatile applied", () => {
+    it("sets forcedMove on the attacker and applies the volatile status from forcedMoveSet", () => {
+      // Arrange: configure executeMoveEffect to return forcedMoveSet on the first call
+      const ruleset = new MockRuleset();
+      let callCount = 0;
+      const origExecute = ruleset.executeMoveEffect.bind(ruleset);
+      ruleset.executeMoveEffect = (context: MoveEffectContext): MoveEffectResult => {
+        callCount++;
+        if (callCount === 1 && context.attacker.pokemon.uid === "charizard-1") {
+          return {
+            statusInflicted: null,
+            volatileInflicted: null,
+            statChanges: [],
+            recoilDamage: 0,
+            healAmount: 0,
+            switchOut: false,
+            messages: [],
+            forcedMoveSet: {
+              moveIndex: 0,
+              moveId: "tackle",
+              volatileStatus: "flying" as VolatileStatus,
+            },
+          };
+        }
+        return origExecute(context);
+      };
+
+      const { engine, events } = createEngine({ ruleset });
+      engine.start();
+
+      // Act: submit moves for both sides
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: forcedMove should be set on side 0's active Pokemon
+      const active0 = engine.getActive(0);
+      expect(active0).not.toBeNull();
+      expect(active0!.forcedMove).toEqual({ moveIndex: 0, moveId: "tackle" });
+
+      // Assert: flying volatile should be applied
+      expect(active0!.volatileStatuses.has("flying")).toBe(true);
+
+      // Assert: volatile-start event for "flying" emitted
+      const volatileStartEvents = events.filter(
+        (e) => e.type === "volatile-start" && "volatile" in e && e.volatile === "flying",
+      );
+      expect(volatileStartEvents.length).toBe(1);
+    });
+  });
+
+  describe("given a Pokemon with forcedMove set, when getAvailableMoves is called, then only the forced move is enabled", () => {
+    it("returns all moves but only the forced move is not disabled", () => {
+      // Arrange
+      const { engine } = createEngine();
+      engine.start();
+
+      // Directly set forcedMove on side 0's active Pokemon
+      const active0 = engine.getActive(0);
+      expect(active0).not.toBeNull();
+      active0!.forcedMove = { moveIndex: 0, moveId: "tackle" };
+
+      // Act
+      const moves = engine.getAvailableMoves(0);
+
+      // Assert: the forced move (index 0) should not be disabled
+      const forcedMove = moves.find((m) => m.index === 0);
+      expect(forcedMove).toBeDefined();
+      expect(forcedMove!.disabled).toBe(false);
+
+      // Assert: all other moves should be disabled with reason "Locked into move"
+      const otherMoves = moves.filter((m) => m.index !== 0);
+      for (const m of otherMoves) {
+        expect(m.disabled).toBe(true);
+        expect(m.disabledReason).toBe("Locked into move");
+      }
+    });
+  });
+
+  describe("given a Pokemon with forcedMove set, when resolveTurn begins, then the action is overridden to the forced move", () => {
+    it("overrides the submitted action and clears forcedMove", () => {
+      // Arrange: set up a ruleset that tracks which moveIndex was used
+      const ruleset = new MockRuleset();
+      const usedMoveIndices: number[] = [];
+      const origExecute = ruleset.executeMoveEffect.bind(ruleset);
+      ruleset.executeMoveEffect = (context: MoveEffectContext): MoveEffectResult => {
+        // Track which move index was used by looking at the move that was executed
+        if (context.attacker.pokemon.uid === "charizard-1") {
+          usedMoveIndices.push(
+            context.attacker.pokemon.moves.findIndex((m) => m.moveId === context.move.id),
+          );
+        }
+        return origExecute(context);
+      };
+
+      const { engine } = createEngine({ ruleset });
+      engine.start();
+
+      // Set forcedMove to move index 0 (tackle)
+      const active0 = engine.getActive(0);
+      expect(active0).not.toBeNull();
+      active0!.forcedMove = { moveIndex: 0, moveId: "tackle" };
+
+      // Act: submit a DIFFERENT move index (1) for side 0
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 1 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: the forced move (index 0) was executed, not index 1
+      expect(usedMoveIndices).toContain(0);
+
+      // Assert: forcedMove should be cleared after the turn
+      expect(active0!.forcedMove).toBeNull();
+    });
+  });
+
+  describe("given a defender in flying state, when opponent uses Thunderbolt (not in override map), then the move misses", () => {
+    it("emits move-miss when canHitSemiInvulnerable returns false", () => {
+      // Arrange
+      const { engine, events } = createEngine();
+      engine.start();
+
+      // Set the defender (Blastoise, side 1) to "flying" semi-invulnerable state
+      const defender = engine.getActive(1);
+      expect(defender).not.toBeNull();
+      defender!.volatileStatuses.set("flying", { turnsLeft: 1 });
+
+      // Act: Charizard uses Thunderbolt (index 1) against flying Blastoise
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 1 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: move-miss event emitted for Charizard's Thunderbolt
+      // Source: Showdown — most moves miss against semi-invulnerable targets
+      const missEvents = events.filter(
+        (e) => e.type === "move-miss" && "pokemon" in e && e.pokemon === "Charizard",
+      );
+      expect(missEvents.length).toBe(1);
+    });
+  });
+
+  describe("given a defender in flying state, when canHitSemiInvulnerable returns true for the move, then the move hits", () => {
+    it("does not emit move-miss when the ruleset allows hitting the semi-invulnerable state", () => {
+      // Arrange: configure ruleset to allow thunderbolt to hit flying targets
+      const ruleset = new MockRuleset();
+      ruleset.setCanHitSemiInvulnerable("thunderbolt", "flying");
+
+      const { engine, events } = createEngine({ ruleset });
+      engine.start();
+
+      // Set the defender to "flying" semi-invulnerable state
+      const defender = engine.getActive(1);
+      expect(defender).not.toBeNull();
+      defender!.volatileStatuses.set("flying", { turnsLeft: 1 });
+
+      // Act: Charizard uses Thunderbolt against flying Blastoise
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 1 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: no move-miss event for Charizard's Thunderbolt
+      // Source: Showdown — Thunder/Hurricane can hit flying targets; we test via mock
+      const missEvents = events.filter(
+        (e) => e.type === "move-miss" && "pokemon" in e && e.pokemon === "Charizard",
+      );
+      expect(missEvents.length).toBe(0);
+
+      // Assert: damage event should be emitted instead (the move landed)
+      const damageEvents = events.filter(
+        (e) => e.type === "damage" && "pokemon" in e && e.pokemon === "Blastoise",
+      );
+      expect(damageEvents.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("given a defender in underground state, when opponent uses Tackle (not in override map), then canHitSemiInvulnerable is consulted", () => {
+    it("auto-misses against underground target when canHitSemiInvulnerable returns false", () => {
+      // Arrange
+      const { engine, events } = createEngine();
+      engine.start();
+
+      // Set the defender to "underground" semi-invulnerable state
+      const defender = engine.getActive(1);
+      expect(defender).not.toBeNull();
+      defender!.volatileStatuses.set("underground", { turnsLeft: 1 });
+
+      // Act: Charizard uses Tackle against underground Blastoise
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: move-miss event emitted (Earthquake would hit underground, Tackle does not)
+      // Source: Showdown — Earthquake can hit underground targets via canHitSemiInvulnerable
+      const missEvents = events.filter(
+        (e) => e.type === "move-miss" && "pokemon" in e && e.pokemon === "Charizard",
+      );
+      expect(missEvents.length).toBe(1);
+    });
+  });
+
+  describe("given a semi-invulnerable volatile on the attacker, when the forced move executes on the second turn, then the volatile is removed before damage", () => {
+    it("removes the flying volatile from the attacker before move execution", () => {
+      // Arrange
+      const { engine, events } = createEngine();
+      engine.start();
+
+      // Simulate: attacker has "flying" volatile and a forcedMove (second turn of Fly)
+      const active0 = engine.getActive(0);
+      expect(active0).not.toBeNull();
+      active0!.volatileStatuses.set("flying", { turnsLeft: 1 });
+      active0!.forcedMove = { moveIndex: 0, moveId: "tackle" };
+
+      // Act: turn executes, forced move fires
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: the "flying" volatile was removed from the attacker
+      // Source: Showdown — semi-invulnerable volatile cleared at start of execution turn
+      expect(active0!.volatileStatuses.has("flying")).toBe(false);
+
+      // Assert: the move actually executed (damage was dealt, not a miss)
+      const damageToDefender = events.filter(
+        (e) => e.type === "damage" && "pokemon" in e && e.pokemon === "Blastoise",
+      );
+      expect(damageToDefender.length).toBeGreaterThan(0);
+    });
+
+    it("removes the charging volatile from the attacker before move execution", () => {
+      // Arrange: test the non-semi-invulnerable "charging" volatile (SolarBeam, etc.)
+      const { engine } = createEngine();
+      engine.start();
+
+      const active0 = engine.getActive(0);
+      expect(active0).not.toBeNull();
+      active0!.volatileStatuses.set("charging", { turnsLeft: 1 });
+      active0!.forcedMove = { moveIndex: 0, moveId: "tackle" };
+
+      // Act
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: charging volatile removed
+      expect(active0!.volatileStatuses.has("charging")).toBe(false);
+    });
+  });
+
+  describe("given a defender with charging volatile (not semi-invulnerable), when opponent attacks, then the move still hits", () => {
+    it("does not auto-miss because charging is not semi-invulnerable", () => {
+      // Arrange: charging is NOT in the semi-invulnerable list
+      const { engine, events } = createEngine();
+      engine.start();
+
+      const defender = engine.getActive(1);
+      expect(defender).not.toBeNull();
+      defender!.volatileStatuses.set("charging", { turnsLeft: 1 });
+
+      // Act
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert: no move-miss event for Charizard — charging does not grant invulnerability
+      // Source: Bulbapedia — SolarBeam/Skull Bash charge turn does NOT make user semi-invulnerable
+      const missEvents = events.filter(
+        (e) => e.type === "move-miss" && "pokemon" in e && e.pokemon === "Charizard",
+      );
+      expect(missEvents.length).toBe(0);
+    });
+  });
+});

--- a/packages/battle/tests/helpers/mock-data-manager.ts
+++ b/packages/battle/tests/helpers/mock-data-manager.ts
@@ -284,6 +284,40 @@ export function createMockDataManager(): DataManager {
     }
   }
 
+  const flyMoveData: MoveData = {
+    id: "fly",
+    displayName: "Fly",
+    type: "flying",
+    category: "physical",
+    power: 90,
+    accuracy: 95,
+    pp: 15,
+    priority: 0,
+    target: "adjacent-foe",
+    flags: {
+      contact: true,
+      sound: false,
+      bullet: false,
+      pulse: false,
+      punch: false,
+      bite: false,
+      wind: false,
+      slicing: false,
+      powder: false,
+      protect: true,
+      mirror: true,
+      snatch: false,
+      gravity: true,
+      defrost: false,
+      recharge: false,
+      charge: true,
+      bypassSubstitute: false,
+    },
+    effect: null,
+    description: "The user flies up high, then strikes on the next turn.",
+    generation: 1,
+  };
+
   const flameWheelMoveData: MoveData = {
     id: "flame-wheel",
     displayName: "Flame Wheel",
@@ -326,6 +360,7 @@ export function createMockDataManager(): DataManager {
       thunderboltMoveData,
       scratchMoveData,
       quickAttackMoveData,
+      flyMoveData,
       flameWheelMoveData,
     ],
     typeChart: typeChart as unknown as TypeChart,

--- a/packages/battle/tests/helpers/mock-ruleset.ts
+++ b/packages/battle/tests/helpers/mock-ruleset.ts
@@ -9,6 +9,7 @@ import type {
   SeededRandom,
   StatBlock,
   TypeChart,
+  VolatileStatus,
 } from "@pokemon-lib-ts/core";
 import type {
   AbilityContext,
@@ -154,6 +155,23 @@ export class MockRuleset implements GenerationRuleset {
 
   doesMoveHit(_context: AccuracyContext): boolean {
     return this.alwaysHit;
+  }
+
+  private semiInvulnerableOverrides = new Map<string, Set<string>>();
+
+  /**
+   * Configure specific moves to hit specific semi-invulnerable states.
+   * E.g., `setCanHitSemiInvulnerable("thunder", "flying")` makes Thunder hit flying targets.
+   */
+  setCanHitSemiInvulnerable(moveId: string, volatile: VolatileStatus): void {
+    if (!this.semiInvulnerableOverrides.has(moveId)) {
+      this.semiInvulnerableOverrides.set(moveId, new Set());
+    }
+    this.semiInvulnerableOverrides.get(moveId)!.add(volatile);
+  }
+
+  canHitSemiInvulnerable(moveId: string, volatile: VolatileStatus): boolean {
+    return this.semiInvulnerableOverrides.get(moveId)?.has(volatile) ?? false;
   }
 
   executeMoveEffect(_context: MoveEffectContext): MoveEffectResult {

--- a/packages/core/src/entities/status.ts
+++ b/packages/core/src/entities/status.ts
@@ -49,4 +49,9 @@ export type VolatileStatus =
   | "just-frozen" // Gen 2 — tracks whether a Pokemon was frozen this turn (cannot thaw same turn, per pokecrystal wPlayerJustGotFrozen)
   | "destiny-bond" // Destiny Bond — if the user faints from the opponent's move, the opponent faints too
   | "choice-locked" // Choice item (Band/Specs/Scarf) — locks the user into one move
-  | "flash-fire"; // Flash Fire — boosts Fire-type moves by 50% when hit by a Fire move
+  | "flash-fire" // Flash Fire — boosts Fire-type moves by 50% when hit by a Fire move
+  | "flying" // Semi-invulnerable turn of Fly, Bounce (Gen 2+)
+  | "underground" // Semi-invulnerable turn of Dig (Gen 2+)
+  | "underwater" // Semi-invulnerable turn of Dive (Gen 3+)
+  | "shadow-force-charging" // Semi-invulnerable turn of Shadow Force (Gen 4+)
+  | "charging"; // Generic charge turn (SolarBeam, Skull Bash, Razor Wind, Sky Attack) — NOT semi-invulnerable

--- a/packages/gen1/src/Gen1Ruleset.ts
+++ b/packages/gen1/src/Gen1Ruleset.ts
@@ -297,6 +297,11 @@ export class Gen1Ruleset implements GenerationRuleset {
     return roll < threshold;
   }
 
+  // Gen 1 has no semi-invulnerable two-turn moves in the Gen 3+ sense.
+  canHitSemiInvulnerable(_moveId: string, _volatile: VolatileStatus): boolean {
+    return false;
+  }
+
   executeMoveEffect(context: MoveEffectContext): MoveEffectResult {
     const { move, damage, defender } = context;
 

--- a/packages/gen2/src/Gen2Ruleset.ts
+++ b/packages/gen2/src/Gen2Ruleset.ts
@@ -288,6 +288,11 @@ export class Gen2Ruleset implements GenerationRuleset {
     return rng.int(0, 255) < accuracy;
   }
 
+  // Gen 2 has no semi-invulnerable two-turn moves in the Gen 3+ sense.
+  canHitSemiInvulnerable(_moveId: string, _volatile: VolatileStatus): boolean {
+    return false;
+  }
+
   executeMoveEffect(context: MoveEffectContext): MoveEffectResult {
     const result: {
       statusInflicted: PrimaryStatus | null;


### PR DESCRIPTION
## Summary

- Add engine plumbing for two-turn moves (Fly, Dig, Dive, Bounce, Shadow Force, SolarBeam) and Gravity field effect
- Core: add 5 semi-invulnerable volatile statuses to `VolatileStatus` type, add `forcedMove` field to `ActivePokemon`
- Battle: add `canHitSemiInvulnerable` to `GenerationRuleset` interface, `forcedMoveSet`/`gravitySet` to `MoveEffectResult`, `gravity-countdown` to `EndOfTurnEffect`
- Engine: forced-move override in `resolveTurn`, `getAvailableMoves` lockout, semi-invulnerable miss/hit checks, volatile removal on execution turn, gravity activation/countdown/move blocking
- 13 new tests across `two-turn-moves.test.ts` (9 tests) and `gravity.test.ts` (4 tests)

This is Wave 1 (engine infrastructure only). Gen4-specific two-turn move handlers and gravity move effect come in Wave 2.

## Test plan

- [x] 9 two-turn move infrastructure tests pass (forcedMove set, volatile applied, getAvailableMoves lockout, action override, semi-invulnerable miss, canHitSemiInvulnerable hit, underground miss, volatile removal for flying and charging)
- [x] 4 gravity infrastructure tests pass (gravitySet activates, countdown decrements, deactivation after 5 turns, gravity blocks flagged moves)
- [x] All existing tests pass (1249+ tests, 13 suites)
- [x] Typecheck passes (12/12 tasks)
- [x] Biome check clean on changed files

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two-turn move mechanics with automatic action locking on the second turn.
  * Introduced semi-invulnerable states during charging turns of multi-turn moves.
  * Implemented Gravity field effect that blocks specific moves and counts down each turn.
  * Added move effectiveness checks against semi-invulnerable targets with generation-specific rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->