### PR TITLE
feat(gen4): Wave 6A -- utility moves, combat items, speed/berry mechanics

### DIFF
--- a/.changeset/gen4-wave6a-utility-items.md
+++ b/.changeset/gen4-wave6a-utility-items.md
@@ -1,0 +1,21 @@
+---
+"@pokemon-lib-ts/gen4": minor
+"@pokemon-lib-ts/battle": patch
+"@pokemon-lib-ts/core": patch
+---
+
+Gen 4 Wave 6A: utility moves, combat items, speed/berry mechanics
+
+Move effects: Magnet Rise (5-turn Ground immunity), Acupressure (+2 random stat),
+Power Swap, Guard Swap, Heart Swap (stat stage swapping), Curse (Ghost-type fix
+with 1/2 HP cost + curse volatile), binding moves (Bind, Wrap, Fire Spin, Clamp,
+Whirlpool, Sand Tomb, Magma Storm).
+
+Items: Sticky Barb (1/8 HP EoT damage), Berry Juice (heal 20 HP at <=50%),
+Grip Claw (binding moves last 7 turns).
+
+Abilities: Gluttony (berry threshold infrastructure), Unburden (2x Speed after
+item consumed/lost, triggers on berry consumption, Knock Off, and Trick/Switcheroo).
+
+Infrastructure: Magnet Rise EoT countdown, "magnet-rise-countdown" EndOfTurnEffect,
+Magnet Rise Ground immunity in damage calc, "unburden" volatile status.

--- a/packages/battle/src/context/types.ts
+++ b/packages/battle/src/context/types.ts
@@ -519,7 +519,8 @@ export type EndOfTurnEffect =
   | "gravity-countdown"
   | "yawn-countdown"
   | "heal-block-countdown"
