### PR TITLE
fix(gen3): correct integration test assertions for damage sides and rain OHKO

### DIFF
--- a/.changeset/gen3-integration-test-fixes.md
+++ b/.changeset/gen3-integration-test-fixes.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/gen3": patch
+---
+
+Fix Gen 3 integration test assertions: correct side-assignment for damage events (Blaziken=side0, Swampert=side1) and fix rain OHKO assertion to check currentHp=0 and amount>=maxHp instead of amount===maxHp (raw damage can exceed HP on OHKO).

--- a/packages/gen3/tests/integration/full-battle.test.ts
+++ b/packages/gen3/tests/integration/full-battle.test.ts
@@ -348,28 +348,28 @@ describe("Gen 3 Full Battle Integration", () => {
     engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
 
     // Assert: both moves deal damage so exactly 2 damage events (one per attacker)
-    // Surf is 4x effective vs Blaziken (Water vs Fire/Fighting); Flamethrower vs Swampert is 0.5x
+    // Surf is 2x effective vs Blaziken (Water→Fire = 2×, Water→Fighting = 1×); Flamethrower vs Swampert is 0.5x
     const events = engine.getEventLog();
     const damageEvents = events.filter((e) => e.type === "damage");
     // Both moves hit — expect exactly 2 combat damage events this turn
     expect(damageEvents.length).toBe(2);
 
-    // Surf hits Blaziken (side 1 = Blaziken with maxHp=155)
-    // Flamethrower hits Swampert (side 0 = Swampert is the defender when side 1 attacks, so side 0 takes damage)
-    // Sort damage events by side: side 0 = Swampert is defender (Blaziken attacks it), side 1 = Blaziken is defender (Swampert attacks it)
-    // Note: damage event side = the side that takes damage
+    // damage event side = the side that takes damage
+    // team1 = Blaziken (side 0), team2 = Swampert (side 1)
+    // Swampert's Surf hits Blaziken → side 0 takes damage (maxHp = 155)
+    // Blaziken's Flamethrower hits Swampert → side 1 takes damage (maxHp = 175)
     const side0Damage = damageEvents.find((e) => e.type === "damage" && e.side === 0);
     const side1Damage = damageEvents.find((e) => e.type === "damage" && e.side === 1);
 
     // Blaziken (side 0) takes Surf damage — Blaziken maxHp = 155
     // Source: HP formula: floor((2*80+31)*50/100)+60 = 155
-    expect(side1Damage?.type === "damage" ? side1Damage.maxHp : undefined).toBe(155);
-    expect(side1Damage?.type === "damage" ? side1Damage.amount : undefined).toBeGreaterThan(0);
+    expect(side0Damage?.type === "damage" ? side0Damage.maxHp : undefined).toBe(155);
+    expect(side0Damage?.type === "damage" ? side0Damage.amount : undefined).toBeGreaterThan(0);
 
     // Swampert (side 1) takes Flamethrower damage — Swampert maxHp = 175
     // Source: HP formula: floor((2*100+31)*50/100)+60 = 175
-    expect(side0Damage?.type === "damage" ? side0Damage.maxHp : undefined).toBe(175);
-    expect(side0Damage?.type === "damage" ? side0Damage.amount : undefined).toBeGreaterThan(0);
+    expect(side1Damage?.type === "damage" ? side1Damage.maxHp : undefined).toBe(175);
+    expect(side1Damage?.type === "damage" ? side1Damage.amount : undefined).toBeGreaterThan(0);
   });
 
   it("given a Gen 3 battle, when moves execute, then move-start events are emitted", () => {
@@ -570,11 +570,11 @@ describe("Gen 3 Weather Integration", () => {
     engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 }); // surf
     engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 }); // flamethrower
 
-    // Assert: Rain boosts Surf (Water) 1.5x and Blaziken is 4x weak to Water (Fire/Fighting)
+    // Assert: Rain boosts Surf (Water) 1.5x; Blaziken is 2x weak to Water (Water→Fire = 2×, Water→Fighting = 1×)
     // Source: pret/pokeemerald — rain multiplies Water damage by 1.5x; type effectiveness stacks
     // Speed comparison: Kyogre base speed=90 (eff. 110 at L50) vs Blaziken base speed=80 (eff. 100)
-    // Kyogre goes first; Surf (4x effective + 1.5x rain) OHKOs Blaziken before Flamethrower fires
-    // Formula: Kyogre L50 SpAtk vs Blaziken L50 Def, Water vs Fire/Fighting (×4), rain ×1.5 → OHKO
+    // Kyogre goes first; Surf (2x effective × 1.5x rain) OHKOs Blaziken before Flamethrower fires
+    // Formula: Kyogre L50 SpAtk (200) vs Blaziken L50 SpDef (90), power 95, 2× type × 1.5× rain → OHKO
     const events = engine.getEventLog();
     const damageEvents = events.filter((e) => e.type === "damage");
     // Kyogre OHKOs Blaziken with Surf before Flamethrower executes → exactly 1 damage event
@@ -586,10 +586,13 @@ describe("Gen 3 Weather Integration", () => {
     if (surfDamage?.type === "damage") {
       // Surf hits Blaziken (side 1)
       expect(surfDamage.side).toBe(1);
-      // Blaziken HP = 155 (floor((2*80+31)*50/100)+60 = 155); OHKO means amount = full HP
-      // Source: HP formula from pret/pokeemerald; an OHKO must deal exactly the target's full HP
+      // Blaziken HP = 155 (floor((2*80+31)*50/100)+60 = 155)
+      // Source: HP formula from pret/pokeemerald
       expect(surfDamage.maxHp).toBe(155);
-      expect(surfDamage.amount).toBe(155);
+      // OHKO: currentHp = 0 after damage (Surf exceeds Blaziken's HP)
+      expect(surfDamage.currentHp).toBe(0);
+      // Damage must exceed Blaziken's HP (OHKO) — rain×1.5 × type×2 produces overkill
+      expect(surfDamage.amount).toBeGreaterThanOrEqual(155);
     }
   });
 


### PR DESCRIPTION
## Summary
- Fixes reversed side-assignment in damage event assertions (Blaziken = side 0, Swampert = side 1 — was swapped in test)
- Fixes rain OHKO assertion: asserts `currentHp === 0` and `amount >= maxHp` since raw damage exceeds HP (overkill); `amount === 155` always fails when damage is unclamped

Both bugs were introduced in PR #490 and block CI on all subsequent PRs.

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed damage event side team assignments in Gen 3 damage calculations to ensure damage is correctly attributed to the appropriate Pokémon during multi-Pokémon battles
  * Updated rain OHKO damage validation to correctly handle overkill scenarios where inflicted damage exceeds the target's maximum HP

<!-- end of auto-generated comment: release notes by coderabbit.ai -->