### PR TITLE
fix(gen4): ability contact-trigger status immunity bypass

### DIFF
--- a/.changeset/status-immunity-contact.md
+++ b/.changeset/status-immunity-contact.md
@@ -1,0 +1,6 @@
+---
+"@pokemon-lib-ts/battle": patch
+"@pokemon-lib-ts/gen4": patch
+---
+
+Fix ability-triggered status/volatile inflictions bypassing immunity checks (Static/Flame Body/Poison Point/Effect Spore/Cute Charm) and add counter initialization for sleep/toxic when status is applied via ability trigger

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -2819,6 +2819,17 @@ export class BattleEngine implements BattleEventEmitter {
               pokemon: getPokemonName(target),
               status: effect.status,
             });
+            // Initialize counters for statuses that require them — same ordering as processEffectResult
+            if (effect.status === "badly-poisoned") {
+              target.volatileStatuses.set("toxic-counter", { turnsLeft: -1, data: { counter: 1 } });
+            }
+            if (effect.status === "sleep") {
+              const sleepTurns = this.ruleset.rollSleepTurns(this.state.rng);
+              target.volatileStatuses.set("sleep-counter", { turnsLeft: sleepTurns, data: {} });
+            }
+            if (effect.status === "freeze") {
+              target.volatileStatuses.set("just-frozen", { turnsLeft: 1 });
+            }
           }
           break;
         }

--- a/packages/gen4/src/Gen4Abilities.ts
+++ b/packages/gen4/src/Gen4Abilities.ts
@@ -1,5 +1,6 @@
 import type { AbilityContext, AbilityEffect, AbilityResult } from "@pokemon-lib-ts/battle";
 import type { AbilityTrigger } from "@pokemon-lib-ts/core";
