### PR TITLE
fix(gen5): add ally-targeting to AbilityEffect for Healer ability

### DIFF
--- a/.changeset/healer-ally-target.md
+++ b/.changeset/healer-ally-target.md
@@ -1,0 +1,6 @@
+---
+"@pokemon-lib-ts/battle": patch
+"@pokemon-lib-ts/gen5": patch
+---
+
+Add "ally" target to AbilityEffect status-cure variant and implement Healer ability

--- a/packages/battle/src/context/types.ts
+++ b/packages/battle/src/context/types.ts
@@ -406,7 +406,7 @@ export type AbilityEffect =
       readonly types: readonly import("@pokemon-lib-ts/core").PokemonType[];
     }
   | { readonly effectType: "weather-immunity"; readonly target: "self" | "opponent" }
-  | { readonly effectType: "status-cure"; readonly target: "self" | "opponent" }
+  | { readonly effectType: "status-cure"; readonly target: "self" | "opponent" | "ally" }
   | {
       readonly effectType: "ability-change";
       readonly target: "self" | "opponent";

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -4581,17 +4581,39 @@ export class BattleEngine implements BattleEventEmitter {
           break;
         }
         case "status-cure": {
-          const target = effect.target === "self" ? pokemon : opponent;
-          const targetSide = effect.target === "self" ? pokemonSide : opponentSide;
-          const status = target.pokemon.status;
-          if (status) {
-            target.pokemon.status = null;
-            this.emit({
-              type: "status-cure",
-              side: targetSide,
-              pokemon: getPokemonName(target),
-              status,
-            });
+          if (effect.target === "ally") {
+            // Ally-targeting status cure (e.g., Healer ability in doubles/triples).
+            // Find an ally on the same side that has a status condition.
+            // Source: Showdown data/abilities.ts -- healer: pokemon.adjacentAllies()
+            const side = this.state.sides[pokemonSide];
+            const ally = side.active.find(
+              (a) => a && a !== pokemon && a.pokemon.currentHp > 0 && a.pokemon.status !== null,
+            );
+            if (ally) {
+              const status = ally.pokemon.status;
+              if (status) {
+                ally.pokemon.status = null;
+                this.emit({
+                  type: "status-cure",
+                  side: pokemonSide,
+                  pokemon: getPokemonName(ally),
+                  status,
+                });
+              }
+            }
+          } else {
+            const target = effect.target === "self" ? pokemon : opponent;
+            const targetSide = effect.target === "self" ? pokemonSide : opponentSide;
+            const status = target.pokemon.status;
+            if (status) {
+              target.pokemon.status = null;
+              this.emit({
+                type: "status-cure",
+                side: targetSide,
+                pokemon: getPokemonName(target),
+                status,
+              });
+            }
           }
           break;
         }

--- a/packages/gen5/src/Gen5AbilitiesRemaining.ts
+++ b/packages/gen5/src/Gen5AbilitiesRemaining.ts
@@ -229,14 +229,19 @@ function handleHealer(ctx: AbilityContext): AbilityResult {
   const ally = allies[0];
   if (!ally) return NO_EFFECT;
 
-  // Healer cures an *ally*, but AbilityEffect only supports target "self" |
-  // "opponent". Using target:"opponent" would apply the cure to the opposing
-  // battler (the foe) instead of the ally. Returning NO_EFFECT is a safe
-  // stopgap until ally-targeting support is added to AbilityEffect/engine.
-  // TODO: add target:"ally" (or targetUid) to AbilityEffect and wire engine.
-  void ally;
-  void name;
-  return NO_EFFECT;
+  const allyName = ally.pokemon.nickname ?? String(ally.pokemon.speciesId);
+  const statusName = ally.pokemon.status;
+
+  // Source: Showdown data/abilities.ts -- healer: allyActive.cureStatus()
+  const effect: AbilityEffect = {
+    effectType: "status-cure",
+    target: "ally",
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Healer cured ${allyName}'s ${statusName}!`],
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gen5/tests/abilities-remaining.test.ts
+++ b/packages/gen5/tests/abilities-remaining.test.ts
@@ -531,12 +531,9 @@ describe("handleGen5RemainingAbility on-turn-end -- Healer", () => {
     expect(result.activated).toBe(false);
   });
 
-  it("given Healer in doubles with poisoned ally and rng below 0.3, when turn ends, then returns NO_EFFECT (ally-targeting stubbed until engine supports it)", () => {
+  it("given Healer in doubles with poisoned ally and rng below 0.3, when turn ends, then activates with status-cure targeting ally", () => {
     // Source: Showdown data/abilities.ts -- healer: this.randomChance(3, 10) = 30%
-    // rng.next() returns 0.2 < 0.3 => the 30% check passes, but NO_EFFECT is returned.
-    // AbilityEffect only supports target "self" | "opponent". Using target:"opponent"
-    // would cure the foe instead of the ally. Returning NO_EFFECT is a safe stopgap
-    // until target:"ally" / targetUid support is added to AbilityEffect and engine.
+    // rng.next() returns 0.2 < 0.3 => the 30% check passes, Healer cures ally's status
     const healer = makeActivePokemon({
       uid: "healer",
       ability: "healer",
@@ -563,7 +560,75 @@ describe("handleGen5RemainingAbility on-turn-end -- Healer", () => {
 
     const result = handleGen5RemainingAbility(ctx);
 
-    // Returns NO_EFFECT until ally-targeting is added to AbilityEffect/engine
+    expect(result.activated).toBe(true);
+    expect(result.effects).toHaveLength(1);
+    expect(result.effects[0]).toEqual({ effectType: "status-cure", target: "ally" });
+    expect(result.messages[0]).toContain("Healer");
+    expect(result.messages[0]).toContain("Charizard");
+    expect(result.messages[0]).toContain("poison");
+  });
+
+  it("given Healer in doubles with burned ally and rng below 0.3, when turn ends, then activates with status-cure targeting ally", () => {
+    // Source: Showdown data/abilities.ts -- healer: allyActive.cureStatus()
+    // Healer cures any primary status, not just poison. Test with burn to triangulate.
+    const healer = makeActivePokemon({
+      uid: "healer",
+      ability: "healer",
+      nickname: "Audino",
+    });
+    const ally = makeActivePokemon({
+      uid: "ally",
+      ability: "blaze",
+      nickname: "Arcanine",
+      status: "burn",
+    });
+    const side0 = makeSide(0, [healer, ally]);
+    const side1 = makeSide(1);
+
+    const ctx = makeContext({
+      ability: "healer",
+      trigger: "on-turn-end",
+      format: "doubles",
+      sides: [side0, side1],
+      rngNextValues: [0.1],
+    });
+    (ctx.pokemon as any).pokemon.uid = "healer";
+
+    const result = handleGen5RemainingAbility(ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toHaveLength(1);
+    expect(result.effects[0]).toEqual({ effectType: "status-cure", target: "ally" });
+    expect(result.messages[0]).toContain("burn");
+  });
+
+  it("given Healer in doubles with healthy ally, when turn ends, then does not activate", () => {
+    // Source: Showdown data/abilities.ts -- healer: `if (allyActive.status)`
+    // Only activates when ally has a status condition
+    const healer = makeActivePokemon({
+      uid: "healer",
+      ability: "healer",
+      nickname: "Audino",
+    });
+    const ally = makeActivePokemon({
+      uid: "ally",
+      ability: "blaze",
+      nickname: "Charizard",
+    });
+    const side0 = makeSide(0, [healer, ally]);
+    const side1 = makeSide(1);
+
+    const ctx = makeContext({
+      ability: "healer",
+      trigger: "on-turn-end",
+      format: "doubles",
+      sides: [side0, side1],
+      rngNextValues: [0.1],
+    });
+    (ctx.pokemon as any).pokemon.uid = "healer";
+
+    const result = handleGen5RemainingAbility(ctx);
+
     expect(result.activated).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Adds `"ally"` to the `AbilityEffect` `status-cure` target union (`"self" | "opponent"` becomes `"self" | "opponent" | "ally"`)
- Wires `BattleEngine.processAbilityResult` to resolve `target: "ally"` by finding a same-side active Pokemon with a status condition
- Replaces the Healer ability stub in `Gen5AbilitiesRemaining.ts` with a working implementation that returns `{ effectType: "status-cure", target: "ally" }`
- Updates and adds tests: Healer with poisoned ally (30% roll passes), Healer with burned ally (triangulation), Healer with healthy ally (no activation)

Closes #583

## Test plan

- [x] Existing Healer test updated: doubles with poisoned ally + rng < 0.3 now expects `activated: true` with `status-cure` / `target: "ally"`
- [x] New triangulation test: doubles with burned ally + rng < 0.3 confirms Healer works for any primary status
- [x] New edge case test: doubles with healthy ally confirms no activation
- [x] Existing edge case: singles format still returns no effect
- [x] Existing edge case: rng >= 0.3 still returns no effect
- [x] Battle package tests all pass (492/492)
- [x] Gen5 correctness-audit tests all pass (53/53)
- [x] Battle package typecheck clean
- [x] Biome lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Fully implemented the Healer ability for double battle scenarios, now actively curing status conditions on adjacent allies at turn end
- Extended status-cure effect system to support ally-targeting alongside existing self and opponent options
- Battle logs now display confirmation messages when Healer successfully removes a status from an ally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->