### PR TITLE
feat(gen4): two-turn moves + gravity handlers (Part 8)

### DIFF
--- a/.changeset/gen4-part8-two-turn-gravity.md
+++ b/.changeset/gen4-part8-two-turn-gravity.md
@@ -1,0 +1,18 @@
+---
+"@pokemon-lib-ts/gen4": minor
+---
+
+feat(gen4): two-turn moves + gravity handlers (Part 8)
+
+- Implement two-turn move charge handler (Fly, Dig, Dive, Bounce, Shadow Force, SolarBeam)
+  with forcedMoveSet, volatile status mapping, and charge-turn messages
+- SolarBeam in sun skips charge; Power Herb skips charge and consumes item
+- Implement canHitSemiInvulnerable: Thunder/Gust/Twister/Sky Uppercut hit flying,
+  Earthquake/Magnitude/Fissure hit underground, Surf/Whirlpool hit underwater,
+  nothing hits shadow-force-charging, all moves hit charging (non-invulnerable)
+- Implement Gravity move effect (gravitySet flag)
+- Gravity accuracy boost: multiply accuracy by 5/3
+- Gravity type immunity suppression: Levitate no longer blocks Ground in damage calc,
+  Flying-type loses Ground immunity in damage calc
+- Gravity + Arena Trap: grounded Pokemon can be trapped
+- Add gravity-countdown to end-of-turn order

