### PR TITLE
feat(gen4): Wave 4 -- Leaf Guard, Storm Drain, Klutz, Suction Cups, Stench, Anticipation/Forewarn fix

### DIFF
--- a/.changeset/gen4-wave4-status-abilities.md
+++ b/.changeset/gen4-wave4-status-abilities.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/gen4": minor
+---
+
+feat(gen4): Wave 4 ability/mechanic batch -- Leaf Guard, Storm Drain, Klutz, Suction Cups, Stench, Anticipation fix, Forewarn fix

--- a/packages/gen4/src/Gen4Abilities.ts
+++ b/packages/gen4/src/Gen4Abilities.ts
@@ -1,6 +1,7 @@
 import type { AbilityContext, AbilityEffect, AbilityResult } from "@pokemon-lib-ts/battle";
-import type { AbilityTrigger } from "@pokemon-lib-ts/core";
+import type { AbilityTrigger, DataManager, PokemonType, TypeChart } from "@pokemon-lib-ts/core";
 import { canInflictGen4Status, isVolatileBlockedByAbility } from "./Gen4MoveEffects";
+import { GEN4_TYPE_CHART } from "./Gen4TypeChart";
 
 /**
  * Gen 4 Abilities — applyAbility dispatch.
@@ -15,6 +16,7 @@ import { canInflictGen4Status, isVolatileBlockedByAbility } from "./Gen4MoveEffe
  *   - "passive-immunity": Water Absorb, Volt Absorb, Motor Drive, Dry Skin,
  *                         Flash Fire (with volatile boost), Levitate
  *   - "on-flinch": Steadfast
+ *   - "on-after-move-hit": Stench (10% flinch)
  *
  * Stat-modifying abilities (damage calc / speed calc integration):
  *   - Solar Power: 1.5x SpAtk in sun (damage calc) + 1/8 HP chip (turn-end)
@@ -24,9 +26,11 @@ import { canInflictGen4Status, isVolatileBlockedByAbility } from "./Gen4MoveEffe
  *   - Slow Start: halve Attack/Speed for 5 turns (volatile tracking + damage calc + speed calc)
  *   - Download: compare foe Def/SpDef, raise Atk or SpAtk (switch-in)
  *
- * Deferred abilities (require engine hooks not yet available):
- *   - Leaf Guard: status prevention in sun
- *   - Klutz: item suppression
+ * Implemented elsewhere:
+ *   - Leaf Guard: status prevention in sun (canInflictGen4Status in Gen4MoveEffects.ts)
+ *   - Klutz: item suppression (Gen4Items.ts, Gen4DamageCalc.ts, Gen4Ruleset.ts)
+ *   - Storm Drain: Water immunity + SpAtk boost (passive-immunity handler + Gen4DamageCalc.ts)
+ *   - Suction Cups: forced switch prevention (Gen4MoveEffects.ts Whirlwind/Roar handler)
  *
  * Source: Showdown sim/battle.ts Gen 4 mod — ability trigger dispatch
  * Source: Bulbapedia — individual ability mechanics
@@ -34,13 +38,21 @@ import { canInflictGen4Status, isVolatileBlockedByAbility } from "./Gen4MoveEffe
 
 /**
  * Dispatch an ability trigger for Gen 4.
+ *
+ * @param trigger - The ability trigger type
+ * @param context - The ability context
+ * @param dataManager - Optional DataManager for move lookups (Anticipation, Forewarn)
  */
