### PR TITLE
chore(gen1,gen2): add missing changesets for flee and bag item methods

### DIFF
--- a/.changeset/gen1-flee-bag-items.md
+++ b/.changeset/gen1-flee-bag-items.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/gen1": minor
+---
+
+Implement Gen 1 flee formula (rollFleeSuccess) and bag item interface stubs (canUseBagItems, applyBagItem)

--- a/.changeset/gen2-flee-bag-items.md
+++ b/.changeset/gen2-flee-bag-items.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/gen2": minor
+---
+
+Implement Gen 2 flee formula (rollFleeSuccess) and bag item interface stubs (canUseBagItems, applyBagItem)


### PR DESCRIPTION
## Summary

- Adds missing changeset for `@pokemon-lib-ts/gen1` (minor) covering `rollFleeSuccess()`, `canUseBagItems()`, and `applyBagItem()` added in PRs #242 and #243
- Adds missing changeset for `@pokemon-lib-ts/gen2` (minor) covering the same methods

These PRs only included changesets for `@pokemon-lib-ts/battle` but also modified gen1 and gen2 source files with new exported behavior.

## Test plan

- [ ] No code changes -- only `.changeset/` markdown files added
- [ ] CI passes (biome, typecheck, tests unaffected)

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)