-  | "embargo-countdown";
+  | "embargo-countdown"
+  | "magnet-rise-countdown";
 
 /**
  * Configuration object passed to the `BattleEngine` constructor.

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -2434,6 +2434,30 @@ export class BattleEngine implements BattleEventEmitter {
           }
           break;
         }
+        case "magnet-rise-countdown": {
+          // Magnet Rise volatile countdown — remove when turnsLeft reaches 0
+          // Source: Bulbapedia — Magnet Rise: "The user levitates for five turns."
+          // Source: Showdown Gen 4 mod — Magnet Rise lasts 5 turns
+          for (const side of this.state.sides) {
+            const active = side.active[0];
+            if (!active || active.pokemon.currentHp <= 0) continue;
+            const mrState = active.volatileStatuses.get("magnet-rise");
+            if (!mrState) continue;
+            if (mrState.turnsLeft > 0) {
+              mrState.turnsLeft--;
+              if (mrState.turnsLeft <= 0) {
+                active.volatileStatuses.delete("magnet-rise");
+                this.emit({
+                  type: "volatile-end",
+                  side: side.index,
+                  pokemon: getPokemonName(active),
+                  volatile: "magnet-rise",
+                });
+              }
+            }
+          }
+          break;
+        }
         default:
           // Many effects not yet implemented
           break;

--- a/packages/core/src/entities/status.ts
+++ b/packages/core/src/entities/status.ts
@@ -56,4 +56,5 @@ export type VolatileStatus =
   | "shadow-force-charging" // Semi-invulnerable turn of Shadow Force (Gen 4+)
   | "charging" // Generic charge turn (SolarBeam, Skull Bash, Razor Wind, Sky Attack) — NOT semi-invulnerable
   | "metronome-count" // Metronome item — tracks consecutive same-move uses (Gen 4+)
-  | "slow-start"; // Slow Start — halves Attack and Speed for 5 turns (Gen 4+ Regigigas)
+  | "slow-start" // Slow Start — halves Attack and Speed for 5 turns (Gen 4+ Regigigas)
+  | "unburden"; // Unburden — Speed doubles when held item is consumed/lost (Gen 4+)

--- a/packages/gen4/src/Gen4DamageCalc.ts
+++ b/packages/gen4/src/Gen4DamageCalc.ts
@@ -649,6 +649,22 @@ export function calculateGen4Damage(context: DamageContext, typeChart: TypeChart
     }
   }
 
+  // 4b. Magnet Rise: grants Ground immunity to the holder for 5 turns.
+  // NOT an ability — Mold Breaker does NOT bypass Magnet Rise.
+  // Gravity suppresses Magnet Rise (grounded Pokemon lose the levitation).
+  // Iron Ball also grounds the holder, suppressing Magnet Rise.
+  // Source: Showdown Gen 4 mod — Magnet Rise grants Ground immunity (not ability-based)
+  // Source: Bulbapedia — Magnet Rise: "The user levitates using electrically generated
+  //   magnetism for five turns."
+  if (
+    effectiveMoveType === "ground" &&
+    defender.volatileStatuses.has("magnet-rise") &&
+    !gravityActive &&
+    !ironBallGrounded
+  ) {
+    return { damage: 0, effectiveness: 0, isCrit, randomFactor: 1 };
+  }
+
   // 5. Physical/Special determination — THE key Gen 4 change
   // In Gen 4, category is per-move, NOT per-type (unlike Gen 1-3).
   // Source: Bulbapedia — Physical/special split: "Starting in Generation IV,

--- a/packages/gen4/src/Gen4Items.ts
+++ b/packages/gen4/src/Gen4Items.ts
@@ -8,6 +8,29 @@ const NO_ACTIVATION: ItemResult = {
 };
 
 /**
+ * Get the HP threshold fraction for pinch berry activation.
+ * Gluttony changes the activation threshold from 25% to 50%.
+ * Normal berries (Sitrus, Oran) already use 50% and are unaffected.
+ *
+ * Source: Bulbapedia — Gluttony: "Makes the Pokemon eat a held Berry when its HP
+ *   drops to 50% or less instead of the usual 25%."
+ * Source: Showdown data/abilities.ts — Gluttony modifies pinch berry threshold
+ *
+ * @param pokemon - The Pokemon holding the berry
+ * @param normalFraction - The normal activation fraction (0.25 for pinch berries)
+ * @returns The effective threshold fraction
+ */
+export function getPinchBerryThreshold(
+  pokemon: { ability: string },
+  normalFraction: number,
+): number {
+  if (pokemon.ability === "gluttony" && normalFraction <= 0.25) {
+    return 0.5;
+  }
+  return normalFraction;
+}
+
+/**
  * Apply a Gen 4 held item effect at the given trigger point.
  *
  * Gen 4 held items follow the DPPt item system. Key differences from Gen 3:
@@ -47,18 +70,40 @@ export function applyGen4HeldItem(trigger: string, context: ItemContext): ItemRe
     return NO_ACTIVATION;
   }
 
+  let result: ItemResult;
   switch (trigger) {
     case "before-move":
-      return handleBeforeMove(item, context);
+      result = handleBeforeMove(item, context);
+      break;
     case "end-of-turn":
-      return handleEndOfTurn(item, context);
+      result = handleEndOfTurn(item, context);
+      break;
     case "on-damage-taken":
-      return handleOnDamageTaken(item, context);
+      result = handleOnDamageTaken(item, context);
+      break;
     case "on-hit":
-      return handleOnHit(item, context);
+      result = handleOnHit(item, context);
+      break;
     default:
-      return NO_ACTIVATION;
+      result = NO_ACTIVATION;
+      break;
   }
+
+  // Unburden: when a held item is consumed and the holder has Unburden,
+  // set the "unburden" volatile to double Speed.
+  // Source: Bulbapedia — Unburden: "Doubles the Pokemon's Speed stat when its held
+  //   item is used or lost."
+  // Source: Showdown data/abilities.ts — Unburden onAfterUseItem
+  if (
+    result.activated &&
+    context.pokemon.ability === "unburden" &&
+    result.effects.some((e) => e.type === "consume") &&
+    !context.pokemon.volatileStatuses.has("unburden")
+  ) {
+    context.pokemon.volatileStatuses.set("unburden", { turnsLeft: -1 });
+  }
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -347,6 +392,37 @@ function handleEndOfTurn(item: string, context: ItemContext): ItemResult {
             { type: "consume", target: "self", value: "mental-herb" },
           ],
           messages: [`${pokemonName}'s Mental Herb cured its infatuation!`],
+        };
+      }
+      return NO_ACTIVATION;
+    }
+
+    // Sticky Barb: 1/8 max HP damage to holder each turn (NOT consumed)
+    // Source: Bulbapedia — Sticky Barb: "At the end of every turn, the holder takes
+    //   damage equal to 1/8 of its maximum HP."
+    // Source: Showdown Gen 4 mod — Sticky Barb end-of-turn chip
+    case "sticky-barb": {
+      const chipDamage = Math.max(1, Math.floor(maxHp / 8));
+      return {
+        activated: true,
+        effects: [{ type: "none", target: "self", value: -chipDamage }],
+        messages: [`${pokemonName} was hurt by its Sticky Barb!`],
+      };
+    }
+
+    // Berry Juice: Heal 20 HP when holder drops to ≤50% HP (consumed)
+    // Source: Bulbapedia — Berry Juice: "Restores 20 HP when the holder's HP drops
+    //   to 50% or below."
+    // Source: Showdown Gen 4 mod — Berry Juice EoT trigger at 50%
+    case "berry-juice": {
+      if (currentHp <= Math.floor(maxHp / 2)) {
+        return {
+          activated: true,
+          effects: [
+            { type: "heal", target: "self", value: 20 },
+            { type: "consume", target: "self", value: "berry-juice" },
+          ],
+          messages: [`${pokemonName}'s Berry Juice restored 20 HP!`],
         };
       }
       return NO_ACTIVATION;

--- a/packages/gen4/src/Gen4MoveEffects.ts
+++ b/packages/gen4/src/Gen4MoveEffects.ts
@@ -1084,6 +1084,99 @@ function handleNullEffectMoves(
       break;
     }
 
+    case "bind":
+    case "wrap":
+    case "fire-spin":
+    case "clamp":
+    case "whirlpool":
+    case "sand-tomb":
+    case "magma-storm": {
+      // Binding moves: trap target for 4-5 turns (or 7 with Grip Claw).
+      // Source: Showdown Gen 4 mod — binding moves set "bound" volatile with duration
+      // Source: Bulbapedia — Binding moves last 4-5 turns in Gen 4 (2-5 in Gen 3);
+      //   Grip Claw extends to 7 turns.
+      const { attacker: bindAtk, defender: bindDef } = context;
+      const defName = bindDef.pokemon.nickname ?? "The foe";
+      if (bindDef.volatileStatuses.has("bound")) {
+        break; // Already bound
+      }
+      // Grip Claw: binding lasts 7 turns instead of randomly 4-5
+      // Source: Bulbapedia — Grip Claw: "Extends the duration of binding moves to 7 turns"
+      // Source: Showdown Gen 4 mod — Grip Claw sets binding duration to 7
+      const hasGripClaw = bindAtk.pokemon.heldItem === "grip-claw" && bindAtk.ability !== "klutz";
+      const turnsLeft = hasGripClaw ? 7 : context.rng.int(4, 5);
+      result.volatileInflicted = "bound";
+      result.volatileData = { turnsLeft };
+      result.messages.push(`${defName} was squeezed by ${moveId}!`);
+      break;
+    }
+
+    case "power-swap": {
+      // Swap Atk and SpAtk stat stages between attacker and defender.
+      // Source: Showdown Gen 4 mod — Power Swap swaps Attack and SpAtk stat boosts/drops
+      // Source: Bulbapedia — Power Swap: "The user swaps its Attack and Sp. Atk stat
+      //   changes with the target's."
+      const { attacker: pswAtk, defender: pswDef } = context;
+      const pswAtkName = pswAtk.pokemon.nickname ?? "The Pokemon";
+
+      const tempAtk = pswAtk.statStages.attack;
+      const tempSpAtk = pswAtk.statStages.spAttack;
+      pswAtk.statStages.attack = pswDef.statStages.attack;
+      pswAtk.statStages.spAttack = pswDef.statStages.spAttack;
+      pswDef.statStages.attack = tempAtk;
+      pswDef.statStages.spAttack = tempSpAtk;
+
+      result.messages.push(
+        `${pswAtkName} switched all changes to its Attack and Sp. Atk with the target!`,
+      );
+      break;
+    }
+
+    case "guard-swap": {
+      // Swap Def and SpDef stat stages between attacker and defender.
+      // Source: Showdown Gen 4 mod — Guard Swap swaps Defense and SpDef stat boosts/drops
+      // Source: Bulbapedia — Guard Swap: "The user swaps its Defense and Sp. Def stat
+      //   changes with the target's."
+      const { attacker: gswAtk, defender: gswDef } = context;
+      const gswAtkName = gswAtk.pokemon.nickname ?? "The Pokemon";
+
+      const tempDef = gswAtk.statStages.defense;
+      const tempSpDef = gswAtk.statStages.spDefense;
+      gswAtk.statStages.defense = gswDef.statStages.defense;
+      gswAtk.statStages.spDefense = gswDef.statStages.spDefense;
+      gswDef.statStages.defense = tempDef;
+      gswDef.statStages.spDefense = tempSpDef;
+
+      result.messages.push(
+        `${gswAtkName} switched all changes to its Defense and Sp. Def with the target!`,
+      );
+      break;
+    }
+
+    case "heart-swap": {
+      // Swap ALL stat stages between attacker and defender.
+      // Source: Showdown Gen 4 mod — Heart Swap swaps all stat stage changes
+      // Source: Bulbapedia — Heart Swap: "The user swaps all stat changes with the target."
+      const { attacker: hswAtk, defender: hswDef } = context;
+      const hswAtkName = hswAtk.pokemon.nickname ?? "The Pokemon";
+      const allStats: Array<keyof typeof hswAtk.statStages> = [
+        "attack",
+        "defense",
+        "spAttack",
+        "spDefense",
+        "speed",
+        "accuracy",
+        "evasion",
+      ];
+      for (const stat of allStats) {
+        const temp = hswAtk.statStages[stat];
+        hswAtk.statStages[stat] = hswDef.statStages[stat];
+        hswDef.statStages[stat] = temp;
+      }
+      result.messages.push(`${hswAtkName} swapped all stat changes with the target!`);
+      break;
+    }
+
     case "counter": {
       // Counter: returns 2x the physical damage taken this turn
       // Source: Showdown Gen 4 sim — Counter returns double physical damage received this turn
@@ -1192,6 +1285,14 @@ export function executeGen4MoveEffect(context: MoveEffectContext): MoveEffectRes
       context.defender.pokemon.heldItem = null;
       const defenderName = context.defender.pokemon.nickname ?? "The foe";
       result.messages.push(`${defenderName} lost its ${item}!`);
+      // Unburden: if the defender had Unburden, set the volatile now that its item is gone
+      // Source: Showdown Gen 4 mod — Unburden activates when item is knocked off
+      if (
+        context.defender.ability === "unburden" &&
+        !context.defender.volatileStatuses.has("unburden")
+      ) {
+        context.defender.volatileStatuses.set("unburden", { turnsLeft: -1 });
+      }
     }
     return result;
   }
@@ -1495,6 +1596,26 @@ export function executeGen4MoveEffect(context: MoveEffectContext): MoveEffectRes
     } else if (attackerItem) {
       result.messages.push(`${attackerName} gave ${attackerItem} to ${defenderName}!`);
     }
+
+    // Unburden: if either Pokemon had an item and now doesn't, and has Unburden, activate it.
+    // Source: Showdown Gen 4 mod — Unburden activates when item is lost via Trick/Switcheroo
+    if (
+      attackerItem &&
+      !attacker.pokemon.heldItem &&
+      attacker.ability === "unburden" &&
+      !attacker.volatileStatuses.has("unburden")
+    ) {
+      attacker.volatileStatuses.set("unburden", { turnsLeft: -1 });
+    }
+    if (
+      defenderItem &&
+      !defender.pokemon.heldItem &&
+      defender.ability === "unburden" &&
+      !defender.volatileStatuses.has("unburden")
+    ) {
+      defender.volatileStatuses.set("unburden", { turnsLeft: -1 });
+    }
+
     return result;
   }
 
@@ -1528,6 +1649,83 @@ export function executeGen4MoveEffect(context: MoveEffectContext): MoveEffectRes
     };
     result.messages.push(`${attackerName} chose Doom Desire as its destiny!`);
     return result;
+  }
+
+  // Magnet Rise: apply "magnet-rise" volatile to user for 5 turns.
+  // Fails if user is already under Gravity or already has Magnet Rise.
+  // Source: Showdown Gen 4 mod — Magnet Rise sets volatile on self for 5 turns
+  // Source: Bulbapedia — Magnet Rise: "The user levitates using electrically generated
+  //   magnetism for five turns." Fails under Gravity.
+  if (context.move.id === "magnet-rise") {
+    const { attacker, state } = context;
+    const attackerName = attacker.pokemon.nickname ?? "The Pokemon";
+    // Fail if Gravity is active
+    if (state.gravity?.active) {
+      result.messages.push("But it failed!");
+      return result;
+    }
+    // Fail if already has Magnet Rise
+    if (attacker.volatileStatuses.has("magnet-rise")) {
+      result.messages.push("But it failed!");
+      return result;
+    }
+    result.selfVolatileInflicted = "magnet-rise";
+    result.selfVolatileData = { turnsLeft: 5 };
+    result.messages.push(`${attackerName} levitated with electromagnetism!`);
+    return result;
+  }
+
+  // Acupressure: +2 to a random stat stage (from stats not already at +6).
+  // Source: Showdown Gen 4 mod — Acupressure boosts a random stat by 2
+  // Source: Bulbapedia — Acupressure: "Sharply raises one of the user's stats at random"
+  if (context.move.id === "acupressure") {
+    const { attacker, rng } = context;
+    const attackerName = attacker.pokemon.nickname ?? "The Pokemon";
+    const allStats: BattleStat[] = [
+      "attack",
+      "defense",
+      "spAttack",
+      "spDefense",
+      "speed",
+      "accuracy",
+      "evasion",
+    ];
+    const boostableStats = allStats.filter((stat) => attacker.statStages[stat] < 6);
+    if (boostableStats.length === 0) {
+      result.messages.push("But it failed!");
+      return result;
+    }
+    const chosenIndex = rng.int(0, boostableStats.length - 1);
+    const chosen = boostableStats[chosenIndex] as BattleStat;
+    result.statChanges.push({ target: "attacker", stat: chosen, stages: 2 });
+    result.messages.push(`${attackerName}'s ${chosen} rose sharply!`);
+    return result;
+  }
+
+  // Curse (Ghost-type): user loses 1/2 max HP, target gets "curse" volatile.
+  // Non-Ghost Curse (stat changes) is handled by data-driven effect (stat-change type).
+  // Ghost-type Curse is intercepted by ID + type check.
+  // Source: Showdown Gen 4 mod — Ghost Curse: user sacrifices 1/2 HP, target gets cursed
+  // Source: Bulbapedia — Curse: "If the user is a Ghost-type, the user loses 1/2 of its
+  //   maximum HP and the target is cursed."
+  if (context.move.id === "curse") {
+    const { attacker, defender } = context;
+    if (attacker.types.includes("ghost")) {
+      const attackerName = attacker.pokemon.nickname ?? "The Pokemon";
+      const defenderName = defender.pokemon.nickname ?? "The foe";
+      const maxHp = attacker.pokemon.calculatedStats?.hp ?? attacker.pokemon.currentHp;
+      const hpCost = Math.max(1, Math.floor(maxHp / 2));
+      // Already cursed — fail
+      if (defender.volatileStatuses.has("curse")) {
+        result.messages.push("But it failed!");
+        return result;
+      }
+      result.customDamage = { target: "attacker", amount: hpCost, source: "curse" };
+      result.volatileInflicted = "curse";
+      result.messages.push(`${attackerName} cut its own HP and laid a curse on ${defenderName}!`);
+      return result;
+    }
+    // Non-Ghost: fall through to data-driven effect (stat changes +Atk +Def -Spd)
   }
 
   // Handle null-effect moves (stealth-rock, toxic-spikes, trick-room, etc.)

--- a/packages/gen4/src/Gen4Ruleset.ts
+++ b/packages/gen4/src/Gen4Ruleset.ts
@@ -270,7 +270,11 @@ export class Gen4Ruleset extends BaseRuleset {
 
     const isFlying = pokemon.types.includes("flying");
     const hasLevitate = pokemon.ability === "levitate";
-    const isGrounded = !isFlying && !hasLevitate;
+    // Magnet Rise: grants levitation — immune to ground-based hazards (Spikes, Toxic Spikes)
+    // Source: Bulbapedia — Magnet Rise: "makes the user immune to Ground-type moves"
+    // Source: Showdown Gen 4 mod — Magnet Rise grants same grounding immunity as Levitate
+    const hasMagnetRise = pokemon.volatileStatuses.has("magnet-rise");
+    const isGrounded = !isFlying && !hasLevitate && !hasMagnetRise;
 
     // --- Stealth Rock ---
     const stealthRock = side.hazards.find((h) => h.type === "stealth-rock");
@@ -592,6 +596,18 @@ export class Gen4Ruleset extends BaseRuleset {
     // Source: Showdown data/abilities.ts — Slow Start onModifySpe
     if (active.ability === "slow-start" && active.volatileStatuses.has("slow-start")) {
       effective = Math.floor(effective / 2);
+    }
+
+    // Unburden: 2x Speed when held item is consumed/lost AND currently has no item.
+    // Source: Bulbapedia — Unburden: "Doubles the Pokemon's Speed stat when its held
+    //   item is used or lost."
+    // Source: Showdown data/abilities.ts — Unburden onModifySpe
+    if (
+      active.ability === "unburden" &&
+      active.volatileStatuses.has("unburden") &&
+      !active.pokemon.heldItem
+    ) {
+      effective = effective * 2;
     }
 
     // Quick Feet: 1.5x Speed when statused, overrides paralysis penalty
@@ -1153,6 +1169,7 @@ export class Gen4Ruleset extends BaseRuleset {
       "disable-countdown", // Disable timer (4 turns in Gen 4)
       "heal-block-countdown", // Heal Block (5 turns)
       "embargo-countdown", // Embargo (5 turns)
+      "magnet-rise-countdown", // Magnet Rise (5 turns)
       "perish-song", // Perish Song countdown
       "screen-countdown", // Reflect / Light Screen
       "safeguard-countdown", // Safeguard

--- a/packages/gen4/tests/ruleset.test.ts
+++ b/packages/gen4/tests/ruleset.test.ts
@@ -580,7 +580,7 @@ describe("Gen4Ruleset getEndOfTurnOrder", () => {
     expect(order[0]).toBe("weather-damage");
   });
 
-  it("given Gen4Ruleset, when getEndOfTurnOrder, then returns all 33 Gen 4 EoT effects in correct order", () => {
+  it("given Gen4Ruleset, when getEndOfTurnOrder, then returns all 34 Gen 4 EoT effects in correct order", () => {
     // Source: Showdown sim/battle.ts Gen 4 mod — full EoT ordering
     // Source: Bulbapedia — Diamond/Pearl/Platinum end-of-turn processing order
     // Key Gen 4 ordering: weather-damage first, toxic/flame orb after weather-countdown,
@@ -610,6 +610,7 @@ describe("Gen4Ruleset getEndOfTurnOrder", () => {
       "disable-countdown",
       "heal-block-countdown",
       "embargo-countdown",
+      "magnet-rise-countdown",
       "perish-song",
       "screen-countdown",
       "safeguard-countdown",

--- a/packages/gen4/tests/wave6a-moves-items.test.ts
+++ b/packages/gen4/tests/wave6a-moves-items.test.ts
@@ -1,0 +1,959 @@
+import type { ActivePokemon, BattleState, MoveEffectContext } from "@pokemon-lib-ts/battle";
+import type { MoveData, PokemonInstance, PokemonType, StatBlock } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import { calculateGen4Damage } from "../src/Gen4DamageCalc";
+import { applyGen4HeldItem, getPinchBerryThreshold } from "../src/Gen4Items";
+import { executeGen4MoveEffect } from "../src/Gen4MoveEffects";
+import { Gen4Ruleset } from "../src/Gen4Ruleset";
+import { GEN4_TYPE_CHART } from "../src/Gen4TypeChart";
+
+/**
+ * Gen 4 Wave 6A -- Utility Moves, Combat Items, Speed/Berry Mechanics Tests
+ *
+ * Covers: Magnet Rise, Acupressure, Power/Guard/Heart Swap, Curse (Ghost),
+ *         Sticky Barb, Berry Juice, Grip Claw, Gluttony, Unburden,
+ *         and binding move duration.
+ *
+ * Source: Showdown sim/battle.ts Gen 4 mod
+ * Source: Bulbapedia -- individual move/item/ability pages
+ */
+
+// ---------------------------------------------------------------------------
+// Test helpers (same pattern as wave5a-volatile-moves.test.ts)
+// ---------------------------------------------------------------------------
+
+function createMockRng(intReturnValue: number, nextValue = 0) {
+  return {
+    next: () => nextValue,
+    int: (_min: number, _max: number) => intReturnValue,
+    chance: () => false,
+    pick: <T>(arr: readonly T[]) => arr[0] as T,
+    shuffle: <T>(arr: readonly T[]) => [...arr],
+    getState: () => 0,
+    setState: () => {},
+  };
+}
+
+function createActivePokemon(opts: {
+  types: PokemonType[];
+  status?: string | null;
+  heldItem?: string | null;
+  nickname?: string | null;
+  currentHp?: number;
+  maxHp?: number;
+  level?: number;
+  ability?: string;
+  lastMoveUsed?: string | null;
+  moves?: Array<{ moveId: string; currentPP: number; maxPP: number }>;
+  volatiles?: Map<string, { turnsLeft: number; data?: Record<string, unknown> }>;
+  statStages?: Partial<Record<string, number>>;
+  gender?: string;
+}): ActivePokemon {
+  const maxHp = opts.maxHp ?? 200;
+  const stats: StatBlock = {
+    hp: maxHp,
+    attack: 100,
+    defense: 100,
+    spAttack: 100,
+    spDefense: 100,
+    speed: 100,
+  };
+
+  const pokemon = {
+    uid: `test-${Math.random().toString(36).slice(2, 8)}`,
+    speciesId: 1,
+    nickname: opts.nickname ?? null,
+    level: opts.level ?? 50,
+    experience: 0,
+    nature: "hardy",
+    ivs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+    evs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+    currentHp: opts.currentHp ?? maxHp,
+    moves: opts.moves ?? [
+      { moveId: "tackle", currentPP: 35, maxPP: 35 },
+      { moveId: "ember", currentPP: 25, maxPP: 25 },
+    ],
+    ability: opts.ability ?? "",
+    abilitySlot: "normal1" as const,
+    heldItem: opts.heldItem ?? null,
+    status: opts.status ?? null,
+    friendship: 0,
+    gender: (opts.gender ?? "male") as "male" | "female" | "genderless",
+    isShiny: false,
+    metLocation: "",
+    metLevel: 1,
+    originalTrainer: "",
+    originalTrainerId: 0,
+    pokeball: "pokeball",
+    calculatedStats: stats,
+  } as PokemonInstance;
+
+  const volatiles =
+    opts.volatiles ?? new Map<string, { turnsLeft: number; data?: Record<string, unknown> }>();
+
+  const defaultStages = {
+    hp: 0,
+    attack: 0,
+    defense: 0,
+    spAttack: 0,
+    spDefense: 0,
+    speed: 0,
+    accuracy: 0,
+    evasion: 0,
+    ...(opts.statStages ?? {}),
+  };
+
+  return {
+    pokemon,
+    teamSlot: 0,
+    statStages: defaultStages,
+    volatileStatuses: volatiles,
+    types: opts.types,
+    ability: opts.ability ?? "",
+    lastMoveUsed: opts.lastMoveUsed ?? null,
+    lastDamageTaken: 0,
+    lastDamageType: null,
+    lastDamageCategory: null,
+    turnsOnField: 0,
+    movedThisTurn: false,
+    consecutiveProtects: 0,
+    substituteHp: 0,
+    transformed: false,
+    transformedSpecies: null,
+    isMega: false,
+    isDynamaxed: false,
+    dynamaxTurnsLeft: 0,
+    isTerastallized: false,
+    teraType: null,
+  } as ActivePokemon;
+}
+
+function createMove(id: string, overrides?: Partial<MoveData>): MoveData {
+  return {
+    id,
+    name: id,
+    type: "normal",
+    category: "status",
+    power: 0,
+    accuracy: 100,
+    pp: 10,
+    maxPp: 10,
+    priority: 0,
+    target: "adjacent-foe",
+    flags: [],
+    effect: null,
+    critRatio: 0,
+    generation: 4,
+    isContact: false,
+    isSound: false,
+    isPunch: false,
+    isBite: false,
+    isBullet: false,
+    description: "",
+    ...overrides,
+  } as MoveData;
+}
+
+function createMinimalBattleState(attacker: ActivePokemon, defender: ActivePokemon): BattleState {
+  return {
+    sides: [
+      {
+        index: 0,
+        active: [attacker],
+        team: [attacker.pokemon],
+        screens: [],
+        hazards: [],
+        tailwind: { active: false, turnsLeft: 0 },
+        luckyChant: { active: false, turnsLeft: 0 },
+        wish: null,
+        futureAttack: null,
+        faintCount: 0,
+        gimmickUsed: false,
+        trainer: null,
+      },
+      {
+        index: 1,
+        active: [defender],
+        team: [defender.pokemon],
+        screens: [],
+        hazards: [],
+        tailwind: { active: false, turnsLeft: 0 },
+        luckyChant: { active: false, turnsLeft: 0 },
+        wish: null,
+        futureAttack: null,
+        faintCount: 0,
+        gimmickUsed: false,
+        trainer: null,
+      },
+    ],
+    weather: { type: null, turnsLeft: 0, source: null },
+    terrain: { type: null, turnsLeft: 0, source: null },
+    trickRoom: { active: false, turnsLeft: 0 },
+    turnNumber: 1,
+    phase: "action-select" as const,
+    winner: null,
+    ended: false,
+    gravity: { active: false, turnsLeft: 0 },
+  } as BattleState;
+}
+
+function createContext(
+  attacker: ActivePokemon,
+  defender: ActivePokemon,
+  move: MoveData,
+  rng: ReturnType<typeof createMockRng>,
+  stateOverrides?: Partial<BattleState>,
+): MoveEffectContext {
+  const state = { ...createMinimalBattleState(attacker, defender), ...stateOverrides };
+  return { attacker, defender, move, damage: 0, state, rng } as MoveEffectContext;
+}
+
+// ===========================================================================
+// Magnet Rise
+// ===========================================================================
+
+describe("Magnet Rise", () => {
+  it("given attacker uses Magnet Rise, when executed, then attacker gets magnet-rise volatile with turnsLeft=5", () => {
+    // Source: Bulbapedia -- Magnet Rise: "levitates for five turns"
+    // Source: Showdown Gen 4 mod -- Magnet Rise self-volatile, 5 turns
+    const attacker = createActivePokemon({ types: ["electric"], nickname: "Magnezone" });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("magnet-rise", { type: "electric" });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.selfVolatileInflicted).toBe("magnet-rise");
+    expect(result.selfVolatileData).toEqual({ turnsLeft: 5 });
+    expect(result.messages).toContain("Magnezone levitated with electromagnetism!");
+  });
+
+  it("given Gravity is active, when attacker uses Magnet Rise, then it fails", () => {
+    // Source: Bulbapedia -- Magnet Rise fails under Gravity
+    // Source: Showdown Gen 4 mod -- Magnet Rise blocked by Gravity
+    const attacker = createActivePokemon({ types: ["electric"] });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("magnet-rise", { type: "electric" });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng, {
+      gravity: { active: true, turnsLeft: 3 },
+    });
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.selfVolatileInflicted).toBeUndefined();
+    expect(result.messages).toContain("But it failed!");
+  });
+
+  it("given attacker already has Magnet Rise, when Magnet Rise is used again, then it fails", () => {
+    // Source: Showdown Gen 4 mod -- Magnet Rise fails if already active
+    const volatiles = new Map<string, { turnsLeft: number }>();
+    volatiles.set("magnet-rise", { turnsLeft: 3 });
+    const attacker = createActivePokemon({ types: ["electric"], volatiles });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("magnet-rise", { type: "electric" });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.selfVolatileInflicted).toBeUndefined();
+    expect(result.messages).toContain("But it failed!");
+  });
+});
+
+// ===========================================================================
+// Acupressure
+// ===========================================================================
+
+describe("Acupressure", () => {
+  it("given attacker uses Acupressure with no stats at +6, when executed, then a random stat is boosted by +2", () => {
+    // Source: Bulbapedia -- Acupressure: "Sharply raises one of the user's stats at random"
+    // Source: Showdown Gen 4 mod -- Acupressure +2 to random stat
+    const attacker = createActivePokemon({ types: ["normal"], nickname: "Shuckle" });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("acupressure");
+    // rng.int returns 0, which picks the first boostable stat ("attack")
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.statChanges).toHaveLength(1);
+    expect(result.statChanges[0].target).toBe("attacker");
+    expect(result.statChanges[0].stages).toBe(2);
+    // First boostable stat alphabetically in our array is "attack"
+    expect(result.statChanges[0].stat).toBe("attack");
+  });
+
+  it("given all stats are at +6, when Acupressure is used, then it fails", () => {
+    // Source: Showdown Gen 4 mod -- Acupressure fails when all stats maxed
+    const attacker = createActivePokemon({
+      types: ["normal"],
+      statStages: {
+        attack: 6,
+        defense: 6,
+        spAttack: 6,
+        spDefense: 6,
+        speed: 6,
+        accuracy: 6,
+        evasion: 6,
+      },
+    });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("acupressure");
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.statChanges).toHaveLength(0);
+    expect(result.messages).toContain("But it failed!");
+  });
+
+  it("given only speed is below +6, when Acupressure is used, then speed is boosted by +2", () => {
+    // Source: Showdown Gen 4 mod -- only non-maxed stats are eligible
+    const attacker = createActivePokemon({
+      types: ["normal"],
+      statStages: {
+        attack: 6,
+        defense: 6,
+        spAttack: 6,
+        spDefense: 6,
+        speed: 4,
+        accuracy: 6,
+        evasion: 6,
+      },
+    });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("acupressure");
+    // rng.int returns 0, only boostable stat is speed
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.statChanges).toHaveLength(1);
+    expect(result.statChanges[0].stat).toBe("speed");
+    expect(result.statChanges[0].stages).toBe(2);
+  });
+});
+
+// ===========================================================================
+// Power Swap
+// ===========================================================================
+
+describe("Power Swap", () => {
+  it("given attacker has +2 Atk and defender has -1 SpAtk, when Power Swap is used, then Atk and SpAtk stages are swapped", () => {
+    // Source: Bulbapedia -- Power Swap swaps Atk and SpAtk stat stages
+    // Source: Showdown Gen 4 mod -- Power Swap exchanges offensive stat changes
+    const attacker = createActivePokemon({
+      types: ["psychic"],
+      statStages: { attack: 2, spAttack: 0 },
+    });
+    const defender = createActivePokemon({
+      types: ["normal"],
+      statStages: { attack: 0, spAttack: -1 },
+    });
+    const move = createMove("power-swap", { type: "psychic" });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    executeGen4MoveEffect(ctx);
+
+    expect(attacker.statStages.attack).toBe(0);
+    expect(attacker.statStages.spAttack).toBe(-1);
+    expect(defender.statStages.attack).toBe(2);
+    expect(defender.statStages.spAttack).toBe(0);
+  });
+
+  it("given both have zero stages, when Power Swap is used, then stages remain zero", () => {
+    // Source: Showdown Gen 4 mod -- Power Swap with no changes is a no-op swap
+    const attacker = createActivePokemon({ types: ["psychic"] });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("power-swap", { type: "psychic" });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(attacker.statStages.attack).toBe(0);
+    expect(attacker.statStages.spAttack).toBe(0);
+    expect(defender.statStages.attack).toBe(0);
+    expect(defender.statStages.spAttack).toBe(0);
+    expect(result.messages.length).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+// Guard Swap
+// ===========================================================================
+
+describe("Guard Swap", () => {
+  it("given attacker has +3 Def and defender has -2 SpDef, when Guard Swap is used, then Def and SpDef stages are swapped", () => {
+    // Source: Bulbapedia -- Guard Swap swaps Def and SpDef stat stages
+    // Source: Showdown Gen 4 mod -- Guard Swap exchanges defensive stat changes
+    const attacker = createActivePokemon({
+      types: ["psychic"],
+      statStages: { defense: 3, spDefense: 0 },
+    });
+    const defender = createActivePokemon({
+      types: ["normal"],
+      statStages: { defense: 0, spDefense: -2 },
+    });
+    const move = createMove("guard-swap", { type: "psychic" });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    executeGen4MoveEffect(ctx);
+
+    expect(attacker.statStages.defense).toBe(0);
+    expect(attacker.statStages.spDefense).toBe(-2);
+    expect(defender.statStages.defense).toBe(3);
+    expect(defender.statStages.spDefense).toBe(0);
+  });
+
+  it("given attacker has -1 Def and +2 SpDef and defender has +1 Def and -3 SpDef, when Guard Swap is used, then both stats swap correctly", () => {
+    // Source: Showdown Gen 4 mod -- Guard Swap swaps all defensive stages
+    const attacker = createActivePokemon({
+      types: ["psychic"],
+      statStages: { defense: -1, spDefense: 2 },
+    });
+    const defender = createActivePokemon({
+      types: ["normal"],
+      statStages: { defense: 1, spDefense: -3 },
+    });
+    const move = createMove("guard-swap", { type: "psychic" });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    executeGen4MoveEffect(ctx);
+
+    expect(attacker.statStages.defense).toBe(1);
+    expect(attacker.statStages.spDefense).toBe(-3);
+    expect(defender.statStages.defense).toBe(-1);
+    expect(defender.statStages.spDefense).toBe(2);
+  });
+});
+
+// ===========================================================================
+// Heart Swap
+// ===========================================================================
+
+describe("Heart Swap", () => {
+  it("given attacker has various stages and defender has different stages, when Heart Swap is used, then ALL stat stages are swapped", () => {
+    // Source: Bulbapedia -- Heart Swap: "swaps all stat changes with the target"
+    // Source: Showdown Gen 4 mod -- Heart Swap swaps every stat stage
+    const attacker = createActivePokemon({
+      types: ["psychic"],
+      statStages: {
+        attack: 2,
+        defense: -1,
+        spAttack: 3,
+        spDefense: 0,
+        speed: 1,
+        accuracy: -2,
+        evasion: 0,
+      },
+    });
+    const defender = createActivePokemon({
+      types: ["normal"],
+      statStages: {
+        attack: -3,
+        defense: 1,
+        spAttack: 0,
+        spDefense: 2,
+        speed: -1,
+        accuracy: 0,
+        evasion: 1,
+      },
+    });
+    const move = createMove("heart-swap", { type: "psychic" });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    executeGen4MoveEffect(ctx);
+
+    // Attacker now has defender's old stages
+    expect(attacker.statStages.attack).toBe(-3);
+    expect(attacker.statStages.defense).toBe(1);
+    expect(attacker.statStages.spAttack).toBe(0);
+    expect(attacker.statStages.spDefense).toBe(2);
+    expect(attacker.statStages.speed).toBe(-1);
+    expect(attacker.statStages.accuracy).toBe(0);
+    expect(attacker.statStages.evasion).toBe(1);
+    // Defender now has attacker's old stages
+    expect(defender.statStages.attack).toBe(2);
+    expect(defender.statStages.defense).toBe(-1);
+    expect(defender.statStages.spAttack).toBe(3);
+    expect(defender.statStages.spDefense).toBe(0);
+    expect(defender.statStages.speed).toBe(1);
+    expect(defender.statStages.accuracy).toBe(-2);
+    expect(defender.statStages.evasion).toBe(0);
+  });
+
+  it("given both have zero stages, when Heart Swap is used, then stages remain zero and message is emitted", () => {
+    // Source: Showdown Gen 4 mod -- Heart Swap still succeeds even with no changes
+    const attacker = createActivePokemon({ types: ["psychic"], nickname: "Manaphy" });
+    const defender = createActivePokemon({ types: ["normal"] });
+    const move = createMove("heart-swap", { type: "psychic" });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.messages).toContain("Manaphy swapped all stat changes with the target!");
+  });
+});
+
+// ===========================================================================
+// Curse (Ghost-type)
+// ===========================================================================
+
+describe("Curse (Ghost-type)", () => {
+  it("given Ghost-type attacker uses Curse, when executed, then attacker takes 1/2 max HP and target gets curse volatile", () => {
+    // Source: Bulbapedia -- Curse (Ghost): "user loses half its maximum HP, target is cursed"
+    // Source: Showdown Gen 4 mod -- Ghost Curse: 1/2 HP cost, curse volatile on target
+    const attacker = createActivePokemon({
+      types: ["ghost"],
+      nickname: "Gengar",
+      maxHp: 200,
+      currentHp: 200,
+    });
+    const defender = createActivePokemon({ types: ["normal"], nickname: "Snorlax" });
+    const move = createMove("curse", {
+      type: "ghost",
+      effect: { type: "volatile-status", status: "curse", chance: 100 },
+    });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    // HP cost = floor(200 / 2) = 100
+    expect(result.customDamage).toEqual({
+      target: "attacker",
+      amount: 100,
+      source: "curse",
+    });
+    expect(result.volatileInflicted).toBe("curse");
+    expect(result.messages).toContain("Gengar cut its own HP and laid a curse on Snorlax!");
+  });
+
+  it("given target already has curse volatile, when Ghost Curse is used, then it fails", () => {
+    // Source: Showdown Gen 4 mod -- Curse fails if target already cursed
+    const attacker = createActivePokemon({ types: ["ghost"] });
+    const volatiles = new Map<string, { turnsLeft: number }>();
+    volatiles.set("curse", { turnsLeft: -1 });
+    const defender = createActivePokemon({ types: ["normal"], volatiles });
+    const move = createMove("curse", {
+      type: "ghost",
+      effect: { type: "volatile-status", status: "curse", chance: 100 },
+    });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.volatileInflicted).toBeNull();
+    expect(result.messages).toContain("But it failed!");
+  });
+});
+
+// ===========================================================================
+// Sticky Barb
+// ===========================================================================
+
+describe("Sticky Barb", () => {
+  it("given holder has Sticky Barb, when end-of-turn triggers, then holder takes 1/8 max HP damage", () => {
+    // Source: Bulbapedia -- Sticky Barb: "1/8 of its maximum HP at the end of every turn"
+    // Source: Showdown Gen 4 mod -- Sticky Barb EoT chip
+    const pokemon = createActivePokemon({
+      types: ["normal"],
+      heldItem: "sticky-barb",
+      maxHp: 200,
+      currentHp: 200,
+      nickname: "Holder",
+    });
+    const state = createMinimalBattleState(pokemon, createActivePokemon({ types: ["normal"] }));
+    const rng = createMockRng(0);
+
+    const result = applyGen4HeldItem("end-of-turn", {
+      pokemon,
+      state,
+      rng,
+    });
+
+    expect(result.activated).toBe(true);
+    // floor(200 / 8) = 25
+    expect(result.effects).toEqual([{ type: "none", target: "self", value: -25 }]);
+    expect(result.messages).toContain("Holder was hurt by its Sticky Barb!");
+  });
+
+  it("given holder has 16 max HP with Sticky Barb, when end-of-turn triggers, then holder takes floor(16/8)=2 damage", () => {
+    // Source: Showdown Gen 4 mod -- Sticky Barb damage is floor(maxHP/8)
+    const pokemon = createActivePokemon({
+      types: ["normal"],
+      heldItem: "sticky-barb",
+      maxHp: 16,
+      currentHp: 16,
+    });
+    const state = createMinimalBattleState(pokemon, createActivePokemon({ types: ["normal"] }));
+    const rng = createMockRng(0);
+
+    const result = applyGen4HeldItem("end-of-turn", {
+      pokemon,
+      state,
+      rng,
+    });
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toEqual([{ type: "none", target: "self", value: -2 }]);
+  });
+});
+
+// ===========================================================================
+// Berry Juice
+// ===========================================================================
+
+describe("Berry Juice", () => {
+  it("given holder has Berry Juice and HP at 50%, when end-of-turn triggers, then holder heals 20 HP and Berry Juice is consumed", () => {
+    // Source: Bulbapedia -- Berry Juice: "Restores 20 HP when HP drops to 50% or below"
+    // Source: Showdown Gen 4 mod -- Berry Juice trigger at 50%
+    const pokemon = createActivePokemon({
+      types: ["normal"],
+      heldItem: "berry-juice",
+      maxHp: 200,
+      currentHp: 100, // 50% exactly
+      nickname: "Holder",
+    });
+    const state = createMinimalBattleState(pokemon, createActivePokemon({ types: ["normal"] }));
+    const rng = createMockRng(0);
+
+    const result = applyGen4HeldItem("end-of-turn", {
+      pokemon,
+      state,
+      rng,
+    });
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toEqual([
+      { type: "heal", target: "self", value: 20 },
+      { type: "consume", target: "self", value: "berry-juice" },
+    ]);
+    expect(result.messages).toContain("Holder's Berry Juice restored 20 HP!");
+  });
+
+  it("given holder has Berry Juice and HP above 50%, when end-of-turn triggers, then Berry Juice does not activate", () => {
+    // Source: Showdown Gen 4 mod -- Berry Juice only triggers at <=50%
+    const pokemon = createActivePokemon({
+      types: ["normal"],
+      heldItem: "berry-juice",
+      maxHp: 200,
+      currentHp: 101, // Above 50%
+    });
+    const state = createMinimalBattleState(pokemon, createActivePokemon({ types: ["normal"] }));
+    const rng = createMockRng(0);
+
+    const result = applyGen4HeldItem("end-of-turn", {
+      pokemon,
+      state,
+      rng,
+    });
+
+    expect(result.activated).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Grip Claw (binding moves)
+// ===========================================================================
+
+describe("Grip Claw and Binding Moves", () => {
+  it("given attacker holds Grip Claw, when using Bind, then binding lasts 7 turns", () => {
+    // Source: Bulbapedia -- Grip Claw: "Extends the duration of binding moves to 7 turns"
+    // Source: Showdown Gen 4 mod -- Grip Claw sets binding to 7 turns
+    const attacker = createActivePokemon({
+      types: ["normal"],
+      heldItem: "grip-claw",
+    });
+    const defender = createActivePokemon({ types: ["normal"], nickname: "Target" });
+    const move = createMove("bind", { type: "normal", category: "physical", power: 15 });
+    const rng = createMockRng(4); // Would be 4 normally, but Grip Claw overrides
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.volatileInflicted).toBe("bound");
+    expect(result.volatileData).toEqual({ turnsLeft: 7 });
+  });
+
+  it("given attacker does NOT hold Grip Claw, when using Fire Spin, then binding lasts 4-5 turns based on RNG", () => {
+    // Source: Bulbapedia -- Binding moves last 4-5 turns in Gen 4
+    // Source: Showdown Gen 4 mod -- binding duration is rng.int(4, 5) without Grip Claw
+    const attacker = createActivePokemon({ types: ["fire"] });
+    const defender = createActivePokemon({ types: ["normal"], nickname: "Foe" });
+    const move = createMove("fire-spin", { type: "fire", category: "special", power: 15 });
+    // rng.int returns 4 (min of range)
+    const rng = createMockRng(4);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.volatileInflicted).toBe("bound");
+    expect(result.volatileData).toEqual({ turnsLeft: 4 });
+  });
+
+  it("given target already has bound volatile, when binding move is used, then no additional binding is applied", () => {
+    // Source: Showdown Gen 4 mod -- cannot stack binding moves
+    const attacker = createActivePokemon({ types: ["normal"] });
+    const volatiles = new Map<string, { turnsLeft: number }>();
+    volatiles.set("bound", { turnsLeft: 3 });
+    const defender = createActivePokemon({ types: ["normal"], volatiles });
+    const move = createMove("wrap", { type: "normal", category: "physical", power: 15 });
+    const rng = createMockRng(4);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    const result = executeGen4MoveEffect(ctx);
+
+    expect(result.volatileInflicted).toBeNull();
+  });
+});
+
+// ===========================================================================
+// Gluttony
+// ===========================================================================
+
+describe("Gluttony", () => {
+  it("given normal fraction 0.25, when holder has Gluttony, then threshold becomes 0.5", () => {
+    // Source: Bulbapedia -- Gluttony: "eats Berry at 50% HP instead of 25%"
+    // Source: Showdown data/abilities.ts -- Gluttony modifies pinch berry threshold
+    const result = getPinchBerryThreshold({ ability: "gluttony" }, 0.25);
+    expect(result).toBe(0.5);
+  });
+
+  it("given normal fraction 0.25, when holder does NOT have Gluttony, then threshold stays 0.25", () => {
+    // Source: Showdown data/abilities.ts -- non-Gluttony Pokemon use normal threshold
+    const result = getPinchBerryThreshold({ ability: "blaze" }, 0.25);
+    expect(result).toBe(0.25);
+  });
+
+  it("given normal fraction 0.5, when holder has Gluttony, then threshold stays 0.5 (Gluttony only affects 25% berries)", () => {
+    // Source: Bulbapedia -- Gluttony only affects berries with 25% threshold
+    // Sitrus Berry already activates at 50%, unaffected by Gluttony
+    const result = getPinchBerryThreshold({ ability: "gluttony" }, 0.5);
+    expect(result).toBe(0.5);
+  });
+});
+
+// ===========================================================================
+// Unburden
+// ===========================================================================
+
+describe("Unburden", () => {
+  it("given holder has Unburden and consumed berry, when getEffectiveSpeed is called, then speed is doubled", () => {
+    // Source: Bulbapedia -- Unburden: "Doubles Speed when held item is consumed/lost"
+    // Source: Showdown data/abilities.ts -- Unburden onModifySpe
+    const ruleset = new Gen4Ruleset();
+    const volatiles = new Map<string, { turnsLeft: number }>();
+    volatiles.set("unburden", { turnsLeft: -1 });
+    const pokemon = createActivePokemon({
+      types: ["normal"],
+      ability: "unburden",
+      heldItem: null, // Item already consumed
+      volatiles,
+    });
+
+    // Access protected method via casting or through resolveTurnOrder
+    // We test through the speed ordering mechanism
+    const opponentAction = {
+      type: "move" as const,
+      side: 1 as 0 | 1,
+      moveIndex: 0,
+      targets: [0 as 0 | 1],
+    };
+    const unburdenAction = {
+      type: "move" as const,
+      side: 0 as 0 | 1,
+      moveIndex: 0,
+      targets: [1 as 0 | 1],
+    };
+
+    // Create a slower opponent (speed 300) -- unburden pokemon has speed 100 * 2 = 200
+    const opponent = createActivePokemon({
+      types: ["normal"],
+      maxHp: 200,
+      currentHp: 200,
+    });
+    (opponent.pokemon.calculatedStats as { speed: number }).speed = 300;
+
+    const state = createMinimalBattleState(pokemon, opponent);
+    const rng = createMockRng(0);
+    const actions = [unburdenAction, opponentAction];
+
+    const ordered = ruleset.resolveTurnOrder(actions, state, rng);
+
+    // Opponent (speed 300) should still be faster than unburden (100 * 2 = 200)
+    expect(ordered[0].side).toBe(1);
+    expect(ordered[1].side).toBe(0);
+  });
+
+  it("given holder has Unburden volatile but still holds an item, when getEffectiveSpeed is called, then speed is NOT doubled", () => {
+    // Source: Showdown data/abilities.ts -- Unburden only active when item is absent
+    const ruleset = new Gen4Ruleset();
+    const volatiles = new Map<string, { turnsLeft: number }>();
+    volatiles.set("unburden", { turnsLeft: -1 });
+    const pokemon = createActivePokemon({
+      types: ["normal"],
+      ability: "unburden",
+      heldItem: "leftovers", // Still has item
+      volatiles,
+    });
+
+    const opponent = createActivePokemon({
+      types: ["normal"],
+      maxHp: 200,
+      currentHp: 200,
+    });
+    // Set opponent speed to 150 -- if Unburden triggers, pokemon would have 200 speed
+    // and go first. If Unburden does NOT trigger, pokemon has 100 speed and goes second.
+    (opponent.pokemon.calculatedStats as { speed: number }).speed = 150;
+
+    const state = createMinimalBattleState(pokemon, opponent);
+    const rng = createMockRng(0);
+
+    const opponentAction = {
+      type: "move" as const,
+      side: 1 as 0 | 1,
+      moveIndex: 0,
+      targets: [0 as 0 | 1],
+    };
+    const unburdenAction = {
+      type: "move" as const,
+      side: 0 as 0 | 1,
+      moveIndex: 0,
+      targets: [1 as 0 | 1],
+    };
+
+    const ordered = ruleset.resolveTurnOrder([unburdenAction, opponentAction], state, rng);
+
+    // Opponent (150) faster than pokemon (100, Unburden NOT active because it has an item)
+    expect(ordered[0].side).toBe(1);
+    expect(ordered[1].side).toBe(0);
+  });
+
+  it("given berry is consumed and holder has Unburden, when item trigger fires, then unburden volatile is set", () => {
+    // Source: Showdown Gen 4 mod -- Unburden volatile set when item is consumed
+    const pokemon = createActivePokemon({
+      types: ["normal"],
+      ability: "unburden",
+      heldItem: "sitrus-berry",
+      maxHp: 200,
+      currentHp: 80, // Below 50%
+    });
+    const state = createMinimalBattleState(pokemon, createActivePokemon({ types: ["normal"] }));
+    const rng = createMockRng(0);
+
+    applyGen4HeldItem("end-of-turn", { pokemon, state, rng });
+
+    expect(pokemon.volatileStatuses.has("unburden")).toBe(true);
+  });
+
+  it("given Knock Off removes defender's item and defender has Unburden, then unburden volatile is set", () => {
+    // Source: Showdown Gen 4 mod -- Unburden triggers on Knock Off
+    const attacker = createActivePokemon({ types: ["dark"] });
+    const defender = createActivePokemon({
+      types: ["normal"],
+      ability: "unburden",
+      heldItem: "leftovers",
+    });
+    const move = createMove("knock-off", { type: "dark", category: "physical", power: 20 });
+    const rng = createMockRng(0);
+    const ctx = createContext(attacker, defender, move, rng);
+
+    executeGen4MoveEffect(ctx);
+
+    expect(defender.pokemon.heldItem).toBeNull();
+    expect(defender.volatileStatuses.has("unburden")).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Magnet Rise -- Ground immunity in damage calc
+// ===========================================================================
+
+describe("Magnet Rise Ground immunity", () => {
+  it("given defender has magnet-rise volatile, when hit by Ground move, then damage is 0", () => {
+    // Source: Bulbapedia -- Magnet Rise: "makes the user immune to Ground-type moves"
+    // Source: Showdown Gen 4 mod -- Magnet Rise grants Ground immunity
+
+    const volatiles = new Map<string, { turnsLeft: number }>();
+    volatiles.set("magnet-rise", { turnsLeft: 3 });
+
+    const attacker = createActivePokemon({ types: ["ground"], maxHp: 200 });
+    const defender = createActivePokemon({ types: ["electric"], volatiles, maxHp: 200 });
+
+    const move = createMove("earthquake", {
+      type: "ground",
+      category: "physical",
+      power: 100,
+    });
+
+    const rng = createMockRng(100);
+    const state = createMinimalBattleState(attacker, defender);
+
+    const result = calculateGen4Damage(
+      {
+        attacker,
+        defender,
+        move,
+        state,
+        rng,
+        isCrit: false,
+      },
+      GEN4_TYPE_CHART,
+    );
+
+    expect(result.damage).toBe(0);
+    expect(result.effectiveness).toBe(0);
+  });
+
+  it("given defender has magnet-rise volatile but Gravity is active, when hit by Ground move, then damage is NOT 0", () => {
+    // Source: Bulbapedia -- Gravity suppresses Magnet Rise
+    // Source: Showdown Gen 4 mod -- Gravity grounds Magnet Rise users
+
+    const volatiles = new Map<string, { turnsLeft: number }>();
+    volatiles.set("magnet-rise", { turnsLeft: 3 });
+
+    const attacker = createActivePokemon({ types: ["ground"], maxHp: 200 });
+    const defender = createActivePokemon({ types: ["electric"], volatiles, maxHp: 200 });
+
+    const move = createMove("earthquake", {
+      type: "ground",
+      category: "physical",
+      power: 100,
+    });
+
+    const rng = createMockRng(100);
+    const state = {
+      ...createMinimalBattleState(attacker, defender),
+      gravity: { active: true, turnsLeft: 3 },
+    } as BattleState;
+
+    const result = calculateGen4Damage(
+      {
+        attacker,
+        defender,
+        move,
+        state,
+        rng,
+        isCrit: false,
+      },
+      GEN4_TYPE_CHART,
+    );
+
+    // Ground move should hit because Gravity is active
+    expect(result.damage).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Move effects**: Magnet Rise (5-turn Ground immunity), Acupressure (+2 random stat), Power Swap, Guard Swap, Heart Swap (stat stage swapping), Curse (Ghost-type fix with 1/2 HP cost + curse volatile), binding moves (Bind, Wrap, Fire Spin, Clamp, Whirlpool, Sand Tomb, Magma Storm)
- **Items**: Sticky Barb (1/8 HP EoT damage), Berry Juice (heal 20 HP at <=50%), Grip Claw (binding moves last 7 turns)
- **Abilities**: Gluttony (berry threshold infrastructure via `getPinchBerryThreshold`), Unburden (2x Speed after item consumed/lost -- triggers on berry consumption, Knock Off, and Trick/Switcheroo)
- **Infrastructure**: Magnet Rise EoT countdown, `magnet-rise-countdown` EndOfTurnEffect type, Magnet Rise Ground immunity in damage calc (not bypassed by Mold Breaker), `unburden` volatile status type

## Files changed

- `packages/core/src/entities/status.ts` -- added "unburden" to VolatileStatus union
- `packages/battle/src/context/types.ts` -- added "magnet-rise-countdown" to EndOfTurnEffect
- `packages/battle/src/engine/BattleEngine.ts` -- Magnet Rise EoT countdown handler
- `packages/gen4/src/Gen4DamageCalc.ts` -- Magnet Rise Ground immunity check
- `packages/gen4/src/Gen4Items.ts` -- Sticky Barb, Berry Juice, Gluttony helper, Unburden item triggers
- `packages/gen4/src/Gen4MoveEffects.ts` -- Magnet Rise, Acupressure, stat swaps, Curse Ghost, binding moves, Unburden triggers on Knock Off/Trick/Switcheroo
- `packages/gen4/src/Gen4Ruleset.ts` -- Unburden speed doubling, Magnet Rise grounding check, EoT ordering
- `packages/gen4/tests/wave6a-moves-items.test.ts` -- 30 new tests
- `packages/gen4/tests/ruleset.test.ts` -- updated EoT order test (33 -> 34 effects)

## Test plan

- [x] All 866 Gen4 tests pass
- [x] All 343 battle tests pass
- [x] TypeScript typecheck clean
- [x] Biome lint/format clean (no project errors)
- [x] 30 new tests covering all implemented mechanics

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Gen 4 Wave 6A support: Magnet Rise (grants Ground immunity), Acupressure, stat-swap moves, Curse (Ghost-type variant), binding move improvements with Grip Claw, Sticky Barb, Berry Juice, and Unburden/Gluttony ability mechanics.

* **Tests**
  * Added comprehensive test suite covering Wave 6A moves, items, and abilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->