-export function applyGen4Ability(trigger: AbilityTrigger, context: AbilityContext): AbilityResult {
+export function applyGen4Ability(
+  trigger: AbilityTrigger,
+  context: AbilityContext,
+  dataManager?: DataManager,
+): AbilityResult {
   const abilityId = context.pokemon.ability;
 
   switch (trigger) {
     case "on-switch-in":
-      return handleSwitchIn(abilityId, context);
+      return handleSwitchIn(abilityId, context, dataManager);
     case "on-turn-end":
       return handleTurnEnd(abilityId, context);
     case "on-contact":
@@ -49,6 +61,8 @@ export function applyGen4Ability(trigger: AbilityTrigger, context: AbilityContex
       return handlePassiveImmunity(abilityId, context);
     case "on-flinch":
       return handleOnFlinch(abilityId, context);
+    case "on-after-move-hit":
+      return handleOnAfterMoveHit(abilityId, context);
     default:
       return { activated: false, effects: [], messages: [] };
   }
@@ -63,7 +77,11 @@ export function applyGen4Ability(trigger: AbilityTrigger, context: AbilityContex
  *
  * Source: Showdown sim/battle.ts Gen 4 mod — switch-in ability triggers
  */
-function handleSwitchIn(abilityId: string, context: AbilityContext): AbilityResult {
+function handleSwitchIn(
+  abilityId: string,
+  context: AbilityContext,
+  dataManager?: DataManager,
+): AbilityResult {
   const name = context.pokemon.pokemon.nickname ?? String(context.pokemon.pokemon.speciesId);
 
   switch (abilityId) {
@@ -179,7 +197,43 @@ function handleSwitchIn(abilityId: string, context: AbilityContext): AbilityResu
       // NEW in Gen 4 — Warns if foe has a super-effective or OHKO move.
       // Informational only — no mechanical effect on stats or state.
       // Source: Bulbapedia — Anticipation: alerts trainer if foe has SE or OHKO move
-      // Source: Showdown Gen 4 mod — Anticipation (advisory, no game-state change)
+      // Source: Showdown data/abilities.ts — Anticipation onStart
+      if (!context.opponent || !dataManager) {
+        return { activated: false, effects: [], messages: [] };
+      }
+
+      const selfTypes = context.pokemon.types;
+      const ohkoMoveIds = ["sheer-cold", "fissure", "guillotine", "horn-drill"];
+      const typeChart: TypeChart = GEN4_TYPE_CHART;
+
+      let hasThreateningMove = false;
+      for (const moveSlot of context.opponent.pokemon.moves) {
+        if (!moveSlot) continue;
+        try {
+          const move = dataManager.getMove(moveSlot.moveId);
+          if (!move) continue;
+          // OHKO moves are always threatening
+          if (ohkoMoveIds.includes(move.id)) {
+            hasThreateningMove = true;
+            break;
+          }
+          // Check type effectiveness — if SE against any of self's types
+          if (move.power && move.power > 0) {
+            let effectiveness = 1;
+            for (const selfType of selfTypes) {
+              effectiveness *= typeChart[move.type]?.[selfType] ?? 1;
+            }
+            if (effectiveness > 1) {
+              hasThreateningMove = true;
+              break;
+            }
+          }
+        } catch {}
+      }
+
+      if (!hasThreateningMove) {
+        return { activated: false, effects: [], messages: [] };
+      }
       return {
         activated: true,
         effects: [{ effectType: "none", target: "self" }],
@@ -191,14 +245,38 @@ function handleSwitchIn(abilityId: string, context: AbilityContext): AbilityResu
       // NEW in Gen 4 — Reveals foe's move with highest base power.
       // Informational only — no mechanical effect on stats or state.
       // Source: Bulbapedia — Forewarn: reveals foe's strongest move on switch-in
-      // Source: Showdown Gen 4 mod — Forewarn (advisory, no game-state change)
-      if (!context.opponent) return { activated: false, effects: [], messages: [] };
-      const oppName =
-        context.opponent.pokemon.nickname ?? String(context.opponent.pokemon.speciesId);
+      // Source: Showdown data/abilities.ts — Forewarn onStart
+      if (!context.opponent || !dataManager) {
+        return { activated: false, effects: [], messages: [] };
+      }
+
+      // OHKO moves count as base power 160 for Forewarn purposes
+      // Source: Bulbapedia — Forewarn counts OHKO moves as BP 160
+      const ohkoMoveIds = ["sheer-cold", "fissure", "guillotine", "horn-drill"];
+
+      let strongestMove: string | null = null;
+      let strongestPower = 0;
+
+      for (const moveSlot of context.opponent.pokemon.moves) {
+        if (!moveSlot) continue;
+        try {
+          const move = dataManager.getMove(moveSlot.moveId);
+          if (!move) continue;
+          const power = ohkoMoveIds.includes(move.id) ? 160 : (move.power ?? 0);
+          if (power > strongestPower) {
+            strongestPower = power;
+            strongestMove = move.displayName ?? move.id;
+          }
+        } catch {}
+      }
+
+      if (!strongestMove) {
+        return { activated: false, effects: [], messages: [] };
+      }
       return {
         activated: true,
         effects: [{ effectType: "none", target: "self" }],
-        messages: [`${name}'s Forewarn let it know ${oppName}'s moves!`],
+        messages: [`${name}'s Forewarn alerted it to ${strongestMove}!`],
       };
     }
 
@@ -717,6 +795,24 @@ function handlePassiveImmunity(abilityId: string, context: AbilityContext): Abil
       };
     }
 
+    case "storm-drain": {
+      // Storm Drain: Water-type moves are absorbed, raising SpAtk by 1 stage.
+      // Source: Bulbapedia — Storm Drain (Gen 4): "Draws in all Water-type moves.
+      //   When hit by a Water-type move, the Pokemon's Sp. Atk is raised by one stage."
+      // Source: Showdown Gen 4 mod — Storm Drain onTryHit boosts SpAtk by 1
+      if (moveType !== "water") return { activated: false, effects: [], messages: [] };
+      const pokeName =
+        context.pokemon.pokemon.nickname ?? String(context.pokemon.pokemon.speciesId);
+      const effects: AbilityEffect[] = [
+        { effectType: "stat-change", target: "self", stat: "spAttack", stages: 1 },
+      ];
+      return {
+        activated: true,
+        effects,
+        messages: [`${pokeName}'s Storm Drain raised its Sp. Atk!`],
+      };
+    }
+
     default:
       return { activated: false, effects: [], messages: [] };
   }
@@ -755,5 +851,42 @@ function handleOnFlinch(abilityId: string, context: AbilityContext): AbilityResu
     activated: true,
     effects: [effect],
     messages: [`${name}'s Steadfast raised its Speed!`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// on-after-move-hit
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-after-move-hit" abilities for Gen 4.
+ *
+ * Fires after the attacker's move hits and deals damage. `context.pokemon`
+ * is the attacker (whose ability triggers), `context.opponent` is the
+ * defender that was hit.
+ *
+ * Currently only handles Stench.
+ *
+ * Source: Showdown Gen 4 mod — Stench on-after-move-hit flinch chance
+ * Source: Bulbapedia — Stench (Gen 4): "10% chance of causing the target to flinch"
+ */
+function handleOnAfterMoveHit(abilityId: string, context: AbilityContext): AbilityResult {
+  if (abilityId !== "stench") {
+    return { activated: false, effects: [], messages: [] };
+  }
+
+  // Stench: 10% flinch chance after dealing damage
+  // Note: Stench does NOT stack with King's Rock / Razor Fang
+  // Source: Bulbapedia — Stench (Gen 4): "Has a 10% chance of making a target flinch
+  //   when the holder deals damage."
+  // Source: Showdown Gen 4 mod — Stench onModifyMove adds flinch chance
+  if (context.rng.next() >= 0.1) {
+    return { activated: false, effects: [], messages: [] };
+  }
+
+  return {
+    activated: true,
+    effects: [{ effectType: "volatile-inflict", target: "opponent", volatile: "flinch" }],
+    messages: [],
   };
 }

--- a/packages/gen4/src/Gen4DamageCalc.ts
+++ b/packages/gen4/src/Gen4DamageCalc.ts
@@ -104,6 +104,7 @@ const ABILITY_TYPE_IMMUNITIES: Readonly<Record<string, string>> = {
   "flash-fire": "fire",
   "motor-drive": "electric",
   "dry-skin": "water",
+  "storm-drain": "water",
 };
 
 // ─── Simple / Unaware Stat Stage Helper ───────────────────────────────────
@@ -198,6 +199,11 @@ function getAttackStat(
   const attackerItem = attacker.pokemon.heldItem;
   const attackerSpecies = attacker.pokemon.speciesId;
 
+  // Klutz: holder cannot use its held item — all item-based stat modifiers are suppressed
+  // Source: Bulbapedia — Klutz: "The Pokemon can't use any held items"
+  // Source: Showdown data/abilities.ts — Klutz gates item modifiers
+  const attackerHasKlutz = ability === "klutz";
+
   // 1. Huge Power / Pure Power: doubles physical attack
   // Source: Showdown sim/battle.ts — Huge Power / Pure Power in Gen 4
   // Source: pret/pokeplatinum — same as Gen 3
@@ -208,28 +214,28 @@ function getAttackStat(
   // 2. Type-boosting held items (1.1x): applied to raw attack/spAttack stat
   // Source: Showdown sim/battle.ts — type boost items
   // Source: pret/pokeplatinum — same as pokeemerald: (attack * 110) / 100
-  if (typeBoostItemType === moveType) {
+  if (!attackerHasKlutz && typeBoostItemType === moveType) {
     rawStat = Math.floor((rawStat * 110) / 100);
   }
 
   // 3. Plates (1.2x, NEW in Gen 4): applied to raw stat
   // Source: Bulbapedia — Plate items boost matching type moves by 20%
   // Source: Showdown sim/items.ts — Plate onBasePowerPriority
-  if (plateItemType === moveType) {
+  if (!attackerHasKlutz && plateItemType === moveType) {
     rawStat = Math.floor((rawStat * 120) / 100);
   }
 
   // 4. Choice Band: 1.5x physical attack (applied to raw stat)
   // Source: Showdown sim/battle.ts — Choice Band Gen 4
   // Source: pret/pokeplatinum — (150 * attack) / 100
-  if (isPhysical && attackerItem === "choice-band") {
+  if (!attackerHasKlutz && isPhysical && attackerItem === "choice-band") {
     rawStat = Math.floor((150 * rawStat) / 100);
   }
 
   // 4a. Choice Specs (NEW in Gen 4): 1.5x special attack (applied to raw stat)
   // Source: Showdown sim/items.ts — Choice Specs
   // Source: Bulbapedia — Choice Specs: "Boosts Sp. Atk by 50%, but locks into one move."
-  if (!isPhysical && attackerItem === "choice-specs") {
+  if (!attackerHasKlutz && !isPhysical && attackerItem === "choice-specs") {
     rawStat = Math.floor((150 * rawStat) / 100);
   }
 
@@ -240,6 +246,7 @@ function getAttackStat(
   // Source: Bulbapedia — Soul Dew: "Raises Latias's and Latios's Sp. Atk and Sp. Def by 50%."
   // Source: Showdown sim/items.ts — Soul Dew Gen 3-6 behavior
   if (
+    !attackerHasKlutz &&
     !isPhysical &&
     attackerItem === "soul-dew" &&
     (attackerSpecies === 380 || attackerSpecies === 381)
@@ -250,7 +257,12 @@ function getAttackStat(
   // Deep Sea Tooth: 2x SpAtk for Clamperl (366)
   // Source: Bulbapedia — Deep Sea Tooth: "When held by Clamperl, doubles its Special Attack."
   // Source: Showdown sim/items.ts — Deep Sea Tooth
-  if (!isPhysical && attackerItem === "deep-sea-tooth" && attackerSpecies === 366) {
+  if (
+    !attackerHasKlutz &&
+    !isPhysical &&
+    attackerItem === "deep-sea-tooth" &&
+    attackerSpecies === 366
+  ) {
     rawStat = rawStat * 2;
   }
 
@@ -259,7 +271,7 @@ function getAttackStat(
   // Source: Bulbapedia — Light Ball: "When held by a Pikachu, doubles its Attack and
   //   Special Attack. (Generation IV+)"
   // Source: Showdown sim/items.ts — Light Ball Gen 4+ behavior
-  if (attackerItem === "light-ball" && attackerSpecies === 25) {
+  if (!attackerHasKlutz && attackerItem === "light-ball" && attackerSpecies === 25) {
     rawStat = rawStat * 2;
   }
 
@@ -267,6 +279,7 @@ function getAttackStat(
   // Source: Bulbapedia — Thick Club: "When held by Cubone or Marowak, doubles Attack."
   // Source: Showdown sim/items.ts — Thick Club
   if (
+    !attackerHasKlutz &&
     isPhysical &&
     attackerItem === "thick-club" &&
     (attackerSpecies === 104 || attackerSpecies === 105)
@@ -361,10 +374,16 @@ function getDefenseStat(
   const defenderItem = defender.pokemon.heldItem;
   const defenderSpecies = defender.pokemon.speciesId;
 
+  // Klutz: holder cannot use its held item — all item-based stat modifiers are suppressed
+  // Source: Bulbapedia — Klutz: "The Pokemon can't use any held items"
+  // Source: Showdown data/abilities.ts — Klutz gates item modifiers
+  const defenderHasKlutz = defender.ability === "klutz";
+
   // Soul Dew: 1.5x SpDef for Latias (380) / Latios (381)
   // Source: Bulbapedia — Soul Dew: "Raises Latias's and Latios's Sp. Atk and Sp. Def by 50%."
   // Source: Showdown sim/items.ts — Soul Dew Gen 3-6 behavior
   if (
+    !defenderHasKlutz &&
     !isPhysical &&
     defenderItem === "soul-dew" &&
     (defenderSpecies === 380 || defenderSpecies === 381)
@@ -375,7 +394,12 @@ function getDefenseStat(
   // Deep Sea Scale: 2x SpDef for Clamperl (366)
   // Source: Bulbapedia — Deep Sea Scale: "When held by Clamperl, doubles its Special Defense."
   // Source: Showdown sim/items.ts — Deep Sea Scale
-  if (!isPhysical && defenderItem === "deep-sea-scale" && defenderSpecies === 366) {
+  if (
+    !defenderHasKlutz &&
+    !isPhysical &&
+    defenderItem === "deep-sea-scale" &&
+    defenderSpecies === 366
+  ) {
     baseStat = baseStat * 2;
   }
 
@@ -869,12 +893,16 @@ export function calculateGen4Damage(context: DamageContext, typeChart: TypeChart
 
   // 20. Item damage modifiers (NEW in Gen 4)
   // Source: Showdown sim/items.ts — Life Orb, Expert Belt, Muscle Band, Wise Glasses
+  // Klutz: suppresses all held item effects (including damage modifiers)
+  // Source: Bulbapedia — Klutz: "The Pokemon can't use any held items"
+  // Source: Showdown data/abilities.ts — Klutz gates item modifiers
   let itemMultiplier = 1;
+  const attackerHasKlutz = attackerAbility === "klutz";
 
   // Life Orb: 1.3x damage (recoil is handled separately by the engine)
   // Source: Bulbapedia — Life Orb: "Boosts the power of moves by 30%."
   // Source: Showdown sim/items.ts — Life Orb onModifyDamage
-  if (attackerItem === "life-orb") {
+  if (!attackerHasKlutz && attackerItem === "life-orb") {
     baseDamage = Math.floor(baseDamage * 1.3);
     itemMultiplier = 1.3;
   }
@@ -882,7 +910,7 @@ export function calculateGen4Damage(context: DamageContext, typeChart: TypeChart
   // Expert Belt: 1.2x damage for super-effective moves
   // Source: Bulbapedia — Expert Belt: "Boosts the power of super effective moves by 20%."
   // Source: Showdown sim/items.ts — Expert Belt
-  if (attackerItem === "expert-belt" && effectiveness > 1) {
+  if (!attackerHasKlutz && attackerItem === "expert-belt" && effectiveness > 1) {
     baseDamage = Math.floor(baseDamage * 1.2);
     itemMultiplier = 1.2;
   }
@@ -890,7 +918,7 @@ export function calculateGen4Damage(context: DamageContext, typeChart: TypeChart
   // Muscle Band: 1.1x damage for physical moves
   // Source: Bulbapedia — Muscle Band: "Boosts the power of physical moves by 10%."
   // Source: Showdown sim/items.ts — Muscle Band
-  if (attackerItem === "muscle-band" && isPhysical) {
+  if (!attackerHasKlutz && attackerItem === "muscle-band" && isPhysical) {
     baseDamage = Math.floor(baseDamage * 1.1);
     itemMultiplier = 1.1;
   }
@@ -898,7 +926,7 @@ export function calculateGen4Damage(context: DamageContext, typeChart: TypeChart
   // Wise Glasses: 1.1x damage for special moves
   // Source: Bulbapedia — Wise Glasses: "Boosts the power of special moves by 10%."
   // Source: Showdown sim/items.ts — Wise Glasses
-  if (attackerItem === "wise-glasses" && !isPhysical) {
+  if (!attackerHasKlutz && attackerItem === "wise-glasses" && !isPhysical) {
     baseDamage = Math.floor(baseDamage * 1.1);
     itemMultiplier = 1.1;
   }
@@ -911,7 +939,7 @@ export function calculateGen4Damage(context: DamageContext, typeChart: TypeChart
   // Source: Showdown sim/items.ts — Metronome item onModifyDamage
   // Source: Bulbapedia — Metronome (item): "Boosts the power of moves used
   //   consecutively. +20% per consecutive use, up to 100% (2.0x)."
-  if (attackerItem === "metronome") {
+  if (!attackerHasKlutz && attackerItem === "metronome") {
     const metronomeState = attacker.volatileStatuses.get("metronome-count");
     if (metronomeState?.data?.count) {
       // count tracks consecutive uses including the first:

--- a/packages/gen4/src/Gen4Items.ts
+++ b/packages/gen4/src/Gen4Items.ts
@@ -33,6 +33,13 @@ export function applyGen4HeldItem(trigger: string, context: ItemContext): ItemRe
     return NO_ACTIVATION;
   }
 
+  // Klutz: holder cannot use its held item — suppress all item triggers
+  // Source: Bulbapedia — Klutz: "The Pokemon can't use any held items"
+  // Source: Showdown data/abilities.ts — Klutz gates all item battle effects
+  if (context.pokemon.ability === "klutz") {
+    return NO_ACTIVATION;
+  }
+
   switch (trigger) {
     case "before-move":
       return handleBeforeMove(item, context);

--- a/packages/gen4/src/Gen4MoveEffects.ts
+++ b/packages/gen4/src/Gen4MoveEffects.ts
@@ -17,7 +17,12 @@
  * Source: pret/pokeplatinum — where decompiled functions exist
  */
 
-import type { ActivePokemon, MoveEffectContext, MoveEffectResult } from "@pokemon-lib-ts/battle";
+import type {
+  ActivePokemon,
+  BattleState,
+  MoveEffectContext,
+  MoveEffectResult,
+} from "@pokemon-lib-ts/battle";
 import type {
   BattleStat,
   EntryHazardType,
@@ -164,13 +169,25 @@ export function isVolatileBlockedByAbility(target: ActivePokemon, volatile: stri
  *
  * @param status - The status to attempt to inflict
  * @param target - The target Pokemon
+ * @param state - Optional battle state (used for Leaf Guard + sun check)
  * @returns true if the status can be inflicted
  *
  * Source: Showdown sim/battle.ts Gen 4 mod — status type immunities
  */
-export function canInflictGen4Status(status: PrimaryStatus, target: ActivePokemon): boolean {
+export function canInflictGen4Status(
+  status: PrimaryStatus,
+  target: ActivePokemon,
+  state?: BattleState,
+): boolean {
   // Can't have two primary statuses at once
   if (target.pokemon.status !== null) {
+    return false;
+  }
+
+  // Leaf Guard: all status conditions blocked in sun weather
+  // Source: Bulbapedia — Leaf Guard: "Prevents status conditions in sunny weather"
+  // Source: Showdown data/abilities.ts — Leaf Guard onSetStatus
+  if (target.ability === "leaf-guard" && state?.weather?.type === "sun") {
     return false;
   }
 
@@ -287,7 +304,7 @@ function applyMoveEffect(
       // Source: Showdown Gen 4 — secondary status effect roll
       if (rollEffectChance(effect.chance, rng, attacker, defender, true)) {
         if (!defender.pokemon.status) {
-          if (canInflictGen4Status(effect.status, defender)) {
+          if (canInflictGen4Status(effect.status, defender, context.state)) {
             result.statusInflicted = effect.status;
           }
         }
@@ -299,7 +316,7 @@ function applyMoveEffect(
       // Guaranteed status (e.g., Thunder Wave, Toxic, Will-O-Wisp)
       // Source: Showdown Gen 4 — primary effect status infliction
       if (!defender.pokemon.status) {
-        if (canInflictGen4Status(effect.status, defender)) {
+        if (canInflictGen4Status(effect.status, defender, context.state)) {
           result.statusInflicted = effect.status;
         }
       }
@@ -1053,6 +1070,15 @@ function handleNullEffectMoves(
     case "roar": {
       // Force switch — engine handles phazing logic
       // Source: Showdown Gen 4 — Whirlwind/Roar force random switch
+      // Suction Cups: prevents forced switch effects (Whirlwind, Roar)
+      // Source: Bulbapedia — Suction Cups: "Prevents the Pokemon from being forced to switch out"
+      // Source: Showdown data/abilities.ts — Suction Cups onDragOut
+      const { defender } = context;
+      if (defender.ability === "suction-cups") {
+        const dName = defender.pokemon.nickname ?? String(defender.pokemon.speciesId);
+        result.messages.push(`${dName} anchored itself with Suction Cups!`);
+        break;
+      }
       result.switchOut = true;
       break;
     }

--- a/packages/gen4/src/Gen4Ruleset.ts
+++ b/packages/gen4/src/Gen4Ruleset.ts
@@ -560,10 +560,15 @@ export class Gen4Ruleset extends BaseRuleset {
 
     let effective = Math.floor(baseSpeed * getStatStageMultiplier(speedStage));
 
+    // Klutz: held item has no effect (including Choice Scarf speed boost)
+    // Source: Bulbapedia — Klutz: "The Pokemon can't use any held items"
+    // Source: Showdown data/abilities.ts — Klutz gates all item battle effects
+    const hasKlutz = active.ability === "klutz";
+
     // Choice Scarf: 1.5x Speed
     // Source: Bulbapedia — Choice Scarf raises Speed by 50%
     // Source: Showdown sim/items.ts — Choice Scarf onModifySpe
-    if (active.pokemon.heldItem === "choice-scarf") {
+    if (!hasKlutz && active.pokemon.heldItem === "choice-scarf") {
       effective = Math.floor(effective * 1.5);
     }
 
@@ -601,10 +606,10 @@ export class Gen4Ruleset extends BaseRuleset {
       effective = Math.floor(effective * 0.25);
     }
 
-    // Iron Ball: halve Speed
+    // Iron Ball: halve Speed (Klutz suppresses Iron Ball's speed penalty)
     // Source: Bulbapedia — Iron Ball: "Cuts the Speed stat of the holder to half."
     // Source: Showdown data/items.ts — Iron Ball onModifySpe halves speed
-    if (active.pokemon.heldItem === "iron-ball") {
+    if (!hasKlutz && active.pokemon.heldItem === "iron-ball") {
       effective = Math.floor(effective * 0.5);
     }
 
@@ -1071,7 +1076,7 @@ export class Gen4Ruleset extends BaseRuleset {
    * Source: Showdown sim/battle.ts Gen 4 mod
    */
   applyAbility(trigger: AbilityTrigger, context: AbilityContext): AbilityResult {
-    return applyGen4Ability(trigger, context);
+    return applyGen4Ability(trigger, context, this.dataManager);
   }
 
   // --- Held Item Triggers ---

--- a/packages/gen4/tests/abilities.test.ts
+++ b/packages/gen4/tests/abilities.test.ts
@@ -415,27 +415,23 @@ describe("applyGen4Ability on-switch-in — Download (NEW in Gen 4)", () => {
 // ---------------------------------------------------------------------------
 
 describe("applyGen4Ability on-switch-in — Anticipation", () => {
-  it("given Anticipation, when Pokemon switches in, then activates with none effect and a message", () => {
-    // Source: Bulbapedia — Anticipation: alerts trainer if foe has SE/OHKO move (informational)
+  it("given Anticipation without DataManager, when Pokemon switches in, then does not activate", () => {
+    // Anticipation requires DataManager to scan opponent moves; without one it returns false
     const ctx = makeContext({ ability: "anticipation" });
     const result = applyGen4Ability("on-switch-in", ctx);
 
-    expect(result.activated).toBe(true);
-    expect(result.effects[0]?.effectType).toBe("none");
-    expect(result.messages).toHaveLength(1);
+    expect(result.activated).toBe(false);
   });
 });
 
 describe("applyGen4Ability on-switch-in — Forewarn", () => {
-  it("given Forewarn with an opponent, when Pokemon switches in, then activates with none effect and a message", () => {
-    // Source: Bulbapedia — Forewarn: reveals foe's strongest move on switch-in (informational)
+  it("given Forewarn without DataManager, when Pokemon switches in, then does not activate", () => {
+    // Forewarn requires DataManager to scan opponent moves; without one it returns false
     const opponent = makeActivePokemon({ speciesId: 2 });
     const ctx = makeContext({ ability: "forewarn", opponent });
     const result = applyGen4Ability("on-switch-in", ctx);
 
-    expect(result.activated).toBe(true);
-    expect(result.effects[0]?.effectType).toBe("none");
-    expect(result.messages).toHaveLength(1);
+    expect(result.activated).toBe(false);
   });
 
   it("given Forewarn with no opponent, when Pokemon switches in, then does not activate", () => {

--- a/packages/gen4/tests/wave4-abilities.test.ts
+++ b/packages/gen4/tests/wave4-abilities.test.ts
@@ -1,0 +1,847 @@
+import type {
+  AbilityContext,
+  BattleSide,
+  BattleState,
+  DamageContext,
+  MoveEffectContext,
+} from "@pokemon-lib-ts/battle";
+import type {
+  DataManager,
+  Gender,
+  MoveData,
+  PokemonInstance,
+  PokemonType,
+} from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import { applyGen4Ability } from "../src/Gen4Abilities";
+import { calculateGen4Damage } from "../src/Gen4DamageCalc";
+import { applyGen4HeldItem } from "../src/Gen4Items";
+import { canInflictGen4Status, executeGen4MoveEffect } from "../src/Gen4MoveEffects";
+import { GEN4_TYPE_CHART } from "../src/Gen4TypeChart";
+
+/**
+ * Gen 4 Wave 4 — Status/Utility Ability Tests
+ *
+ * Tests for: Leaf Guard, Storm Drain, Klutz, Suction Cups, Stench,
+ *            Anticipation (fix), Forewarn (fix)
+ *
+ * Source: Showdown sim/battle.ts Gen 4 mod
+ * Source: Bulbapedia — individual ability mechanics
+ */
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makePokemonInstance(overrides: {
+  speciesId?: number;
+  nickname?: string | null;
+  ability?: string;
+  heldItem?: string | null;
+  status?: "burn" | "poison" | "badly-poisoned" | "paralysis" | "sleep" | "freeze" | null;
+  currentHp?: number;
+  maxHp?: number;
+  defense?: number;
+  spDefense?: number;
+  attack?: number;
+  spAttack?: number;
+  speed?: number;
+  gender?: Gender;
+  moves?: Array<{ moveId: string; currentPP: number; maxPP: number; ppUps: number }>;
+}): PokemonInstance {
+  const maxHp = overrides.maxHp ?? 200;
+  return {
+    uid: "test",
+    speciesId: overrides.speciesId ?? 1,
+    nickname: overrides.nickname ?? null,
+    level: 50,
+    experience: 0,
+    nature: "hardy",
+    ivs: { hp: 31, attack: 31, defense: 31, spAttack: 31, spDefense: 31, speed: 31 },
+    evs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+    currentHp: overrides.currentHp ?? maxHp,
+    moves: overrides.moves ?? [],
+    ability: overrides.ability ?? "",
+    abilitySlot: "normal1" as const,
+    heldItem: overrides.heldItem ?? null,
+    status: overrides.status ?? null,
+    friendship: 0,
+    gender: (overrides.gender ?? "male") as const,
+    isShiny: false,
+    metLocation: "",
+    metLevel: 1,
+    originalTrainer: "",
+    originalTrainerId: 0,
+    pokeball: "pokeball",
+    calculatedStats: {
+      hp: maxHp,
+      attack: overrides.attack ?? 100,
+      defense: overrides.defense ?? 100,
+      spAttack: overrides.spAttack ?? 100,
+      spDefense: overrides.spDefense ?? 100,
+      speed: overrides.speed ?? 100,
+    },
+  } as PokemonInstance;
+}
+
+function makeActivePokemon(overrides: {
+  ability?: string;
+  types?: PokemonType[];
+  speciesId?: number;
+  nickname?: string | null;
+  status?: "burn" | "poison" | "badly-poisoned" | "paralysis" | "sleep" | "freeze" | null;
+  currentHp?: number;
+  maxHp?: number;
+  heldItem?: string | null;
+  defense?: number;
+  spDefense?: number;
+  attack?: number;
+  spAttack?: number;
+  speed?: number;
+  gender?: Gender;
+  moves?: Array<{ moveId: string; currentPP: number; maxPP: number; ppUps: number }>;
+}) {
+  return {
+    pokemon: makePokemonInstance({
+      ability: overrides.ability,
+      speciesId: overrides.speciesId,
+      nickname: overrides.nickname,
+      status: overrides.status,
+      currentHp: overrides.currentHp,
+      maxHp: overrides.maxHp,
+      heldItem: overrides.heldItem,
+      defense: overrides.defense,
+      spDefense: overrides.spDefense,
+      attack: overrides.attack,
+      spAttack: overrides.spAttack,
+      speed: overrides.speed,
+      gender: overrides.gender,
+      moves: overrides.moves,
+    }),
+    teamSlot: 0,
+    statStages: {
+      attack: 0,
+      defense: 0,
+      spAttack: 0,
+      spDefense: 0,
+      speed: 0,
+      accuracy: 0,
+      evasion: 0,
+    },
+    volatileStatuses: new Map(),
+    types: overrides.types ?? ["normal"],
+    ability: overrides.ability ?? "",
+    lastMoveUsed: null,
+    lastDamageTaken: 0,
+    lastDamageType: null,
+    lastDamageCategory: null,
+    turnsOnField: 0,
+    movedThisTurn: false,
+    consecutiveProtects: 0,
+    substituteHp: 0,
+    transformed: false,
+    transformedSpecies: null,
+    isMega: false,
+    isDynamaxed: false,
+    dynamaxTurnsLeft: 0,
+    isTerastallized: false,
+    teraType: null,
+  };
+}
+
+function makeSide(index: 0 | 1): BattleSide {
+  return {
+    index,
+    trainer: null,
+    team: [],
+    active: [],
+    hazards: [],
+    screens: [],
+    tailwind: { active: false, turnsLeft: 0 },
+    luckyChant: { active: false, turnsLeft: 0 },
+    wish: null,
+    futureAttack: null,
+    faintCount: 0,
+    gimmickUsed: false,
+  };
+}
+
+function makeBattleState(weather?: {
+  type: "sand" | "hail" | "rain" | "sun";
+  turnsLeft: number;
+  source: string;
+}): BattleState {
+  return {
+    phase: "turn-end",
+    generation: 4,
+    format: "singles",
+    turnNumber: 1,
+    sides: [makeSide(0), makeSide(1)],
+    weather: weather ?? null,
+    terrain: null,
+    trickRoom: { active: false, turnsLeft: 0 },
+    magicRoom: { active: false, turnsLeft: 0 },
+    wonderRoom: { active: false, turnsLeft: 0 },
+    gravity: { active: false, turnsLeft: 0 },
+    turnHistory: [],
+    rng: {
+      next: () => 0,
+      int: () => 1,
+      chance: (_p: number) => false,
+      pick: <T>(arr: readonly T[]) => arr[0] as T,
+      shuffle: <T>(arr: T[]) => arr,
+      getState: () => 0,
+      setState: () => {},
+    },
+    ended: false,
+    winner: null,
+  } as unknown as BattleState;
+}
+
+function makeMove(type: PokemonType, overrides?: Partial<MoveData>): MoveData {
+  return {
+    id: overrides?.id ?? "test-move",
+    displayName: overrides?.displayName ?? "Test Move",
+    type,
+    category: overrides?.category ?? "physical",
+    power: overrides?.power ?? 80,
+    accuracy: overrides?.accuracy ?? 100,
+    pp: 10,
+    maxPp: 10,
+    priority: 0,
+    target: "single",
+    generation: 4,
+    flags: overrides?.flags ?? { contact: true },
+    effectChance: null,
+    secondaryEffects: [],
+    effect: overrides?.effect ?? null,
+    ...overrides,
+  } as unknown as MoveData;
+}
+
+function makeAbilityContext(opts: {
+  ability: string;
+  types?: PokemonType[];
+  opponent?: ReturnType<typeof makeActivePokemon>;
+  weather?: { type: "sand" | "hail" | "rain" | "sun"; turnsLeft: number; source: string };
+  status?: "burn" | "poison" | "badly-poisoned" | "paralysis" | "sleep" | "freeze" | null;
+  currentHp?: number;
+  maxHp?: number;
+  rngNextValues?: number[];
+  rngChance?: boolean;
+  move?: MoveData;
+}): AbilityContext {
+  const state = makeBattleState(opts.weather);
+  const pokemon = makeActivePokemon({
+    ability: opts.ability,
+    types: opts.types,
+    status: opts.status,
+    currentHp: opts.currentHp,
+    maxHp: opts.maxHp,
+  });
+
+  let nextIndex = 0;
+  const rngNextValues = opts.rngNextValues;
+
+  return {
+    pokemon,
+    opponent: opts.opponent,
+    state,
+    trigger: "on-switch-in",
+    move: opts.move,
+    rng: {
+      next: () => {
+        if (rngNextValues && nextIndex < rngNextValues.length) {
+          return rngNextValues[nextIndex++];
+        }
+        return 0;
+      },
+      int: () => 1,
+      chance: (_p: number) => opts.rngChance ?? false,
+      pick: <T>(arr: readonly T[]) => arr[0] as T,
+      shuffle: <T>(arr: T[]) => arr,
+      getState: () => 0,
+      setState: () => {},
+    },
+  } as unknown as AbilityContext;
+}
+
+/**
+ * Minimal DataManager mock that only supports getMove().
+ * Used for Anticipation/Forewarn tests.
+ */
+function makeMockDataManager(moves: Record<string, MoveData>): DataManager {
+  return {
+    getMove: (id: string) => {
+      const move = moves[id];
+      if (!move) throw new Error(`Move "${id}" not found`);
+      return move;
+    },
+  } as unknown as DataManager;
+}
+
+// ---------------------------------------------------------------------------
+// Leaf Guard
+// ---------------------------------------------------------------------------
+
+describe("Leaf Guard — prevent all status in sun", () => {
+  it("given Leaf Guard in sun, when status infliction attempted, then status blocked", () => {
+    // Source: Bulbapedia — Leaf Guard: "Prevents status conditions in sunny weather"
+    // Source: Showdown data/abilities.ts — Leaf Guard onSetStatus
+    const target = makeActivePokemon({ ability: "leaf-guard", types: ["grass"] });
+    const state = makeBattleState({ type: "sun", turnsLeft: -1, source: "drought" });
+
+    const result = canInflictGen4Status("paralysis", target, state);
+
+    expect(result).toBe(false);
+  });
+
+  it("given Leaf Guard NOT in sun, when status infliction attempted, then status applied normally", () => {
+    // Source: Bulbapedia — Leaf Guard only activates in harsh sunlight
+    const target = makeActivePokemon({ ability: "leaf-guard", types: ["grass"] });
+    const state = makeBattleState({ type: "rain", turnsLeft: 5, source: "drizzle" });
+
+    const result = canInflictGen4Status("paralysis", target, state);
+
+    expect(result).toBe(true);
+  });
+
+  it("given no Leaf Guard in sun, when status infliction attempted, then status applied normally", () => {
+    // Triangulation: confirm Leaf Guard is ability-specific, not weather-only
+    const target = makeActivePokemon({ ability: "overgrow", types: ["grass"] });
+    const state = makeBattleState({ type: "sun", turnsLeft: -1, source: "drought" });
+
+    const result = canInflictGen4Status("paralysis", target, state);
+
+    expect(result).toBe(true);
+  });
+
+  it("given Leaf Guard in sun, when burn attempted, then burn also blocked", () => {
+    // Source: Bulbapedia — Leaf Guard blocks ALL primary status conditions in sun
+    const target = makeActivePokemon({ ability: "leaf-guard", types: ["grass"] });
+    const state = makeBattleState({ type: "sun", turnsLeft: -1, source: "drought" });
+
+    const result = canInflictGen4Status("burn", target, state);
+
+    expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Storm Drain
+// ---------------------------------------------------------------------------
+
+describe("Storm Drain — Water immunity + SpAtk boost", () => {
+  it("given Storm Drain, when hit by Water move, then damage = 0 AND SpAtk raised by 1", () => {
+    // Source: Bulbapedia — Storm Drain (Gen 4): "Draws in all Water-type moves.
+    //   When hit by a Water-type move, the Pokemon's Sp. Atk is raised by one stage."
+    // Source: Showdown Gen 4 mod — Storm Drain onTryHit
+
+    // Test via damage calc — Storm Drain is in ABILITY_TYPE_IMMUNITIES
+    const attacker = makeActivePokemon({ types: ["water"], attack: 100 });
+    const defender = makeActivePokemon({ ability: "storm-drain", types: ["ground"] });
+    const move = makeMove("water", { power: 90, category: "special" });
+    const state = makeBattleState();
+
+    const damageResult = calculateGen4Damage(
+      {
+        attacker,
+        defender,
+        move,
+        state,
+        rng: { next: () => 0.5, int: () => 100, chance: () => false } as any,
+        isCrit: false,
+      } as DamageContext,
+      GEN4_TYPE_CHART,
+    );
+
+    expect(damageResult.damage).toBe(0);
+    expect(damageResult.effectiveness).toBe(0);
+
+    // Test via passive-immunity ability handler — SpAtk boost
+    const ctx = makeAbilityContext({
+      ability: "storm-drain",
+      types: ["ground"],
+      move: makeMove("water"),
+    });
+    const abilityResult = applyGen4Ability("passive-immunity", ctx);
+
+    expect(abilityResult.activated).toBe(true);
+    expect(abilityResult.effects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          effectType: "stat-change",
+          target: "self",
+          stat: "spAttack",
+          stages: 1,
+        }),
+      ]),
+    );
+  });
+
+  it("given Storm Drain, when hit by non-Water move, then ability does not activate", () => {
+    // Triangulation: Storm Drain only triggers on Water moves
+    const ctx = makeAbilityContext({
+      ability: "storm-drain",
+      types: ["ground"],
+      move: makeMove("fire"),
+    });
+    const result = applyGen4Ability("passive-immunity", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Klutz
+// ---------------------------------------------------------------------------
+
+describe("Klutz — held item has no effect", () => {
+  it("given Klutz holding Choice Scarf, when getEffectiveSpeed called (via damage calc item check), then Choice Band does not boost attack", () => {
+    // Source: Bulbapedia — Klutz: "The Pokemon can't use any held items"
+    // Source: Showdown data/abilities.ts — Klutz gates item modifiers
+    // Test via damage calc: Choice Band should NOT boost attack when holder has Klutz
+    const attacker = makeActivePokemon({
+      ability: "klutz",
+      types: ["normal"],
+      heldItem: "choice-band",
+      attack: 100,
+    });
+    const attackerNoKlutz = makeActivePokemon({
+      ability: "intimidate",
+      types: ["normal"],
+      heldItem: "choice-band",
+      attack: 100,
+    });
+    const defender = makeActivePokemon({ types: ["normal"], defense: 100 });
+    const move = makeMove("normal", { power: 80, category: "physical" });
+    const state = makeBattleState();
+    const rng = {
+      next: () => 0.5,
+      int: (_min: number, _max: number) => 100,
+      chance: () => false,
+    } as any;
+
+    const resultKlutz = calculateGen4Damage(
+      { attacker, defender, move, state, rng, isCrit: false } as DamageContext,
+      GEN4_TYPE_CHART,
+    );
+    const resultNormal = calculateGen4Damage(
+      { attacker: attackerNoKlutz, defender, move, state, rng, isCrit: false } as DamageContext,
+      GEN4_TYPE_CHART,
+    );
+
+    // Klutz holder should deal LESS damage (no Choice Band 1.5x boost)
+    expect(resultKlutz.damage).toBeLessThan(resultNormal.damage);
+  });
+
+  it("given Klutz holding Sitrus Berry, when item trigger fires, then Sitrus Berry does NOT heal", () => {
+    // Source: Bulbapedia — Klutz: "The Pokemon can't use any held items"
+    const pokemon = makeActivePokemon({
+      ability: "klutz",
+      heldItem: "sitrus-berry",
+      currentHp: 50,
+      maxHp: 200,
+    });
+    const state = makeBattleState();
+
+    const result = applyGen4HeldItem("end-of-turn", {
+      pokemon,
+      state,
+      rng: { next: () => 0, int: () => 0, chance: () => false } as any,
+    });
+
+    expect(result.activated).toBe(false);
+  });
+
+  it("given no Klutz holding Sitrus Berry, when HP drops to 50% at end of turn, then Sitrus Berry DOES heal", () => {
+    // Triangulation: without Klutz, Sitrus Berry activates normally
+    const pokemon = makeActivePokemon({
+      ability: "overgrow",
+      heldItem: "sitrus-berry",
+      currentHp: 50,
+      maxHp: 200,
+    });
+    const state = makeBattleState();
+
+    const result = applyGen4HeldItem("end-of-turn", {
+      pokemon,
+      state,
+      rng: { next: () => 0, int: () => 0, chance: () => false } as any,
+    });
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "heal", value: 50 })]),
+    );
+  });
+
+  it("given Klutz holding Life Orb, when damage calc runs, then Life Orb 1.3x boost is NOT applied", () => {
+    // Source: Showdown data/abilities.ts — Klutz gates all item damage modifiers
+    const attacker = makeActivePokemon({
+      ability: "klutz",
+      types: ["normal"],
+      heldItem: "life-orb",
+      attack: 100,
+    });
+    const attackerNoKlutz = makeActivePokemon({
+      ability: "intimidate",
+      types: ["normal"],
+      heldItem: "life-orb",
+      attack: 100,
+    });
+    const defender = makeActivePokemon({ types: ["normal"], defense: 100 });
+    const move = makeMove("normal", { power: 80, category: "physical" });
+    const state = makeBattleState();
+    const rng = {
+      next: () => 0.5,
+      int: (_min: number, _max: number) => 100,
+      chance: () => false,
+    } as any;
+
+    const resultKlutz = calculateGen4Damage(
+      { attacker, defender, move, state, rng, isCrit: false } as DamageContext,
+      GEN4_TYPE_CHART,
+    );
+    const resultNormal = calculateGen4Damage(
+      { attacker: attackerNoKlutz, defender, move, state, rng, isCrit: false } as DamageContext,
+      GEN4_TYPE_CHART,
+    );
+
+    // Klutz holder should deal LESS damage (no Life Orb 1.3x boost)
+    expect(resultKlutz.damage).toBeLessThan(resultNormal.damage);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suction Cups
+// ---------------------------------------------------------------------------
+
+describe("Suction Cups — prevent forced switching", () => {
+  it("given Suction Cups defender, when Whirlwind is used, then forced switch is prevented", () => {
+    // Source: Bulbapedia — Suction Cups: "Prevents the Pokemon from being forced to switch out"
+    // Source: Showdown data/abilities.ts — Suction Cups onDragOut
+    const attacker = makeActivePokemon({ types: ["normal"] });
+    const defender = makeActivePokemon({ ability: "suction-cups", types: ["rock"] });
+    const move = makeMove("normal", {
+      id: "whirlwind",
+      displayName: "Whirlwind",
+      power: null,
+      category: "status",
+      effect: null,
+    });
+    const state = makeBattleState();
+    state.sides[0].active = [attacker as any];
+    state.sides[1].active = [defender as any];
+
+    const result = executeGen4MoveEffect({
+      attacker,
+      defender,
+      move,
+      damage: 0,
+      state,
+      rng: { next: () => 0.5, int: () => 50, chance: () => false } as any,
+    } as MoveEffectContext);
+
+    // Switch should NOT happen
+    expect(result.switchOut).toBe(false);
+    // Message should mention Suction Cups
+    expect(result.messages.some((m) => m.includes("Suction Cups"))).toBe(true);
+  });
+
+  it("given no Suction Cups, when Whirlwind is used, then forced switch succeeds", () => {
+    // Triangulation: without Suction Cups, Whirlwind forces switch
+    const attacker = makeActivePokemon({ types: ["normal"] });
+    const defender = makeActivePokemon({ ability: "sturdy", types: ["rock"] });
+    const move = makeMove("normal", {
+      id: "whirlwind",
+      displayName: "Whirlwind",
+      power: null,
+      category: "status",
+      effect: null,
+    });
+    const state = makeBattleState();
+    state.sides[0].active = [attacker as any];
+    state.sides[1].active = [defender as any];
+
+    const result = executeGen4MoveEffect({
+      attacker,
+      defender,
+      move,
+      damage: 0,
+      state,
+      rng: { next: () => 0.5, int: () => 50, chance: () => false } as any,
+    } as MoveEffectContext);
+
+    // Switch should happen
+    expect(result.switchOut).toBe(true);
+  });
+
+  it("given Suction Cups defender, when Roar is used, then forced switch is also prevented", () => {
+    // Source: Showdown — Suction Cups blocks both Whirlwind and Roar
+    const attacker = makeActivePokemon({ types: ["normal"] });
+    const defender = makeActivePokemon({ ability: "suction-cups", types: ["rock"] });
+    const move = makeMove("normal", {
+      id: "roar",
+      displayName: "Roar",
+      power: null,
+      category: "status",
+      effect: null,
+    });
+    const state = makeBattleState();
+    state.sides[0].active = [attacker as any];
+    state.sides[1].active = [defender as any];
+
+    const result = executeGen4MoveEffect({
+      attacker,
+      defender,
+      move,
+      damage: 0,
+      state,
+      rng: { next: () => 0.5, int: () => 50, chance: () => false } as any,
+    } as MoveEffectContext);
+
+    expect(result.switchOut).toBe(false);
+    expect(result.messages.some((m) => m.includes("Suction Cups"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stench
+// ---------------------------------------------------------------------------
+
+describe("Stench — 10% flinch on damaging moves", () => {
+  it("given Stench and RNG < 0.1, when attacker deals damage, then target flinches", () => {
+    // Source: Bulbapedia — Stench (Gen 4): "Has a 10% chance of making a target flinch"
+    // Source: Showdown Gen 4 mod — Stench onModifyMove flinch chance
+    const ctx = makeAbilityContext({
+      ability: "stench",
+      rngNextValues: [0.05], // < 0.1 threshold
+    });
+
+    const result = applyGen4Ability("on-after-move-hit", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          effectType: "volatile-inflict",
+          target: "opponent",
+          volatile: "flinch",
+        }),
+      ]),
+    );
+  });
+
+  it("given Stench and RNG >= 0.1, when attacker deals damage, then target does NOT flinch", () => {
+    // Triangulation: 90% of the time, Stench does not cause flinch
+    const ctx = makeAbilityContext({
+      ability: "stench",
+      rngNextValues: [0.5], // >= 0.1 threshold
+    });
+
+    const result = applyGen4Ability("on-after-move-hit", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anticipation
+// ---------------------------------------------------------------------------
+
+describe("Anticipation — scan opponent moveset for SE/OHKO moves", () => {
+  it("given foe has a SE move, when Pokemon with Anticipation switches in, then shudder message appears", () => {
+    // Source: Bulbapedia — Anticipation: warns if foe has SE or OHKO move
+    // Source: Showdown data/abilities.ts — Anticipation onStart
+    const opponent = makeActivePokemon({
+      types: ["fire"],
+      moves: [{ moveId: "flamethrower", currentPP: 15, maxPP: 15, ppUps: 0 }],
+    });
+
+    const dataManager = makeMockDataManager({
+      flamethrower: makeMove("fire", {
+        id: "flamethrower",
+        displayName: "Flamethrower",
+        power: 95,
+        category: "special",
+      }),
+    });
+
+    const ctx = makeAbilityContext({
+      ability: "anticipation",
+      types: ["grass"], // Fire is SE against Grass
+      opponent,
+    });
+
+    const result = applyGen4Ability("on-switch-in", ctx, dataManager);
+
+    expect(result.activated).toBe(true);
+    expect(result.messages[0]).toContain("shudder");
+  });
+
+  it("given foe has only neutral/resisted moves, when Pokemon with Anticipation switches in, then no activation", () => {
+    // Triangulation: Anticipation should NOT trigger for neutral/resisted moves
+    const opponent = makeActivePokemon({
+      types: ["normal"],
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+    });
+
+    const dataManager = makeMockDataManager({
+      tackle: makeMove("normal", {
+        id: "tackle",
+        displayName: "Tackle",
+        power: 40,
+        category: "physical",
+      }),
+    });
+
+    const ctx = makeAbilityContext({
+      ability: "anticipation",
+      types: ["normal"], // Normal is neutral against Normal
+      opponent,
+    });
+
+    const result = applyGen4Ability("on-switch-in", ctx, dataManager);
+
+    expect(result.activated).toBe(false);
+  });
+
+  it("given foe has an OHKO move, when Pokemon with Anticipation switches in, then shudder message appears", () => {
+    // Source: Bulbapedia — Anticipation triggers for OHKO moves regardless of type
+    const opponent = makeActivePokemon({
+      types: ["ground"],
+      moves: [{ moveId: "fissure", currentPP: 5, maxPP: 5, ppUps: 0 }],
+    });
+
+    const dataManager = makeMockDataManager({
+      fissure: makeMove("ground", {
+        id: "fissure",
+        displayName: "Fissure",
+        power: null,
+        category: "physical",
+      }),
+    });
+
+    const ctx = makeAbilityContext({
+      ability: "anticipation",
+      types: ["steel"], // Ground is SE against Steel, but OHKO should trigger regardless
+      opponent,
+    });
+
+    const result = applyGen4Ability("on-switch-in", ctx, dataManager);
+
+    expect(result.activated).toBe(true);
+    expect(result.messages[0]).toContain("shudder");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Forewarn
+// ---------------------------------------------------------------------------
+
+describe("Forewarn — identify strongest move by base power", () => {
+  it("given foe has moves of varying power, when Pokemon with Forewarn switches in, then strongest move is revealed", () => {
+    // Source: Bulbapedia — Forewarn: reveals opponent's highest base power move
+    // Source: Showdown data/abilities.ts — Forewarn onStart
+    const opponent = makeActivePokemon({
+      types: ["fire"],
+      moves: [
+        { moveId: "ember", currentPP: 25, maxPP: 25, ppUps: 0 },
+        { moveId: "fire-blast", currentPP: 5, maxPP: 5, ppUps: 0 },
+      ],
+    });
+
+    const dataManager = makeMockDataManager({
+      ember: makeMove("fire", {
+        id: "ember",
+        displayName: "Ember",
+        power: 40,
+        category: "special",
+      }),
+      "fire-blast": makeMove("fire", {
+        id: "fire-blast",
+        displayName: "Fire Blast",
+        power: 110,
+        category: "special",
+      }),
+    });
+
+    const ctx = makeAbilityContext({
+      ability: "forewarn",
+      types: ["grass"],
+      opponent,
+    });
+
+    const result = applyGen4Ability("on-switch-in", ctx, dataManager);
+
+    expect(result.activated).toBe(true);
+    // Should mention the strongest move (Fire Blast, 110 BP)
+    expect(result.messages[0]).toContain("Fire Blast");
+  });
+
+  it("given foe has an OHKO move, when Pokemon with Forewarn switches in, then OHKO move treated as 160 BP (revealed as strongest)", () => {
+    // Source: Bulbapedia — Forewarn counts OHKO moves as BP 160
+    const opponent = makeActivePokemon({
+      types: ["ground"],
+      moves: [
+        { moveId: "earthquake", currentPP: 10, maxPP: 10, ppUps: 0 },
+        { moveId: "fissure", currentPP: 5, maxPP: 5, ppUps: 0 },
+      ],
+    });
+
+    const dataManager = makeMockDataManager({
+      earthquake: makeMove("ground", {
+        id: "earthquake",
+        displayName: "Earthquake",
+        power: 100,
+        category: "physical",
+      }),
+      fissure: makeMove("ground", {
+        id: "fissure",
+        displayName: "Fissure",
+        power: null, // OHKO moves have null power in data but Forewarn treats them as 160
+        category: "physical",
+      }),
+    });
+
+    const ctx = makeAbilityContext({
+      ability: "forewarn",
+      types: ["steel"],
+      opponent,
+    });
+
+    const result = applyGen4Ability("on-switch-in", ctx, dataManager);
+
+    expect(result.activated).toBe(true);
+    // Should mention Fissure (treated as 160 BP, > Earthquake's 100 BP)
+    expect(result.messages[0]).toContain("Fissure");
+  });
+
+  it("given foe has no moves with power, when Pokemon with Forewarn switches in, then no activation", () => {
+    // Edge case: foe with only status moves (no base power)
+    const opponent = makeActivePokemon({
+      types: ["psychic"],
+      moves: [{ moveId: "thunder-wave", currentPP: 20, maxPP: 20, ppUps: 0 }],
+    });
+
+    const dataManager = makeMockDataManager({
+      "thunder-wave": makeMove("electric", {
+        id: "thunder-wave",
+        displayName: "Thunder Wave",
+        power: null,
+        category: "status",
+      }),
+    });
+
+    const ctx = makeAbilityContext({
+      ability: "forewarn",
+      types: ["normal"],
+      opponent,
+    });
+
+    const result = applyGen4Ability("on-switch-in", ctx, dataManager);
+
+    expect(result.activated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **Leaf Guard**: blocks all status conditions in sun weather via `canInflictGen4Status`
- **Storm Drain**: Water-type immunity + SpAtk boost (damage calc passive immunity + ability handler)
- **Klutz**: suppresses held item effects across damage calc (attack/defense/post-formula), item triggers, and speed calc
- **Suction Cups**: prevents forced switching from Whirlwind/Roar in move effects
- **Stench**: 10% flinch chance via new `on-after-move-hit` ability trigger
- **Anticipation fix**: now scans opponent's moveset via DataManager for super-effective/OHKO moves (was a stub returning true always)
- **Forewarn fix**: now identifies foe's highest base power move via DataManager, treating OHKO moves as 160 BP (was a stub)
- 21 new tests covering all 7 mechanics with triangulation (2-4 tests each)

## Files Changed

- `packages/gen4/src/Gen4Abilities.ts` — Storm Drain handler, Stench on-after-move-hit, Anticipation/Forewarn real implementations
- `packages/gen4/src/Gen4DamageCalc.ts` — Storm Drain in ABILITY_TYPE_IMMUNITIES, Klutz guards on all item boosts
- `packages/gen4/src/Gen4Items.ts` — Klutz early-return guard
- `packages/gen4/src/Gen4MoveEffects.ts` — Leaf Guard in canInflictGen4Status, Suction Cups in Whirlwind/Roar
- `packages/gen4/src/Gen4Ruleset.ts` — Klutz in getEffectiveSpeed, DataManager passed to applyAbility
- `packages/gen4/tests/wave4-abilities.test.ts` — 21 new tests
- `packages/gen4/tests/abilities.test.ts` — updated Anticipation/Forewarn stubs to expect false without DataManager

## Test plan

- [x] All 791 gen4 tests pass (21 new + 770 existing)
- [x] TypeScript typecheck passes
- [x] Biome lint clean (gen4 package)
- [ ] CI build/test/typecheck/lint gates

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Wave 4 ability suite: Leaf Guard prevents status conditions in sunny weather, Storm Drain absorbs water-type moves and increases Special Attack, Klutz suppresses held item effects, Suction Cups prevents forced switches, and Stench inflicts flinch on move hit
  * Enhanced Anticipation and Forewarn to accurately detect opposing move threats and super-effective matchups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->