--- a/packages/gen4/src/Gen4DamageCalc.ts
+++ b/packages/gen4/src/Gen4DamageCalc.ts
@@ -425,9 +425,17 @@ export function calculateGen4Damage(context: DamageContext, typeChart: TypeChart
 
   // 4. Defender ability type immunities
   // Source: Showdown sim/battle.ts — Gen 4 ability immunities
+  const gravityActive = context.state.gravity?.active ?? false;
   const immuneType = ABILITY_TYPE_IMMUNITIES[defenderAbility];
   if (immuneType && move.type === immuneType) {
-    return { damage: 0, effectiveness: 0, isCrit, randomFactor: 1 };
+    // Gravity grounds all Pokemon — Levitate no longer grants Ground immunity
+    // Source: Showdown Gen 4 mod — Gravity suppresses Levitate
+    // Source: Bulbapedia — Gravity: "Levitate will not give immunity to Ground-type moves."
+    const isLevitateGrounded =
+      defenderAbility === "levitate" && move.type === "ground" && gravityActive;
+    if (!isLevitateGrounded) {
+      return { damage: 0, effectiveness: 0, isCrit, randomFactor: 1 };
+    }
   }
 
   // 5. Physical/Special determination — THE key Gen 4 change
@@ -540,7 +548,18 @@ export function calculateGen4Damage(context: DamageContext, typeChart: TypeChart
 
   // 15. Type effectiveness
   // Source: Showdown sim/battle.ts — Gen 4 type effectiveness
-  const effectiveness = getTypeEffectiveness(move.type, defender.types, typeChart);
+  // Gravity: Ground moves ignore Flying-type immunity
+  // Source: Showdown Gen 4 mod — Gravity makes Ground moves hit Flying-types
+  // Source: Bulbapedia — Gravity: "All Pokémon on the ground are no longer immune to
+  //   Ground-type moves because of their Flying type."
+  let effectiveDefenderTypes: readonly PokemonType[] = defender.types;
+  if (gravityActive && move.type === "ground" && defender.types.includes("flying")) {
+    // Remove Flying from the defender's types for effectiveness calculation
+    // so Ground moves can hit. If the defender is pure Flying, treat as Normal.
+    const nonFlyingTypes = defender.types.filter((t) => t !== "flying");
+    effectiveDefenderTypes = nonFlyingTypes.length > 0 ? nonFlyingTypes : ["normal"];
+  }
+  const effectiveness = getTypeEffectiveness(move.type, effectiveDefenderTypes, typeChart);
 
   const burnMultiplier = burnApplied ? 0.5 : 1;
 

--- a/packages/gen4/src/Gen4MoveEffects.ts
+++ b/packages/gen4/src/Gen4MoveEffects.ts
@@ -70,6 +70,13 @@ type MutableResult = {
   trickRoomSet?: { turnsLeft: number } | null;
   volatileData?: { turnsLeft: number; data?: Record<string, unknown> } | null;
   futureAttack?: { moveId: string; turnsLeft: number; sourceSide: 0 | 1 } | null;
+  gravitySet?: boolean;
+  forcedMoveSet?: {
+    moveIndex: number;
+    moveId: string;
+    volatileStatus: VolatileStatus;
+  } | null;
+  itemConsumed?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -382,10 +389,109 @@ function applyMoveEffect(
 
     case "terrain":
     case "multi-hit":
-    case "two-turn":
       // Handled by the engine or N/A in Gen 4
       break;
+
+    case "two-turn": {
+      // Two-turn moves: charge on turn 1, attack on turn 2.
+      // On the charge turn, set a volatile status and force the move next turn.
+      // Source: Showdown Gen 4 mod — two-turn move handling
+      // Source: Bulbapedia — https://bulbapedia.bulbagarden.net/wiki/Two-turn_move
+      handleTwoTurnEffect(move, result, context);
+      break;
+    }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Two-Turn Move Effect Handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Volatile status map for two-turn semi-invulnerable moves.
+ * Maps move ID to the volatile status applied during the charge turn.
+ *
+ * Source: Showdown Gen 4 mod — semi-invulnerable states per move
+ * Source: Bulbapedia — https://bulbapedia.bulbagarden.net/wiki/Two-turn_move
+ */
+const TWO_TURN_VOLATILE_MAP: Readonly<Record<string, VolatileStatus>> = {
+  fly: "flying",
+  bounce: "flying",
+  dig: "underground",
+  dive: "underwater",
+  "shadow-force": "shadow-force-charging",
+  "solar-beam": "charging",
+  "skull-bash": "charging",
+  "razor-wind": "charging",
+  "sky-attack": "charging",
+};
+
+/**
+ * Charge-turn messages for two-turn moves.
+ *
+ * Source: Showdown Gen 4 mod — charge turn messages
+ */
+const TWO_TURN_MESSAGES: Readonly<Record<string, string>> = {
+  fly: "{pokemon} flew up high!",
+  bounce: "{pokemon} sprang up!",
+  dig: "{pokemon} dug underground!",
+  dive: "{pokemon} dived underwater!",
+  "shadow-force": "{pokemon} vanished!",
+  "solar-beam": "{pokemon} is absorbing sunlight!",
+};
+
+/**
+ * Handle the charge turn of a two-turn move.
+ *
+ * On the charge turn:
+ *   1. Determine the volatile status from the move ID
+ *   2. Check skip-charge conditions (SolarBeam in sun, Power Herb)
+ *   3. If charging, set forcedMoveSet and emit a charge message
+ *
+ * Source: Showdown Gen 4 mod — two-turn move charge handling
+ * Source: Bulbapedia — https://bulbapedia.bulbagarden.net/wiki/Two-turn_move
+ */
+function handleTwoTurnEffect(
+  move: MoveData,
+  result: MutableResult,
+  context: MoveEffectContext,
+): void {
+  const { attacker } = context;
+  const attackerName = attacker.pokemon.nickname ?? "The Pokemon";
+
+  const volatile = TWO_TURN_VOLATILE_MAP[move.id] ?? "charging";
+
+  // SolarBeam in sun: skip charge, attack immediately
+  // Source: Showdown Gen 4 mod — SolarBeam fires immediately in sun
+  // Source: Bulbapedia — "In harsh sunlight, Solar Beam can be used without a charging turn."
+  if (move.id === "solar-beam" && context.state.weather?.type === "sun") {
+    return; // No forcedMoveSet — engine proceeds with the attack immediately
+  }
+
+  // Power Herb: skip charge, consume the item
+  // Source: Showdown Gen 4 mod — Power Herb allows immediate attack
+  // Source: Bulbapedia — "Power Herb allows the holder to skip the charge turn of a
+  //   two-turn move. It is consumed after use."
+  if (attacker.pokemon.heldItem === "power-herb") {
+    result.itemConsumed = true;
+    result.messages.push(`${attackerName} became fully charged due to its Power Herb!`);
+    return; // No forcedMoveSet — engine proceeds with the attack immediately
+  }
+
+  // Determine the move index from the attacker's moveset
+  // Source: Engine uses moveIndex to identify which move slot to force next turn
+  const moveIndex = attacker.pokemon.moves.findIndex((m) => m.moveId === move.id);
+
+  // Set up the forced move for next turn
+  result.forcedMoveSet = {
+    moveIndex: moveIndex >= 0 ? moveIndex : 0,
+    moveId: move.id,
+    volatileStatus: volatile,
+  };
+
+  // Emit the charge message
+  const messageTemplate = TWO_TURN_MESSAGES[move.id] ?? "{pokemon} is charging up!";
+  result.messages.push(messageTemplate.replace("{pokemon}", attackerName));
 }
 
 // ---------------------------------------------------------------------------
@@ -857,8 +963,10 @@ function handleNullEffectMoves(
     }
 
     case "gravity": {
-      // Intensify gravity — engine handles field state
-      // Source: Showdown Gen 4 — Gravity lasts 5 turns
+      // Intensify gravity — engine applies the field state via gravitySet flag
+      // Source: Showdown Gen 4 — Gravity lasts 5 turns, grounds all Pokemon
+      // Source: Bulbapedia — https://bulbapedia.bulbagarden.net/wiki/Gravity_(move)
+      result.gravitySet = true;
       result.messages.push("Gravity intensified!");
       break;
     }

--- a/packages/gen4/src/Gen4Ruleset.ts
+++ b/packages/gen4/src/Gen4Ruleset.ts
@@ -26,6 +26,7 @@ import type {
   PrimaryStatus,
   SeededRandom,
   TypeChart,
+  VolatileStatus,
 } from "@pokemon-lib-ts/core";
 import {
   calculateExpGainClassic,
@@ -124,6 +125,40 @@ export class Gen4Ruleset extends BaseRuleset {
    */
   executeMoveEffect(context: MoveEffectContext): MoveEffectResult {
     return executeGen4MoveEffect(context);
+  }
+
+  // --- Semi-Invulnerable Hit Check ---
+
+  /**
+   * Gen 4 semi-invulnerable move bypass check.
+   *
+   * Determines if a move can hit a target that is in a semi-invulnerable state
+   * (Fly, Dig, Dive, Shadow Force charge turn).
+   *
+   * - "flying" (Fly/Bounce): Thunder, Gust, Twister, Sky Uppercut can hit
+   * - "underground" (Dig): Earthquake, Magnitude, Fissure can hit
+   * - "underwater" (Dive): Surf, Whirlpool can hit
+   * - "shadow-force-charging" (Shadow Force): nothing bypasses
+   * - "charging" (SolarBeam, Skull Bash, etc.): not semi-invulnerable; all moves hit
+   *
+   * Source: Showdown Gen 4 mod — semi-invulnerable move immunity checks
+   * Source: Bulbapedia — https://bulbapedia.bulbagarden.net/wiki/Semi-invulnerable_turn
+   */
+  override canHitSemiInvulnerable(moveId: string, volatile: VolatileStatus): boolean {
+    switch (volatile) {
+      case "flying":
+        return ["gust", "twister", "thunder", "sky-uppercut"].includes(moveId);
+      case "underground":
+        return ["earthquake", "magnitude", "fissure"].includes(moveId);
+      case "underwater":
+        return ["surf", "whirlpool"].includes(moveId);
+      case "shadow-force-charging":
+        return false; // Nothing bypasses Shadow Force
+      case "charging":
+        return true; // Generic charging moves are NOT semi-invulnerable
+      default:
+        return false;
+    }
   }
 
   // --- Critical Hit System ---
@@ -673,6 +708,14 @@ export class Gen4Ruleset extends BaseRuleset {
       calc = Math.floor((calc * 110) / 100);
     }
 
+    // Gravity: multiply accuracy by 5/3 when gravity is active
+    // Source: Showdown Gen 4 mod — Gravity boosts accuracy by 5/3
+    // Source: Bulbapedia — Gravity: "The accuracy of all moves is boosted to 5/3 of their
+    //   original accuracy during the effect."
+    if (context.state.gravity?.active) {
+      calc = Math.floor((calc * 5) / 3);
+    }
+
     // Final accuracy check: (Random() % 100 + 1) > calc means miss
     // Source: pret/pokeplatinum — same check as pokeemerald
     // Equivalent: hit if roll <= calc, where roll is 1-100
@@ -714,9 +757,13 @@ export class Gen4Ruleset extends BaseRuleset {
     if (oppAbility === "shadow-tag" && pokemon.ability !== "shadow-tag") return false;
 
     // Arena Trap: traps grounded (non-Flying, non-Levitate) opponents
+    // Gravity grounds all Pokemon, so Arena Trap traps everyone under gravity
     // Source: Bulbapedia — Arena Trap does not affect Flying-types or Levitate holders
+    // Source: Bulbapedia — Gravity: "All Pokémon are grounded. Arena Trap can trap them."
     if (oppAbility === "arena-trap") {
-      const isGrounded = !pokemon.types.includes("flying") && pokemon.ability !== "levitate";
+      const gravityActive = state.gravity?.active ?? false;
+      const isGrounded =
+        gravityActive || (!pokemon.types.includes("flying") && pokemon.ability !== "levitate");
       if (isGrounded) return false;
     }
 
@@ -829,6 +876,7 @@ export class Gen4Ruleset extends BaseRuleset {
       "safeguard-countdown", // Safeguard
       "tailwind-countdown", // Tailwind
       "trick-room-countdown", // Trick Room
+      "gravity-countdown", // Gravity (Gen 4+)
       "weather-countdown", // Weather timer
       "toxic-orb-activation", // Toxic Orb
       "flame-orb-activation", // Flame Orb

--- a/packages/gen4/tests/gravity.test.ts
+++ b/packages/gen4/tests/gravity.test.ts
@@ -1,0 +1,564 @@
+import type {
+  AccuracyContext,
+  ActivePokemon,
+  BattleState,
+  DamageContext,
+  MoveEffectContext,
+} from "@pokemon-lib-ts/battle";
+import type { MoveData, PokemonInstance, PokemonType, StatBlock } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import { Gen4Ruleset } from "../src";
+import { createGen4DataManager } from "../src/data";
+
+/**
+ * Gen 4 Gravity Tests
+ *
+ * Tests for the Gravity field effect: accuracy boost (5/3), type immunity
+ * suppression (Levitate, Flying-type ground immunity), end-of-turn countdown,
+ * and gravity move handler.
+ *
+ * Source: Showdown Gen 4 mod — Gravity mechanics
+ * Source: Bulbapedia — https://bulbapedia.bulbagarden.net/wiki/Gravity_(move)
+ */
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createMockRng(intReturnValue: number, chanceResult = false) {
+  return {
+    next: () => 0,
+    int: (_min: number, _max: number) => intReturnValue,
+    chance: () => chanceResult,
+    pick: <T>(arr: readonly T[]) => arr[0] as T,
+    shuffle: <T>(arr: readonly T[]) => [...arr],
+    getState: () => 0,
+    setState: () => {},
+  };
+}
+
+/**
+ * Create a mock RNG that returns the provided value for int() calls,
+ * allowing us to control the accuracy roll outcome.
+ */
+function createAccuracyRng(rollValue: number) {
+  return {
+    next: () => 0,
+    int: (_min: number, _max: number) => rollValue,
+    chance: () => false,
+    pick: <T>(arr: readonly T[]) => arr[0] as T,
+    shuffle: <T>(arr: readonly T[]) => [...arr],
+    getState: () => 0,
+    setState: () => {},
+  };
+}
+
+function createActivePokemon(opts: {
+  types: PokemonType[];
+  status?: string | null;
+  heldItem?: string | null;
+  nickname?: string | null;
+  currentHp?: number;
+  maxHp?: number;
+  level?: number;
+  ability?: string;
+  moves?: Array<{ moveId: string; pp: number; maxPp: number }>;
+  statStages?: Partial<Record<string, number>>;
+  speciesId?: number;
+}): ActivePokemon {
+  const maxHp = opts.maxHp ?? 200;
+  const stats: StatBlock = {
+    hp: maxHp,
+    attack: 100,
+    defense: 100,
+    spAttack: 100,
+    spDefense: 100,
+    speed: 100,
+  };
+
+  const pokemon = {
+    uid: "test-mon",
+    speciesId: opts.speciesId ?? 1,
+    nickname: opts.nickname ?? null,
+    level: opts.level ?? 50,
+    experience: 0,
+    nature: "hardy",
+    ivs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+    evs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+    currentHp: opts.currentHp ?? maxHp,
+    moves: opts.moves ?? [],
+    ability: opts.ability ?? "",
+    abilitySlot: "normal1" as const,
+    heldItem: opts.heldItem ?? null,
+    status: opts.status ?? null,
+    friendship: 0,
+    gender: "male" as const,
+    isShiny: false,
+    metLocation: "",
+    metLevel: 1,
+    originalTrainer: "",
+    originalTrainerId: 0,
+    pokeball: "pokeball",
+    calculatedStats: stats,
+  } as PokemonInstance;
+
+  return {
+    pokemon,
+    teamSlot: 0,
+    statStages: {
+      hp: 0,
+      attack: opts.statStages?.attack ?? 0,
+      defense: opts.statStages?.defense ?? 0,
+      spAttack: opts.statStages?.spAttack ?? 0,
+      spDefense: opts.statStages?.spDefense ?? 0,
+      speed: 0,
+      accuracy: opts.statStages?.accuracy ?? 0,
+      evasion: opts.statStages?.evasion ?? 0,
+    },
+    volatileStatuses: new Map(),
+    types: opts.types,
+    ability: opts.ability ?? "",
+    lastMoveUsed: null,
+    lastDamageTaken: 0,
+    lastDamageType: null,
+    turnsOnField: 0,
+    movedThisTurn: false,
+    consecutiveProtects: 0,
+    substituteHp: 0,
+    transformed: false,
+    transformedSpecies: null,
+    isMega: false,
+    isDynamaxed: false,
+    dynamaxTurnsLeft: 0,
+    isTerastallized: false,
+    teraType: null,
+  } as ActivePokemon;
+}
+
+function createMove(id: string, overrides?: Partial<MoveData>): MoveData {
+  return {
+    id,
+    name: id,
+    type: "normal",
+    category: "physical",
+    power: 80,
+    accuracy: 100,
+    pp: 10,
+    maxPp: 10,
+    priority: 0,
+    target: "adjacent-foe",
+    flags: {
+      contact: false,
+      protect: false,
+      mirror: false,
+      snatch: false,
+      gravity: false,
+      defrost: false,
+      recharge: false,
+      charge: false,
+      sound: false,
+      wind: false,
+      powder: false,
+      bullet: false,
+      pulse: false,
+      bite: false,
+      punch: false,
+      slicing: false,
+    },
+    effect: null,
+    critRatio: 0,
+    generation: 4,
+    isContact: false,
+    isSound: false,
+    isPunch: false,
+    isBite: false,
+    isBullet: false,
+    description: "",
+    ...overrides,
+  } as MoveData;
+}
+
+function createMinimalBattleState(
+  attacker: ActivePokemon,
+  defender: ActivePokemon,
+  opts?: {
+    weatherType?: string | null;
+    gravityActive?: boolean;
+  },
+): BattleState {
+  const gravityActive = opts?.gravityActive ?? false;
+  return {
+    sides: [
+      {
+        index: 0,
+        active: [attacker],
+        team: [attacker.pokemon],
+        screens: [],
+        hazards: [],
+        tailwind: { active: false, turnsLeft: 0 },
+        luckyChant: { active: false, turnsLeft: 0 },
+        wish: null,
+        futureAttack: null,
+        faintCount: 0,
+        gimmickUsed: false,
+        trainer: null,
+      },
+      {
+        index: 1,
+        active: [defender],
+        team: [defender.pokemon],
+        screens: [],
+        hazards: [],
+        tailwind: { active: false, turnsLeft: 0 },
+        luckyChant: { active: false, turnsLeft: 0 },
+        wish: null,
+        futureAttack: null,
+        faintCount: 0,
+        gimmickUsed: false,
+        trainer: null,
+      },
+    ],
+    weather: { type: opts?.weatherType ?? null, turnsLeft: 0, source: null },
+    terrain: { type: null, turnsLeft: 0, source: null },
+    trickRoom: { active: false, turnsLeft: 0 },
+    gravity: { active: gravityActive, turnsLeft: gravityActive ? 5 : 0 },
+    turnNumber: 1,
+    phase: "action-select" as const,
+    winner: null,
+    ended: false,
+  } as BattleState;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const dataManager = createGen4DataManager();
+const ruleset = new Gen4Ruleset(dataManager);
+
+// ─── Gravity Move Effect ──────────────────────────────────────────────────
+
+describe("Gen 4 Gravity Move Effect", () => {
+  it("given Gravity used, when executeMoveEffect called, then returns gravitySet=true", () => {
+    // Source: Showdown Gen 4 — Gravity sets gravitySet in the move effect result
+    // Source: Bulbapedia — Gravity: "Gravity is intensified for five turns."
+    const attacker = createActivePokemon({ types: ["psychic"] });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("gravity", {
+      type: "psychic",
+      category: "status",
+      power: null,
+      accuracy: null,
+    });
+    const rng = createMockRng(0);
+    const state = createMinimalBattleState(attacker, defender);
+    const context = { attacker, defender, move, damage: 0, state, rng } as MoveEffectContext;
+
+    const result = ruleset.executeMoveEffect(context);
+
+    expect(result.gravitySet).toBe(true);
+    expect(result.messages).toContain("Gravity intensified!");
+  });
+});
+
+// ─── Gravity Accuracy Boost ───────────────────────────────────────────────
+
+describe("Gen 4 Gravity — Accuracy Boost", () => {
+  it("given gravity active, when calculating accuracy for move with 80 accuracy, then accuracy is multiplied by 5/3", () => {
+    // Source: Showdown Gen 4 mod — Gravity multiplies accuracy by 5/3
+    // Source: Bulbapedia — Gravity: "The accuracy of all moves is boosted to 5/3 of their
+    //   original accuracy during the effect."
+    //
+    // With gravity: 80 * 5/3 = floor(400/3) = 133. Roll of 133 should still hit.
+    // Without gravity: 80 accuracy, roll of 81 would miss.
+    //
+    // Derivation: at accuracy stage 0, calc = floor(1 * 80 / 1) = 80.
+    // With gravity: calc = floor(80 * 5 / 3) = floor(133.33) = 133.
+    // A roll of 133 hits (133 <= 133), but 134 misses.
+    const attacker = createActivePokemon({ types: ["normal"] });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("thunder", {
+      type: "electric",
+      category: "special",
+      power: 120,
+      accuracy: 80,
+    });
+
+    // Test: with gravity, roll of 133 should hit
+    const rngHit = createAccuracyRng(133);
+    const stateWithGravity = createMinimalBattleState(attacker, defender, {
+      gravityActive: true,
+    });
+    const contextHit: AccuracyContext = {
+      attacker,
+      defender,
+      move,
+      state: stateWithGravity,
+      rng: rngHit,
+    };
+    expect(ruleset.doesMoveHit(contextHit)).toBe(true);
+
+    // Test: without gravity, roll of 81 should miss (80 accuracy, roll > 80)
+    const rngMiss = createAccuracyRng(81);
+    const stateNoGravity = createMinimalBattleState(attacker, defender, {
+      gravityActive: false,
+    });
+    const contextMiss: AccuracyContext = {
+      attacker,
+      defender,
+      move,
+      state: stateNoGravity,
+      rng: rngMiss,
+    };
+    expect(ruleset.doesMoveHit(contextMiss)).toBe(false);
+  });
+
+  it("given gravity active, when using Blizzard (70 acc), then accuracy is boosted to floor(70*5/3)=116", () => {
+    // Source: Showdown Gen 4 — Gravity accuracy calculation
+    // Derivation: base acc = 70, stage 0 calc = 70.
+    // With gravity: floor(70 * 5 / 3) = floor(116.67) = 116.
+    // Roll of 116 hits, 117 misses.
+    const attacker = createActivePokemon({ types: ["ice"] });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("blizzard", {
+      type: "ice",
+      category: "special",
+      power: 120,
+      accuracy: 70,
+    });
+
+    const rngHit = createAccuracyRng(116);
+    const stateGravity = createMinimalBattleState(attacker, defender, {
+      gravityActive: true,
+    });
+    const contextHit: AccuracyContext = {
+      attacker,
+      defender,
+      move,
+      state: stateGravity,
+      rng: rngHit,
+    };
+    expect(ruleset.doesMoveHit(contextHit)).toBe(true);
+
+    const rngMiss = createAccuracyRng(117);
+    const contextMiss: AccuracyContext = {
+      attacker,
+      defender,
+      move,
+      state: stateGravity,
+      rng: rngMiss,
+    };
+    expect(ruleset.doesMoveHit(contextMiss)).toBe(false);
+  });
+});
+
+// ─── Gravity Type Immunity Suppression ────────────────────────────────────
+
+describe("Gen 4 Gravity — Type Immunity Suppression", () => {
+  it("given gravity active, when Ground move targets Levitate Pokemon, then type immunity not applied", () => {
+    // Source: Showdown Gen 4 mod — Gravity suppresses Levitate
+    // Source: Bulbapedia — Gravity: "Levitate will not give immunity to Ground-type moves."
+    const attacker = createActivePokemon({ types: ["ground"], level: 50 });
+    const defender = createActivePokemon({ types: ["psychic"], ability: "levitate" });
+    const move = createMove("earthquake", {
+      type: "ground",
+      power: 100,
+    });
+
+    const stateGravity = createMinimalBattleState(attacker, defender, {
+      gravityActive: true,
+    });
+    const rng = createMockRng(100); // max random roll for consistent output
+    const context: DamageContext = {
+      attacker,
+      defender,
+      move,
+      state: stateGravity,
+      rng,
+      isCrit: false,
+    };
+
+    const result = ruleset.calculateDamage(context);
+
+    // With gravity active, Levitate no longer blocks Ground moves — damage > 0
+    expect(result.damage).toBeGreaterThan(0);
+    expect(result.effectiveness).not.toBe(0);
+  });
+
+  it("given gravity NOT active, when Ground move targets Levitate Pokemon, then type immunity IS applied", () => {
+    // Source: Showdown Gen 4 — Levitate grants Ground immunity normally
+    const attacker = createActivePokemon({ types: ["ground"], level: 50 });
+    const defender = createActivePokemon({ types: ["psychic"], ability: "levitate" });
+    const move = createMove("earthquake", {
+      type: "ground",
+      power: 100,
+    });
+
+    const stateNoGravity = createMinimalBattleState(attacker, defender, {
+      gravityActive: false,
+    });
+    const rng = createMockRng(100);
+    const context: DamageContext = {
+      attacker,
+      defender,
+      move,
+      state: stateNoGravity,
+      rng,
+      isCrit: false,
+    };
+
+    const result = ruleset.calculateDamage(context);
+
+    expect(result.damage).toBe(0);
+    expect(result.effectiveness).toBe(0);
+  });
+
+  it("given gravity active, when Ground move targets Flying-type Pokemon, then type immunity not applied", () => {
+    // Source: Showdown Gen 4 mod — Gravity grounds Flying-type Pokemon
+    // Source: Bulbapedia — Gravity: "All Pokemon are affected by Ground-type moves,
+    //   regardless of their Flying-type status."
+    const attacker = createActivePokemon({ types: ["ground"], level: 50 });
+    const defender = createActivePokemon({ types: ["flying"] });
+    const move = createMove("earthquake", {
+      type: "ground",
+      power: 100,
+    });
+
+    const stateGravity = createMinimalBattleState(attacker, defender, {
+      gravityActive: true,
+    });
+    const rng = createMockRng(100);
+    const context: DamageContext = {
+      attacker,
+      defender,
+      move,
+      state: stateGravity,
+      rng,
+      isCrit: false,
+    };
+
+    const result = ruleset.calculateDamage(context);
+
+    // With gravity, pure Flying-type is treated as Normal for Ground effectiveness
+    // Ground vs Normal = 1.0x (neutral). Damage should be > 0.
+    expect(result.damage).toBeGreaterThan(0);
+    expect(result.effectiveness).not.toBe(0);
+  });
+
+  it("given gravity NOT active, when Ground move targets Flying-type Pokemon, then type immunity IS applied", () => {
+    // Source: Showdown Gen 4 — Ground moves cannot hit Flying-type Pokemon normally
+    const attacker = createActivePokemon({ types: ["ground"], level: 50 });
+    const defender = createActivePokemon({ types: ["flying"] });
+    const move = createMove("earthquake", {
+      type: "ground",
+      power: 100,
+    });
+
+    const stateNoGravity = createMinimalBattleState(attacker, defender, {
+      gravityActive: false,
+    });
+    const rng = createMockRng(100);
+    const context: DamageContext = {
+      attacker,
+      defender,
+      move,
+      state: stateNoGravity,
+      rng,
+      isCrit: false,
+    };
+
+    const result = ruleset.calculateDamage(context);
+
+    expect(result.damage).toBe(0);
+    expect(result.effectiveness).toBe(0);
+  });
+
+  it("given gravity active, when non-Ground move targets Flying-type Pokemon, then effectiveness is normal", () => {
+    // Source: Showdown Gen 4 — Gravity only affects Ground-type move immunity, not other types
+    // A Fire move should still use normal Flying effectiveness (0.5x resist)
+    const attacker = createActivePokemon({ types: ["fire"], level: 50 });
+    const defender = createActivePokemon({ types: ["flying"] });
+    const move = createMove("flamethrower", {
+      type: "fire",
+      category: "special",
+      power: 95,
+    });
+
+    const stateGravity = createMinimalBattleState(attacker, defender, {
+      gravityActive: true,
+    });
+    const rng = createMockRng(100);
+    const context: DamageContext = {
+      attacker,
+      defender,
+      move,
+      state: stateGravity,
+      rng,
+      isCrit: false,
+    };
+
+    const result = ruleset.calculateDamage(context);
+
+    // Fire vs Flying = 1x (neutral, not affected by gravity)
+    // Result should be normal damage, not 0
+    expect(result.damage).toBeGreaterThan(0);
+  });
+});
+
+// ─── Gravity End-of-Turn Order ────────────────────────────────────────────
+
+describe("Gen 4 Gravity — End-of-Turn Order", () => {
+  it("given Gen4 ruleset, when getEndOfTurnOrder called, then gravity-countdown is present", () => {
+    // Source: Showdown Gen 4 mod — gravity countdown is part of end-of-turn processing
+    const order = ruleset.getEndOfTurnOrder();
+    expect(order).toContain("gravity-countdown");
+  });
+
+  it("given Gen4 ruleset, when getEndOfTurnOrder called, then gravity-countdown is after trick-room-countdown", () => {
+    // Source: Showdown Gen 4 mod — countdown order: trick room, then gravity, then weather
+    const order = ruleset.getEndOfTurnOrder();
+    const trickRoomIndex = order.indexOf("trick-room-countdown");
+    const gravityIndex = order.indexOf("gravity-countdown");
+    expect(gravityIndex).toBeGreaterThan(trickRoomIndex);
+  });
+
+  it("given Gen4 ruleset, when getEndOfTurnOrder called, then gravity-countdown is before weather-countdown", () => {
+    // Source: Showdown Gen 4 mod — gravity countdown runs before weather countdown
+    const order = ruleset.getEndOfTurnOrder();
+    const gravityIndex = order.indexOf("gravity-countdown");
+    const weatherIndex = order.indexOf("weather-countdown");
+    expect(gravityIndex).toBeLessThan(weatherIndex);
+  });
+});
+
+// ─── Gravity + Arena Trap ─────────────────────────────────────────────────
+
+describe("Gen 4 Gravity — Arena Trap Grounding", () => {
+  it("given gravity active and opponent has Arena Trap, when Flying-type tries to switch, then cannot switch", () => {
+    // Source: Showdown Gen 4 — Gravity grounds Flying Pokemon, Arena Trap traps them
+    // Source: Bulbapedia — "Under Gravity, Arena Trap affects all adjacent Pokemon."
+    const pokemon = createActivePokemon({ types: ["normal", "flying"] });
+    const opponent = createActivePokemon({ types: ["ground"], ability: "arena-trap" });
+    const state = createMinimalBattleState(pokemon, opponent, { gravityActive: true });
+
+    expect(ruleset.canSwitch(pokemon, state)).toBe(false);
+  });
+
+  it("given gravity NOT active and opponent has Arena Trap, when Flying-type tries to switch, then CAN switch", () => {
+    // Source: Showdown Gen 4 — Flying types are not grounded without gravity
+    const pokemon = createActivePokemon({ types: ["normal", "flying"] });
+    const opponent = createActivePokemon({ types: ["ground"], ability: "arena-trap" });
+    const state = createMinimalBattleState(pokemon, opponent, { gravityActive: false });
+
+    expect(ruleset.canSwitch(pokemon, state)).toBe(true);
+  });
+
+  it("given gravity active and opponent has Arena Trap, when Levitate Pokemon tries to switch, then cannot switch", () => {
+    // Source: Showdown Gen 4 — Gravity grounds Levitate Pokemon, Arena Trap traps them
+    const pokemon = createActivePokemon({ types: ["psychic"], ability: "levitate" });
+    const opponent = createActivePokemon({ types: ["ground"], ability: "arena-trap" });
+    const state = createMinimalBattleState(pokemon, opponent, { gravityActive: true });
+
+    expect(ruleset.canSwitch(pokemon, state)).toBe(false);
+  });
+});

--- a/packages/gen4/tests/ruleset.test.ts
+++ b/packages/gen4/tests/ruleset.test.ts
@@ -612,6 +612,7 @@ describe("Gen4Ruleset getEndOfTurnOrder", () => {
       "safeguard-countdown",
       "tailwind-countdown",
       "trick-room-countdown",
+      "gravity-countdown",
       "weather-countdown",
       "toxic-orb-activation",
       "flame-orb-activation",

--- a/packages/gen4/tests/two-turn-moves.test.ts
+++ b/packages/gen4/tests/two-turn-moves.test.ts
@@ -1,0 +1,610 @@
+import type { ActivePokemon, BattleState, MoveEffectContext } from "@pokemon-lib-ts/battle";
+import type { MoveData, PokemonInstance, PokemonType, StatBlock } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import { Gen4Ruleset } from "../src";
+import { createGen4DataManager } from "../src/data";
+
+/**
+ * Gen 4 Two-Turn Move Tests
+ *
+ * Tests for two-turn move charge handling (Fly, Dig, Dive, Bounce, Shadow Force,
+ * Solar Beam) including skip-charge exceptions (SolarBeam in sun, Power Herb)
+ * and semi-invulnerable hit checks (canHitSemiInvulnerable).
+ *
+ * Source: Showdown Gen 4 mod — two-turn move handling
+ * Source: Bulbapedia — https://bulbapedia.bulbagarden.net/wiki/Two-turn_move
+ */
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createMockRng(intReturnValue: number, chanceResult = false) {
+  return {
+    next: () => 0,
+    int: (_min: number, _max: number) => intReturnValue,
+    chance: () => chanceResult,
+    pick: <T>(arr: readonly T[]) => arr[0] as T,
+    shuffle: <T>(arr: readonly T[]) => [...arr],
+    getState: () => 0,
+    setState: () => {},
+  };
+}
+
+function createActivePokemon(opts: {
+  types: PokemonType[];
+  status?: string | null;
+  heldItem?: string | null;
+  nickname?: string | null;
+  currentHp?: number;
+  maxHp?: number;
+  level?: number;
+  ability?: string;
+  moves?: Array<{ moveId: string; pp: number; maxPp: number }>;
+}): ActivePokemon {
+  const maxHp = opts.maxHp ?? 200;
+  const stats: StatBlock = {
+    hp: maxHp,
+    attack: 100,
+    defense: 100,
+    spAttack: 100,
+    spDefense: 100,
+    speed: 100,
+  };
+
+  const pokemon = {
+    uid: "test-mon",
+    speciesId: 1,
+    nickname: opts.nickname ?? null,
+    level: opts.level ?? 50,
+    experience: 0,
+    nature: "hardy",
+    ivs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+    evs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+    currentHp: opts.currentHp ?? maxHp,
+    moves: opts.moves ?? [],
+    ability: opts.ability ?? "",
+    abilitySlot: "normal1" as const,
+    heldItem: opts.heldItem ?? null,
+    status: opts.status ?? null,
+    friendship: 0,
+    gender: "male" as const,
+    isShiny: false,
+    metLocation: "",
+    metLevel: 1,
+    originalTrainer: "",
+    originalTrainerId: 0,
+    pokeball: "pokeball",
+    calculatedStats: stats,
+  } as PokemonInstance;
+
+  return {
+    pokemon,
+    teamSlot: 0,
+    statStages: {
+      hp: 0,
+      attack: 0,
+      defense: 0,
+      spAttack: 0,
+      spDefense: 0,
+      speed: 0,
+      accuracy: 0,
+      evasion: 0,
+    },
+    volatileStatuses: new Map(),
+    types: opts.types,
+    ability: opts.ability ?? "",
+    lastMoveUsed: null,
+    lastDamageTaken: 0,
+    lastDamageType: null,
+    turnsOnField: 0,
+    movedThisTurn: false,
+    consecutiveProtects: 0,
+    substituteHp: 0,
+    transformed: false,
+    transformedSpecies: null,
+    isMega: false,
+    isDynamaxed: false,
+    dynamaxTurnsLeft: 0,
+    isTerastallized: false,
+    teraType: null,
+  } as ActivePokemon;
+}
+
+function createMove(id: string, overrides?: Partial<MoveData>): MoveData {
+  return {
+    id,
+    name: id,
+    type: "normal",
+    category: "physical",
+    power: 80,
+    accuracy: 100,
+    pp: 10,
+    maxPp: 10,
+    priority: 0,
+    target: "adjacent-foe",
+    flags: {
+      contact: false,
+      protect: false,
+      mirror: false,
+      snatch: false,
+      gravity: false,
+      defrost: false,
+      recharge: false,
+      charge: false,
+      sound: false,
+      wind: false,
+      powder: false,
+      bullet: false,
+      pulse: false,
+      bite: false,
+      punch: false,
+      slicing: false,
+    },
+    effect: null,
+    critRatio: 0,
+    generation: 4,
+    isContact: false,
+    isSound: false,
+    isPunch: false,
+    isBite: false,
+    isBullet: false,
+    description: "",
+    ...overrides,
+  } as MoveData;
+}
+
+function createMinimalBattleState(
+  attacker: ActivePokemon,
+  defender: ActivePokemon,
+  weatherType?: string | null,
+  gravityActive = false,
+): BattleState {
+  return {
+    sides: [
+      {
+        index: 0,
+        active: [attacker],
+        team: [attacker.pokemon],
+        screens: [],
+        hazards: [],
+        tailwind: { active: false, turnsLeft: 0 },
+        luckyChant: { active: false, turnsLeft: 0 },
+        wish: null,
+        futureAttack: null,
+        faintCount: 0,
+        gimmickUsed: false,
+        trainer: null,
+      },
+      {
+        index: 1,
+        active: [defender],
+        team: [defender.pokemon],
+        screens: [],
+        hazards: [],
+        tailwind: { active: false, turnsLeft: 0 },
+        luckyChant: { active: false, turnsLeft: 0 },
+        wish: null,
+        futureAttack: null,
+        faintCount: 0,
+        gimmickUsed: false,
+        trainer: null,
+      },
+    ],
+    weather: { type: weatherType ?? null, turnsLeft: 0, source: null },
+    terrain: { type: null, turnsLeft: 0, source: null },
+    trickRoom: { active: false, turnsLeft: 0 },
+    gravity: { active: gravityActive, turnsLeft: gravityActive ? 5 : 0 },
+    turnNumber: 1,
+    phase: "action-select" as const,
+    winner: null,
+    ended: false,
+  } as BattleState;
+}
+
+function createContext(
+  attacker: ActivePokemon,
+  defender: ActivePokemon,
+  move: MoveData,
+  damage: number,
+  rng: ReturnType<typeof createMockRng>,
+  weatherType?: string | null,
+  gravityActive = false,
+): MoveEffectContext {
+  const state = createMinimalBattleState(attacker, defender, weatherType, gravityActive);
+  return { attacker, defender, move, damage, state, rng } as MoveEffectContext;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const dataManager = createGen4DataManager();
+const ruleset = new Gen4Ruleset(dataManager);
+
+// ─── Two-Turn Move Charge Handling ────────────────────────────────────────
+
+describe("Gen 4 Two-Turn Moves — Charge Turn", () => {
+  it("given Fly on charge turn, when executed, then sets flying volatile and forcedMove", () => {
+    // Source: Showdown Gen 4 — Fly sets flying volatile on charge turn
+    // Source: Bulbapedia — "Fly: The user flies up on the first turn and attacks on the second."
+    const attacker = createActivePokemon({
+      types: ["normal", "flying"],
+      moves: [{ moveId: "fly", pp: 10, maxPp: 10 }],
+    });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("fly", {
+      type: "flying",
+      power: 90,
+      effect: { type: "two-turn" } as any,
+      flags: {
+        contact: true,
+        protect: true,
+        mirror: true,
+        snatch: false,
+        gravity: true,
+        defrost: false,
+        recharge: false,
+        charge: true,
+        sound: false,
+        wind: false,
+        powder: false,
+        bullet: false,
+        pulse: false,
+        bite: false,
+        punch: false,
+        slicing: false,
+      },
+    });
+    const rng = createMockRng(0);
+    const context = createContext(attacker, defender, move, 0, rng);
+
+    const result = ruleset.executeMoveEffect(context);
+
+    expect(result.forcedMoveSet).toEqual({
+      moveIndex: 0,
+      moveId: "fly",
+      volatileStatus: "flying",
+    });
+    expect(result.messages).toContain("The Pokemon flew up high!");
+  });
+
+  it("given Dig on charge turn, when executed, then sets underground volatile and forcedMove", () => {
+    // Source: Showdown Gen 4 — Dig sets underground volatile on charge turn
+    // Source: Bulbapedia — "Dig: The user digs underground on the first turn and attacks on the second."
+    const attacker = createActivePokemon({
+      types: ["ground"],
+      moves: [{ moveId: "dig", pp: 10, maxPp: 10 }],
+    });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("dig", {
+      type: "ground",
+      power: 80,
+      effect: { type: "two-turn" } as any,
+      flags: {
+        contact: true,
+        protect: true,
+        mirror: true,
+        snatch: false,
+        gravity: false,
+        defrost: false,
+        recharge: false,
+        charge: true,
+        sound: false,
+        wind: false,
+        powder: false,
+        bullet: false,
+        pulse: false,
+        bite: false,
+        punch: false,
+        slicing: false,
+      },
+    });
+    const rng = createMockRng(0);
+    const context = createContext(attacker, defender, move, 0, rng);
+
+    const result = ruleset.executeMoveEffect(context);
+
+    expect(result.forcedMoveSet).toEqual({
+      moveIndex: 0,
+      moveId: "dig",
+      volatileStatus: "underground",
+    });
+    expect(result.messages).toContain("The Pokemon dug underground!");
+  });
+
+  it("given Shadow Force on charge turn, when executed, then sets shadow-force-charging volatile", () => {
+    // Source: Showdown Gen 4 — Shadow Force sets shadow-force-charging volatile
+    // Source: Bulbapedia — "Shadow Force: The user vanishes on the first turn and attacks on the second."
+    const attacker = createActivePokemon({
+      types: ["ghost"],
+      moves: [{ moveId: "shadow-force", pp: 5, maxPp: 5 }],
+    });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("shadow-force", {
+      type: "ghost",
+      power: 120,
+      effect: { type: "two-turn" } as any,
+      flags: {
+        contact: true,
+        protect: false,
+        mirror: true,
+        snatch: false,
+        gravity: false,
+        defrost: false,
+        recharge: false,
+        charge: true,
+        sound: false,
+        wind: false,
+        powder: false,
+        bullet: false,
+        pulse: false,
+        bite: false,
+        punch: false,
+        slicing: false,
+      },
+    });
+    const rng = createMockRng(0);
+    const context = createContext(attacker, defender, move, 0, rng);
+
+    const result = ruleset.executeMoveEffect(context);
+
+    expect(result.forcedMoveSet).toEqual({
+      moveIndex: 0,
+      moveId: "shadow-force",
+      volatileStatus: "shadow-force-charging",
+    });
+    expect(result.messages).toContain("The Pokemon vanished!");
+  });
+
+  it("given Bounce on charge turn, when executed, then sets flying volatile (same as Fly)", () => {
+    // Source: Showdown Gen 4 — Bounce uses the same flying volatile as Fly
+    // Source: Bulbapedia — "Bounce: The user bounces up on the first turn and attacks on the second."
+    const attacker = createActivePokemon({
+      types: ["normal"],
+      moves: [{ moveId: "bounce", pp: 5, maxPp: 5 }],
+    });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("bounce", {
+      type: "flying",
+      power: 85,
+      effect: { type: "two-turn" } as any,
+      flags: {
+        contact: true,
+        protect: true,
+        mirror: true,
+        snatch: false,
+        gravity: true,
+        defrost: false,
+        recharge: false,
+        charge: true,
+        sound: false,
+        wind: false,
+        powder: false,
+        bullet: false,
+        pulse: false,
+        bite: false,
+        punch: false,
+        slicing: false,
+      },
+    });
+    const rng = createMockRng(0);
+    const context = createContext(attacker, defender, move, 0, rng);
+
+    const result = ruleset.executeMoveEffect(context);
+
+    expect(result.forcedMoveSet).toEqual({
+      moveIndex: 0,
+      moveId: "bounce",
+      volatileStatus: "flying",
+    });
+    expect(result.messages).toContain("The Pokemon sprang up!");
+  });
+
+  it("given Dive on charge turn, when executed, then sets underwater volatile", () => {
+    // Source: Showdown Gen 4 — Dive sets underwater volatile on charge turn
+    const attacker = createActivePokemon({
+      types: ["water"],
+      moves: [{ moveId: "dive", pp: 10, maxPp: 10 }],
+    });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("dive", {
+      type: "water",
+      power: 80,
+      effect: { type: "two-turn" } as any,
+      flags: {
+        contact: true,
+        protect: true,
+        mirror: true,
+        snatch: false,
+        gravity: false,
+        defrost: false,
+        recharge: false,
+        charge: true,
+        sound: false,
+        wind: false,
+        powder: false,
+        bullet: false,
+        pulse: false,
+        bite: false,
+        punch: false,
+        slicing: false,
+      },
+    });
+    const rng = createMockRng(0);
+    const context = createContext(attacker, defender, move, 0, rng);
+
+    const result = ruleset.executeMoveEffect(context);
+
+    expect(result.forcedMoveSet).toEqual({
+      moveIndex: 0,
+      moveId: "dive",
+      volatileStatus: "underwater",
+    });
+    expect(result.messages).toContain("The Pokemon dived underwater!");
+  });
+});
+
+// ─── SolarBeam Sun Exception ──────────────────────────────────────────────
+
+describe("Gen 4 Two-Turn Moves — SolarBeam Sun Exception", () => {
+  it("given Solar Beam in sun weather, when executed, then attacks immediately without charge", () => {
+    // Source: Showdown Gen 4 — SolarBeam fires immediately in harsh sunlight
+    // Source: Bulbapedia — "In harsh sunlight, Solar Beam can be used without a charging turn."
+    const attacker = createActivePokemon({
+      types: ["grass"],
+      moves: [{ moveId: "solar-beam", pp: 10, maxPp: 10 }],
+    });
+    const defender = createActivePokemon({ types: ["water"] });
+    const move = createMove("solar-beam", {
+      type: "grass",
+      category: "special",
+      power: 120,
+      effect: { type: "two-turn" } as any,
+    });
+    const rng = createMockRng(0);
+    const context = createContext(attacker, defender, move, 0, rng, "sun");
+
+    const result = ruleset.executeMoveEffect(context);
+
+    // No forcedMoveSet means the attack proceeds immediately
+    expect(result.forcedMoveSet).toBeUndefined();
+  });
+
+  it("given Solar Beam without sun, when executed, then sets forcedMove on first turn", () => {
+    // Source: Showdown Gen 4 — SolarBeam charges in non-sun weather
+    // Source: Bulbapedia — "Solar Beam requires a turn to charge before attacking."
+    const attacker = createActivePokemon({
+      types: ["grass"],
+      moves: [{ moveId: "solar-beam", pp: 10, maxPp: 10 }],
+    });
+    const defender = createActivePokemon({ types: ["water"] });
+    const move = createMove("solar-beam", {
+      type: "grass",
+      category: "special",
+      power: 120,
+      effect: { type: "two-turn" } as any,
+    });
+    const rng = createMockRng(0);
+    const context = createContext(attacker, defender, move, 0, rng);
+
+    const result = ruleset.executeMoveEffect(context);
+
+    expect(result.forcedMoveSet).toEqual({
+      moveIndex: 0,
+      moveId: "solar-beam",
+      volatileStatus: "charging",
+    });
+    expect(result.messages).toContain("The Pokemon is absorbing sunlight!");
+  });
+});
+
+// ─── Power Herb Exception ─────────────────────────────────────────────────
+
+describe("Gen 4 Two-Turn Moves — Power Herb", () => {
+  it("given Pokemon with Power Herb, when using Fly, then skips charge and consumes item", () => {
+    // Source: Showdown Gen 4 — Power Herb skips charge turn and is consumed
+    // Source: Bulbapedia — "Power Herb allows the holder to skip the charge turn of a
+    //   two-turn move. It is consumed after use."
+    const attacker = createActivePokemon({
+      types: ["normal", "flying"],
+      heldItem: "power-herb",
+      moves: [{ moveId: "fly", pp: 10, maxPp: 10 }],
+    });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("fly", {
+      type: "flying",
+      power: 90,
+      effect: { type: "two-turn" } as any,
+    });
+    const rng = createMockRng(0);
+    const context = createContext(attacker, defender, move, 0, rng);
+
+    const result = ruleset.executeMoveEffect(context);
+
+    // No forcedMoveSet — attack proceeds immediately
+    expect(result.forcedMoveSet).toBeUndefined();
+    // Item is consumed
+    expect(result.itemConsumed).toBe(true);
+    expect(result.messages).toContain("The Pokemon became fully charged due to its Power Herb!");
+  });
+});
+
+// ─── canHitSemiInvulnerable ───────────────────────────────────────────────
+
+describe("Gen 4 canHitSemiInvulnerable", () => {
+  it("given defender in flying state, when canHitSemiInvulnerable called with Thunder, then returns true", () => {
+    // Source: Showdown Gen 4 — Thunder hits flying targets
+    // Source: Bulbapedia — "Thunder has perfect accuracy and can hit a Pokemon using Fly or Bounce."
+    expect(ruleset.canHitSemiInvulnerable("thunder", "flying")).toBe(true);
+  });
+
+  it("given defender in flying state, when canHitSemiInvulnerable called with Gust, then returns true", () => {
+    // Source: Showdown Gen 4 — Gust hits flying targets
+    // Source: Bulbapedia — "Gust can hit a Pokemon during the semi-invulnerable turn of Fly."
+    expect(ruleset.canHitSemiInvulnerable("gust", "flying")).toBe(true);
+  });
+
+  it("given defender in flying state, when canHitSemiInvulnerable called with Twister, then returns true", () => {
+    // Source: Showdown Gen 4 — Twister hits flying targets
+    expect(ruleset.canHitSemiInvulnerable("twister", "flying")).toBe(true);
+  });
+
+  it("given defender in flying state, when canHitSemiInvulnerable called with Sky Uppercut, then returns true", () => {
+    // Source: Showdown Gen 4 — Sky Uppercut hits flying targets
+    // Source: Bulbapedia — "Sky Uppercut can hit a target during the semi-invulnerable turn of Fly."
+    expect(ruleset.canHitSemiInvulnerable("sky-uppercut", "flying")).toBe(true);
+  });
+
+  it("given defender in flying state, when canHitSemiInvulnerable called with Flamethrower, then returns false", () => {
+    // Source: Showdown Gen 4 — Flamethrower cannot hit flying targets
+    expect(ruleset.canHitSemiInvulnerable("flamethrower", "flying")).toBe(false);
+  });
+
+  it("given defender in underground state, when canHitSemiInvulnerable called with Earthquake, then returns true", () => {
+    // Source: Showdown Gen 4 — Earthquake hits underground targets
+    // Source: Bulbapedia — "Earthquake can hit a Pokemon during the semi-invulnerable turn of Dig."
+    expect(ruleset.canHitSemiInvulnerable("earthquake", "underground")).toBe(true);
+  });
+
+  it("given defender in underground state, when canHitSemiInvulnerable called with Magnitude, then returns true", () => {
+    // Source: Showdown Gen 4 — Magnitude hits underground targets
+    expect(ruleset.canHitSemiInvulnerable("magnitude", "underground")).toBe(true);
+  });
+
+  it("given defender in underground state, when canHitSemiInvulnerable called with Fissure, then returns true", () => {
+    // Source: Showdown Gen 4 — Fissure hits underground targets
+    expect(ruleset.canHitSemiInvulnerable("fissure", "underground")).toBe(true);
+  });
+
+  it("given defender in underground state, when canHitSemiInvulnerable called with Surf, then returns false", () => {
+    // Source: Showdown Gen 4 — Surf cannot hit underground targets (only underwater)
+    expect(ruleset.canHitSemiInvulnerable("surf", "underground")).toBe(false);
+  });
+
+  it("given defender in underwater state, when canHitSemiInvulnerable called with Surf, then returns true", () => {
+    // Source: Showdown Gen 4 — Surf hits underwater targets
+    // Source: Bulbapedia — "Surf can hit a Pokemon during the semi-invulnerable turn of Dive."
+    expect(ruleset.canHitSemiInvulnerable("surf", "underwater")).toBe(true);
+  });
+
+  it("given defender in underwater state, when canHitSemiInvulnerable called with Whirlpool, then returns true", () => {
+    // Source: Showdown Gen 4 — Whirlpool hits underwater targets
+    expect(ruleset.canHitSemiInvulnerable("whirlpool", "underwater")).toBe(true);
+  });
+
+  it("given defender in shadow-force-charging state, when canHitSemiInvulnerable called with any move, then returns false", () => {
+    // Source: Showdown Gen 4 — Nothing can hit a Pokemon during Shadow Force's charge
+    // Source: Bulbapedia — "Shadow Force bypasses Protect and Detect."
+    expect(ruleset.canHitSemiInvulnerable("thunder", "shadow-force-charging")).toBe(false);
+    expect(ruleset.canHitSemiInvulnerable("earthquake", "shadow-force-charging")).toBe(false);
+    expect(ruleset.canHitSemiInvulnerable("surf", "shadow-force-charging")).toBe(false);
+  });
+
+  it("given defender in charging state (generic), when canHitSemiInvulnerable called with any move, then returns true", () => {
+    // Source: Showdown Gen 4 — Generic charging (SolarBeam, Skull Bash) is NOT semi-invulnerable
+    // These moves do not grant evasion during the charge turn
+    expect(ruleset.canHitSemiInvulnerable("flamethrower", "charging")).toBe(true);
+    expect(ruleset.canHitSemiInvulnerable("tackle", "charging")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Implement two-turn move charge handler (Fly, Dig, Dive, Bounce, Shadow Force, SolarBeam) with volatile status mapping, forcedMoveSet, and charge-turn messages
- SolarBeam in sun skips charge; Power Herb skips charge and consumes item
- Implement `canHitSemiInvulnerable` for Gen 4: Thunder/Gust/Twister/Sky Uppercut hit flying, Earthquake/Magnitude/Fissure hit underground, Surf/Whirlpool hit underwater, nothing bypasses Shadow Force
- Implement Gravity move effect (`gravitySet` flag)
- Gravity accuracy boost: multiply accuracy by 5/3
- Gravity type immunity suppression in damage calc: Levitate no longer blocks Ground, Flying-type loses Ground immunity
- Gravity + Arena Trap: grounded Pokemon can be trapped
- Add `gravity-countdown` to end-of-turn order (after trick-room-countdown, before weather-countdown)
- 35 new tests across `two-turn-moves.test.ts` and `gravity.test.ts`

## Test plan

- [x] Two-turn charge handler sets correct volatile (flying/underground/underwater/shadow-force-charging/charging)
- [x] SolarBeam skips charge in sun weather
- [x] Power Herb skips charge and consumes item
- [x] canHitSemiInvulnerable returns correct results for all volatile + move combinations
- [x] Gravity move sets gravitySet=true
- [x] Gravity boosts accuracy by 5/3 (verified with exact roll values)
- [x] Gravity suppresses Levitate ground immunity in damage calc
- [x] Gravity suppresses Flying-type ground immunity in damage calc
- [x] Gravity + Arena Trap traps Flying-type and Levitate Pokemon
- [x] gravity-countdown in correct end-of-turn order position
- [x] All 588 existing gen4 tests still pass

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gravity move with increased accuracy (5/3 multiplier) and type immunity modifications
  * Gravity suppresses Levitate and Flying-type Ground immunity, allowing Ground moves to hit normally
  * Gravity grounds all Pokémon, enabling Arena Trap to prevent switching for Flying-type and Levitate Pokémon
  * Implemented two-turn move charging with Solar Beam sun exception and Power Herb bypass
  * Added semi-invulnerable hit mechanics for charging moves

<!-- end of auto-generated comment: release notes by coderabbit.ai -->