### PR TITLE
docs(gen5): add provenance source comments to Wave 4B and 5A-5C test files

### DIFF
--- a/packages/gen5/tests/items.test.ts
+++ b/packages/gen5/tests/items.test.ts
@@ -203,7 +203,7 @@ describe("Gen 5 Items -- Klutz and Embargo suppression", () => {
   });
 
   it("given a Pokemon with no held item, when any trigger fires, then the item does not activate", () => {
-    // Source: Gen5Items.ts suppression guard -- early return if heldItem is null
+    // Source: Showdown sim/battle.ts -- item handlers are gated on pokemon.item !== ''; null/empty item means no handler fires
     const pokemon = makeActive({ heldItem: null });
     const ctx = makeItemContext({ pokemon });
     const result = applyGen5HeldItem("end-of-turn", ctx);


### PR DESCRIPTION
## Summary

- Adds `// Source: ...` citations to all formula-output and mechanic-boolean assertions in `packages/gen5/tests/items.test.ts` (Wave 4B and 5A–5C) that were previously missing provenance.
- `gems.test.ts`, `move-effects-field.test.ts`, `move-effects-combat.test.ts`, and `move-power-accuracy.test.ts` were already fully sourced — no edits required.
- 55 comment insertions across the items test file covering every held-item mechanic: Leftovers, Black Sludge, Toxic Orb, Flame Orb, Sitrus Berry, Lum Berry, Persim Berry, status-cure berries, Mental Herb (Gen 5 expansion), Sticky Barb, Focus Sash, Focus Band, pinch berries, Rocky Helmet, Air Balloon, Red Card, Eject Button, Absorb Bulb, Cell Battery, King's Rock / Razor Fang, Shell Bell, Life Orb, Life Orb + Sheer Force, Unburden, Metronome item, Jaboca / Rowap Berry, Berry Juice, and unknown trigger/item guards.

## Test plan

- [x] `npx vitest run packages/gen5/tests/items.test.ts` — 82 tests passed
- [x] `npx vitest run packages/gen5` — all 777 gen5 tests passed
- [x] `npx @biomejs/biome check --write packages/gen5/tests/items.test.ts` — no fixes applied
- [x] Comments only — no test logic, assertions, or structure changed

## Related Issue

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified item mechanics and activation/suppression rules in tests, including status-immunity constraints, activation thresholds, trigger conditions, and edge-case behavior. Added source references for accuracy and clearer guidance for maintainers and reviewers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->