### PR TITLE
test(gen4): bughunt audit -- regression tests for abilities, items, and move effects

### DIFF
--- a/packages/gen4/tests/bughunt-gen4-audit.test.ts
+++ b/packages/gen4/tests/bughunt-gen4-audit.test.ts
@@ -763,7 +763,7 @@ describe("Gen4MoveEffects — Wonder Room and Magic Room are Gen 5+ only", () =>
     const result = ruleset.executeMoveEffect(context);
 
     // Wonder Room should not set any special field state in Gen 4
-    expect(result.trickRoomSet).toBeFalsy();
+    expect(result.trickRoomSet).toBe(undefined);
     // No special messages about swapping defense/sp defense should appear
     expect(result.messages.every((m) => !m.toLowerCase().includes("wonder room"))).toBe(true);
   });
@@ -820,7 +820,7 @@ describe("Gen4MoveEffects — Wonder Room and Magic Room are Gen 5+ only", () =>
     const result = ruleset.executeMoveEffect(context);
 
     // Magic Room should not set any special field state in Gen 4
-    expect(result.trickRoomSet).toBeFalsy();
+    expect(result.trickRoomSet).toBe(undefined);
     expect(result.messages.every((m) => !m.toLowerCase().includes("magic room"))).toBe(true);
   });
 });
@@ -872,7 +872,7 @@ describe("Gen4MoveEffects Trick/Switcheroo — Klutz holder can swap items", () 
     // Per Showdown: Klutz holders can use Trick to give away or receive items; Klutz only prevents
     // the item's battle effect (stat boost, berry activation, etc.)
     const trickMove = dataManager.getMove("trick");
-    if (!trickMove) return; // skip if move data unavailable
+    expect(trickMove).toBeDefined(); // fail fast if move data is missing — that would be a regression
 
     const attacker = createActivePokemon({ ability: "klutz", types: ["normal"] });
     attacker.pokemon.heldItem = "life-orb"; // Klutz holder with an item to swap
@@ -883,7 +883,8 @@ describe("Gen4MoveEffects Trick/Switcheroo — Klutz holder can swap items", () 
     const context = {
       attacker,
       defender,
-      move: trickMove,
+      // biome-ignore lint/style/noNonNullAssertion: asserted above via expect()
+      move: trickMove!,
       damage: 0,
       state,
       rng: createMockRng(),
@@ -894,5 +895,35 @@ describe("Gen4MoveEffects Trick/Switcheroo — Klutz holder can swap items", () 
     // Items should be swapped: attacker gets choice-band, defender gets life-orb
     expect(attacker.pokemon.heldItem).toBe("choice-band");
     expect(defender.pokemon.heldItem).toBe("life-orb");
+  });
+
+  it("given a Klutz attacker holding no item using Trick against a defender holding Leftovers, when Trick is executed, then items are swapped (null for item)", () => {
+    // Source: Showdown Gen 4 mod — Klutz does not block Trick/Switcheroo even when attacker has no item
+    // Triangulates: attacker starts with null item, defender starts with an item; after Trick, attacker
+    // has defender's item, defender has null. Tests the swap in the opposite direction.
+    const trickMove = dataManager.getMove("trick");
+    expect(trickMove).toBeDefined();
+
+    const attacker = createActivePokemon({ ability: "klutz", types: ["normal"] });
+    attacker.pokemon.heldItem = null; // No item — Trick still allowed even for Klutz with no item
+    const defender = createActivePokemon({ ability: "blaze", types: ["normal"] });
+    defender.pokemon.heldItem = "leftovers";
+
+    const state = createNullState();
+    const context = {
+      attacker,
+      defender,
+      // biome-ignore lint/style/noNonNullAssertion: asserted above via expect()
+      move: trickMove!,
+      damage: 0,
+      state,
+      rng: createMockRng(),
+    } as MoveEffectContext;
+
+    ruleset.executeMoveEffect(context);
+
+    // Items should be swapped: attacker gets leftovers, defender gets null
+    expect(attacker.pokemon.heldItem).toBe("leftovers");
+    expect(defender.pokemon.heldItem).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Adds `packages/gen4/tests/bughunt-gen4-audit.test.ts` — 19 regression tests covering Gen 4 mechanics verified against the Showdown Gen 4 mod and Bulbapedia during a targeted correctness audit.

- **Skill Link**: forces exactly 5 hits on multi-hit moves regardless of RNG
- **Technician + Charcoal interaction**: items at priority 15 run before Technician at priority 30 (correct order verified); 55-BP fire → Charcoal gives 65 BP → Technician skips (>60); 40-BP fire → Charcoal gives 47 BP → Technician activates
- **Focus Sash** (issue #551): unit function works correctly when passed pre-damage HP; documents that the engine passes post-damage HP making the item non-functional in battle
- **Reckless + Struggle**: `hasRecoilEffect(null)` returns false — Struggle gets no power boost
- **Download**: raises Attack when foe Def < SpDef, SpAttack otherwise
- **Metronome item** (issue #559): documents that Showdown Gen 4 has NO cap on consecutive-use boost; implementation incorrectly applies `Math.min(..., 5)` cap; count=7 asserts current (buggy) value 82 with a `TODO(#559)` to update to 88 when the cap is removed
- **Wonder Room / Magic Room**: `executeMoveEffect` produces no effects for these Gen 5-only moves
- **Klutz**: suppresses Toxic Orb and Flame Orb end-of-turn triggers
- **Trick/Switcheroo with Klutz attacker**: Klutz does not block item swaps (intentional — only blocks item use)

## Audit findings

All 30+ mechanics verified correct in implementation except for tracked bugs:
- **#551**: Focus Sash — engine timing issue (post-damage HP in `on-damage-taken` context)
- **#559**: Metronome cap — `Math.min(count-1, 5)` not in Showdown Gen 4 source
- **#549**: Life Orb + Magic Guard (pre-existing, not re-filed)
- **#526**: Pain Split defender heal (pre-existing FIXME, not re-filed)
- **#538**: Choice lock on miss (pre-existing, not re-filed)

## Test plan

- [x] `npx vitest run packages/gen4/tests/bughunt-gen4-audit.test.ts` — 19/19 pass
- [x] `npx vitest run packages/gen4/` — 1161/1161 pass (no regressions)
- [x] `npx @biomejs/biome check` — clean
- [x] `npm run typecheck` — no errors

## Related Issue

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive Gen 4 regression tests covering multi-hit consistency (Skill Link), damage scaling and item/ability interactions (Technician, Reckless, Download), held-item and survival behavior (Focus Sash, item swaps/Trick), status/item suppression (Klutz with Toxic/Flame Orb), move-use scaling (Metronome), and absence of special field effects (Wonder Room, Magic Room).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->