+import { canInflictGen4Status, isVolatileBlockedByAbility } from "./Gen4MoveEffects";
 
 /**
  * Gen 4 Abilities — applyAbility dispatch.
@@ -465,6 +466,9 @@ function handleOnContact(abilityId: string, context: AbilityContext): AbilityRes
       // Source: Showdown Gen 4 mod — Static trigger (30% = rng.next() < 0.3)
       if (attackerStatus) return { activated: false, effects: [], messages: [] };
       if (context.rng.next() >= 0.3) return { activated: false, effects: [], messages: [] };
+      // Check type and ability immunities before inflicting
+      if (!canInflictGen4Status("paralysis", attacker))
+        return { activated: false, effects: [], messages: [] };
       return {
         activated: true,
         effects: [{ effectType: "status-inflict", target: "opponent", status: "paralysis" }],
@@ -477,6 +481,9 @@ function handleOnContact(abilityId: string, context: AbilityContext): AbilityRes
       // Source: Showdown Gen 4 mod — Flame Body trigger (30%)
       if (attackerStatus) return { activated: false, effects: [], messages: [] };
       if (context.rng.next() >= 0.3) return { activated: false, effects: [], messages: [] };
+      // Check type and ability immunities before inflicting
+      if (!canInflictGen4Status("burn", attacker))
+        return { activated: false, effects: [], messages: [] };
       return {
         activated: true,
         effects: [{ effectType: "status-inflict", target: "opponent", status: "burn" }],
@@ -489,6 +496,9 @@ function handleOnContact(abilityId: string, context: AbilityContext): AbilityRes
       // Source: Showdown Gen 4 mod — Poison Point trigger (30%)
       if (attackerStatus) return { activated: false, effects: [], messages: [] };
       if (context.rng.next() >= 0.3) return { activated: false, effects: [], messages: [] };
+      // Check type and ability immunities before inflicting
+      if (!canInflictGen4Status("poison", attacker))
+        return { activated: false, effects: [], messages: [] };
       return {
         activated: true,
         effects: [{ effectType: "status-inflict", target: "opponent", status: "poison" }],
@@ -515,6 +525,9 @@ function handleOnContact(abilityId: string, context: AbilityContext): AbilityRes
       if (context.rng.next() >= 0.3) return { activated: false, effects: [], messages: [] };
       const roll = context.rng.next();
       if (roll < 1 / 3) {
+        // Check immunity before inflicting poison
+        if (!canInflictGen4Status("poison", attacker))
+          return { activated: false, effects: [], messages: [] };
         return {
           activated: true,
           effects: [{ effectType: "status-inflict", target: "opponent", status: "poison" }],
@@ -522,12 +535,18 @@ function handleOnContact(abilityId: string, context: AbilityContext): AbilityRes
         };
       }
       if (roll < 2 / 3) {
+        // Check immunity before inflicting paralysis
+        if (!canInflictGen4Status("paralysis", attacker))
+          return { activated: false, effects: [], messages: [] };
         return {
           activated: true,
           effects: [{ effectType: "status-inflict", target: "opponent", status: "paralysis" }],
           messages: [],
         };
       }
+      // Check immunity before inflicting sleep
+      if (!canInflictGen4Status("sleep", attacker))
+        return { activated: false, effects: [], messages: [] };
       return {
         activated: true,
         effects: [{ effectType: "status-inflict", target: "opponent", status: "sleep" }],
@@ -551,6 +570,9 @@ function handleOnContact(abilityId: string, context: AbilityContext): AbilityRes
       ) {
         return { activated: false, effects: [], messages: [] };
       }
+      // Check Oblivious immunity before inflicting infatuation
+      if (isVolatileBlockedByAbility(attacker, "infatuation"))
+        return { activated: false, effects: [], messages: [] };
       return {
         activated: true,
         effects: [{ effectType: "volatile-inflict", target: "opponent", volatile: "infatuation" }],

--- a/packages/gen4/tests/contact-abilities.test.ts
+++ b/packages/gen4/tests/contact-abilities.test.ts
@@ -3,6 +3,23 @@ import type { Gender, PokemonInstance, PokemonType } from "@pokemon-lib-ts/core"
 import { describe, expect, it } from "vitest";
 import { applyGen4Ability } from "../src/Gen4Abilities";
 
+// ---------------------------------------------------------------------------
+// RNG helpers
+// ---------------------------------------------------------------------------
+
+/** RNG that always passes the 30% roll (next() returns 0) */
+function makeAlwaysTriggersRng() {
+  return {
+    next: () => 0,
+    int: () => 1,
+    chance: (_p: number) => false,
+    pick: <T>(arr: readonly T[]) => arr[0] as T,
+    shuffle: <T>(arr: T[]) => arr,
+    getState: () => 0,
+    setState: () => {},
+  };
+}
+
 /**
  * Gen 4 Contact Abilities Tests — Aftermath
  *
@@ -303,5 +320,248 @@ describe("applyGen4Ability on-contact -- Aftermath (NEW in Gen 4)", () => {
 
     expect(result.activated).toBe(true);
     expect(result.messages[0]).toContain("Aftermath");
+  });
+});
+
+// ===========================================================================
+// Status immunity checks for contact abilities
+// ===========================================================================
+
+describe("applyGen4Ability on-contact -- Static immunity checks", () => {
+  it("given attacker with Limber ability, when Static triggers, then paralysis is blocked", () => {
+    // Source: Bulbapedia — Limber: prevents paralysis
+    // Source: Showdown Gen 4 mod — ability immunity table (ABILITY_STATUS_IMMUNITIES)
+    // Static fires (rng returns 0) but Limber blocks the paralysis infliction.
+    const attacker = makeActivePokemon({ ability: "limber" });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "static" });
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: makeAlwaysTriggersRng(),
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+
+  it("given attacker without status immunity, when Static triggers, then paralysis is inflicted", () => {
+    // Triangulation: confirm Static does fire when no immunity is present.
+    // Source: Bulbapedia — Static: 30% chance to paralyze attacker on contact
+    const attacker = makeActivePokemon({ ability: "blaze" });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "static" });
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: makeAlwaysTriggersRng(),
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects[0]).toMatchObject({ effectType: "status-inflict", status: "paralysis" });
+  });
+});
+
+describe("applyGen4Ability on-contact -- Flame Body immunity checks", () => {
+  it("given Fire-type attacker, when Flame Body triggers, then burn is blocked", () => {
+    // Source: Bulbapedia — Fire-types are immune to burn
+    // Source: Showdown Gen 4 mod — GEN4_STATUS_IMMUNITIES: burn: ['fire']
+    const attacker = makeActivePokemon({ types: ["fire"] });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "flame-body" });
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: makeAlwaysTriggersRng(),
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+
+  it("given attacker with Water Veil, when Flame Body triggers, then burn is blocked", () => {
+    // Source: Bulbapedia — Water Veil: prevents burn
+    // Source: Showdown Gen 4 mod — ABILITY_STATUS_IMMUNITIES: 'water-veil': ['burn']
+    const attacker = makeActivePokemon({ ability: "water-veil", types: ["water"] });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "flame-body" });
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: makeAlwaysTriggersRng(),
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+});
+
+describe("applyGen4Ability on-contact -- Poison Point immunity checks", () => {
+  it("given attacker with Immunity ability, when Poison Point triggers, then poison is blocked", () => {
+    // Source: Bulbapedia — Immunity: prevents poisoning
+    // Source: Showdown Gen 4 mod — ABILITY_STATUS_IMMUNITIES: immunity: ['poison', 'badly-poisoned']
+    const attacker = makeActivePokemon({ ability: "immunity" });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "poison-point" });
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: makeAlwaysTriggersRng(),
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+
+  it("given Poison-type attacker, when Poison Point triggers, then poison is blocked", () => {
+    // Source: Bulbapedia — Poison-types are immune to being poisoned
+    // Source: Showdown Gen 4 mod — GEN4_STATUS_IMMUNITIES: poison: ['poison', 'steel']
+    const attacker = makeActivePokemon({ types: ["poison"] });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "poison-point" });
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: makeAlwaysTriggersRng(),
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+
+  it("given Steel-type attacker, when Poison Point triggers, then poison is blocked", () => {
+    // Source: Bulbapedia — Steel-types are immune to being poisoned
+    // Source: Showdown Gen 4 mod — GEN4_STATUS_IMMUNITIES: poison: ['poison', 'steel']
+    const attacker = makeActivePokemon({ types: ["steel"] });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "poison-point" });
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: makeAlwaysTriggersRng(),
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+});
+
+describe("applyGen4Ability on-contact -- Effect Spore immunity checks", () => {
+  it("given Steel-type attacker, when Effect Spore rolls poison (roll < 1/3), then poison is blocked", () => {
+    // Source: Bulbapedia — Steel-types are immune to poison
+    // Source: Showdown Gen 4 mod — GEN4_STATUS_IMMUNITIES: poison: ['poison', 'steel']
+    // Effect Spore gate roll = 0 (triggers), effect roll = 0 (< 1/3 → poison path)
+    const attacker = makeActivePokemon({ types: ["steel"] });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "effect-spore" });
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: makeAlwaysTriggersRng(), // next() always returns 0: gate passes, roll=0 → poison path
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+
+  it("given attacker with Insomnia, when Effect Spore rolls sleep (roll >= 2/3), then sleep is blocked", () => {
+    // Source: Bulbapedia — Insomnia: prevents sleep
+    // Source: Showdown Gen 4 mod — ABILITY_STATUS_IMMUNITIES: insomnia: ['sleep']
+    // Effect Spore gate roll = 0 (triggers), then second roll = 0.9 (>= 2/3 → sleep path)
+    const attacker = makeActivePokemon({ ability: "insomnia" });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "effect-spore" });
+    let callCount = 0;
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: {
+        next: () => {
+          // First call: gate check (0 = triggers); second call: effect roll (0.9 → sleep)
+          return callCount++ === 0 ? 0 : 0.9;
+        },
+        int: () => 1,
+        chance: (_p: number) => false,
+        pick: <T>(arr: readonly T[]) => arr[0] as T,
+        shuffle: <T>(arr: T[]) => arr,
+        getState: () => 0,
+        setState: () => {},
+      },
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+});
+
+describe("applyGen4Ability on-contact -- Cute Charm immunity checks", () => {
+  it("given attacker with Oblivious, when Cute Charm triggers, then infatuation is blocked", () => {
+    // Source: Bulbapedia — Oblivious: prevents infatuation
+    // Source: Showdown Gen 4 mod — ABILITY_VOLATILE_IMMUNITIES: oblivious: ['infatuation']
+    const attacker = makeActivePokemon({ ability: "oblivious", gender: "male" });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "cute-charm", gender: "female" });
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: makeAlwaysTriggersRng(),
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+
+  it("given attacker without Oblivious and opposite gender, when Cute Charm triggers, then infatuation is inflicted", () => {
+    // Triangulation: confirm Cute Charm fires when no immunity is present.
+    // Source: Bulbapedia — Cute Charm: 30% chance to infatuate attacker of opposite gender
+    const attacker = makeActivePokemon({ ability: "blaze", gender: "male" });
+    const state = makeBattleState();
+    const defender = makeActivePokemon({ ability: "cute-charm", gender: "female" });
+    const ctx: AbilityContext = {
+      pokemon: defender,
+      opponent: attacker,
+      state,
+      trigger: "on-contact",
+      rng: makeAlwaysTriggersRng(),
+    } as unknown as AbilityContext;
+
+    const result = applyGen4Ability("on-contact", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects[0]).toMatchObject({
+      effectType: "volatile-inflict",
+      volatile: "infatuation",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause**: `Static`, `Flame Body`, `Poison Point`, `Effect Spore`, and `Cute Charm` in `Gen4Abilities.ts` applied status/volatile inflictions raw — no type or ability immunity checks ran on the contact path, only on the move-effect path
- **Fix**: Import `canInflictGen4Status` / `isVolatileBlockedByAbility` from `Gen4MoveEffects` and check before returning each infliction result
- **Engine fix**: `processAbilityResult` now initializes `sleep-counter`, `toxic-counter`, and `just-frozen` volatiles after status infliction, matching `processEffectResult` behavior (emit → then init counters)

## Immunities now respected on ability contact path

| Ability | Inflicts | Immunity now blocked |
|---------|----------|----------------------|
| Static | paralysis | Limber ability |
| Flame Body | burn | Fire-type, Water Veil ability |
| Poison Point | poison | Poison/Steel-type, Immunity ability |
| Effect Spore | poison/paralysis/sleep | All corresponding type + ability immunities |
| Cute Charm | infatuation | Oblivious ability |

## Test plan

- [x] `canInflictGen4Status` checks type + ability immunity tables (existing coverage)
- [x] `contact-abilities.test.ts` — 9 new tests: Limber/Static, Fire-type+Water Veil/Flame Body, Immunity ability+Poison-type+Steel-type/Poison Point, Insomnia+Steel-type/Effect Spore, Oblivious/Cute Charm (+ triangulation positives)
- [x] `npm run test` — 683 gen4 tests pass, 337 battle tests pass
- [x] `npm run typecheck` — clean
- [x] Biome — clean

## Related Issue

Closes: N/A

Identified from CodeRabbit review on PR #182 (Part 8 simple abilities batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ability-triggered status inflictions to respect target immunities for Static, Flame Body, Poison Point, Effect Spore, and Cute Charm.
  * Fixed status counter initialization when abilities trigger primary statuses.

* **Tests**
  * Added tests validating ability-based status and volatile effect immunity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->