### PR TITLE
fix(battle): correct end-of-turn order and confusion damage random factor

### DIFF
--- a/.changeset/fix-baseruleset-eot-confusion.md
+++ b/.changeset/fix-baseruleset-eot-confusion.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/battle": patch
+---
+
+Fix BaseRuleset: correct end-of-turn ordering to match Showdown residualOrder (future-attack first, wish before weather, leftovers before leech-seed, nightmare/curse before bind) and apply 85-100% random factor to confusion self-hit damage

--- a/packages/battle/src/ruleset/BaseRuleset.ts
+++ b/packages/battle/src/ruleset/BaseRuleset.ts
@@ -634,16 +634,13 @@ export abstract class BaseRuleset implements GenerationRuleset {
     return 0.5;
   }
 
-  calculateConfusionDamage(
-    pokemon: ActivePokemon,
-    _state: BattleState,
-    _rng: SeededRandom,
-  ): number {
+  calculateConfusionDamage(pokemon: ActivePokemon, _state: BattleState, rng: SeededRandom): number {
     // Gen 3+: confusion self-hit uses 40 base power with the user's own Attack and Defense.
-    // No random variance, no STAB, no critical hit, no type effectiveness.
+    // Applies 85-100% random variance like normal damage, but no STAB, no critical hit,
+    // no type effectiveness.
     // Burn halves physical attack even on confusion self-hits (confusion is always physical-category).
     // No Gen 1 stat overflow check — that bug is Gen 1 specific.
-    // Source: Showdown sim/battle.ts confusion self-damage logic
+    // Source: Showdown sim/battle-actions.ts confusion self-damage logic
     const level = pokemon.pokemon.level;
     const calcStats = pokemon.pokemon.calculatedStats;
     const baseAtk = calcStats?.attack ?? 50;
@@ -660,7 +657,13 @@ export abstract class BaseRuleset implements GenerationRuleset {
     }
 
     const levelFactor = Math.floor((2 * level) / 5) + 2;
-    const damage = Math.floor(Math.floor(levelFactor * 40 * atk) / def / 50) + 2;
+    const baseDamage = Math.floor(Math.floor(levelFactor * 40 * atk) / def / 50) + 2;
+
+    // Source: Showdown sim/battle-actions.ts — confusion self-hit applies 85-100% random factor
+    // damage = tr(damage * (85 + rng.next(16)) / 100)
+    const randomFactor = 85 + rng.int(0, 15);
+    const damage = Math.floor((baseDamage * randomFactor) / 100);
+
     return Math.max(1, damage);
   }
 
@@ -899,23 +902,30 @@ export abstract class BaseRuleset implements GenerationRuleset {
     // Note: "defrost" is intentionally absent here. Gen 3+ handle freeze thaw pre-move
     // via checkFreezeThaw (20% per turn), NOT between turns. Only Gen 2 includes "defrost"
     // in its EoT order (see Gen2Ruleset.getEndOfTurnOrder and processEndOfTurnDefrost).
+    // Source: Showdown sim/battle-actions.ts residualOrder values from
+    // data/conditions.ts, data/moves.ts, data/items.ts
+    // future-attack(3), wish(4), weather-damage(5), leftovers/black-sludge(5.2),
+    // ingrain(7), leech-seed(8), status-damage(9-10), nightmare(11),
+    // curse(12), bind/partiallytrapped(13), perish-song(24), countdowns(26)
     return [
+      "future-attack",
+      "wish",
       "weather-damage",
-      "weather-countdown",
-      "terrain-countdown",
-      "status-damage",
-      "leech-seed",
       "leftovers",
       "black-sludge",
-      "bind",
-      "curse",
+      "ingrain",
+      "leech-seed",
+      "status-damage",
       "nightmare",
-      "wish",
-      "future-attack",
+      "curse",
+      "bind",
       "perish-song",
       "screen-countdown",
+      "weather-countdown",
+      "terrain-countdown",
       "tailwind-countdown",
       "trick-room-countdown",
+      "encore-countdown",
     ];
   }
 

--- a/packages/battle/tests/ruleset/base-ruleset-mechanics.test.ts
+++ b/packages/battle/tests/ruleset/base-ruleset-mechanics.test.ts
@@ -336,9 +336,9 @@ describe("BaseRuleset — calculateConfusionDamage", () => {
     //   = floor(floor(floor(22 * 4000) / 100) / 50) + 2
     //   = floor(floor(88000 / 100) / 50) + 2
     //   = floor(880 / 50) + 2
-    //   = floor(17.6) + 2 = 17 + 2 = 19
-    // Note: BaseRuleset does not apply the random roll (known issue #557),
-    //   so we test the base formula only.
+    //   = floor(17.6) + 2 = 17 + 2 = 19 (base damage)
+    //   Random factor with seed 42: rng.int(0,15)=9, so randomFactor=94
+    //   finalDamage = max(1, floor(19 * 94 / 100)) = max(1, floor(17.86)) = 17
     const pokemon = createTestPokemon(6, 50, {
       calculatedStats: {
         hp: 200,
@@ -356,9 +356,8 @@ describe("BaseRuleset — calculateConfusionDamage", () => {
     const damage = ruleset.calculateConfusionDamage(active, emptyState, rng);
 
     // Assert
-    // levelFactor = floor(2*50/5) + 2 = floor(20) + 2 = 22
-    // damage = floor(floor(22 * 40 * 100) / 100 / 50) + 2 = floor(880/50) + 2 = 17 + 2 = 19
-    expect(damage).toBe(19);
+    // baseDamage=19, randomFactor=94 (seed 42), final=floor(19*94/100)=17
+    expect(damage).toBe(17);
   });
 
   it("given a level 100 pokemon with 200 attack and 100 defense, when calculateConfusionDamage is called, then damage scales correctly", () => {
@@ -368,7 +367,9 @@ describe("BaseRuleset — calculateConfusionDamage", () => {
     //   baseDamage = floor(floor(42 * 40 * 200) / 100) / 50) + 2
     //   = floor(floor(336000 / 100) / 50) + 2
     //   = floor(3360 / 50) + 2
-    //   = floor(67.2) + 2 = 67 + 2 = 69
+    //   = floor(67.2) + 2 = 67 + 2 = 69 (base damage)
+    //   Random factor with seed 42: rng.int(0,15)=9, randomFactor=94
+    //   finalDamage = max(1, floor(69 * 94 / 100)) = max(1, floor(64.86)) = 64
     const pokemon = createTestPokemon(6, 100, {
       calculatedStats: {
         hp: 300,
@@ -385,8 +386,8 @@ describe("BaseRuleset — calculateConfusionDamage", () => {
     // Act
     const damage = ruleset.calculateConfusionDamage(active, emptyState, rng);
 
-    // Assert
-    expect(damage).toBe(69);
+    // Assert — baseDamage=69, randomFactor=94, final=floor(69*94/100)=64
+    expect(damage).toBe(64);
   });
 
   it("given a burned pokemon with neutral attack stages, when calculateConfusionDamage is called, then attack is halved before calculation", () => {
@@ -395,7 +396,9 @@ describe("BaseRuleset — calculateConfusionDamage", () => {
     //   burn halves the attack stat (same as any physical attack)
     //   With burn: effective attack = floor(100 / 2) = 50
     //   levelFactor = floor(2*50/5) + 2 = 22
-    //   damage = floor(floor(22 * 40 * 50) / 100 / 50) + 2 = floor(440/50) + 2 = 8 + 2 = 10
+    //   baseDamage = floor(floor(22 * 40 * 50) / 100 / 50) + 2 = floor(440/50) + 2 = 8 + 2 = 10
+    //   Random factor with seed 42: rng.int(0,15)=9, randomFactor=94
+    //   finalDamage = max(1, floor(10 * 94 / 100)) = max(1, floor(9.4)) = 9
     const pokemon = createTestPokemon(6, 50, {
       status: "burn",
       calculatedStats: {
@@ -413,8 +416,8 @@ describe("BaseRuleset — calculateConfusionDamage", () => {
     // Act
     const damage = ruleset.calculateConfusionDamage(active, emptyState, rng);
 
-    // Assert — burn halves attack: floor(22 * 40 * 50) / 100 / 50 = 8.8 → 8 + 2 = 10
-    expect(damage).toBe(10);
+    // Assert — burn halves atk: baseDamage=10, randomFactor=94, final=floor(10*94/100)=9
+    expect(damage).toBe(9);
   });
 
   it("given a pokemon with attack stage +6 (boosted), when calculateConfusionDamage is called, then boosted attack is applied", () => {
@@ -422,7 +425,9 @@ describe("BaseRuleset — calculateConfusionDamage", () => {
     // Source: Showdown — confusion self-hit applies stat stages
     //   +6 stage = 4x multiplier; 100 attack * 4 = 400
     //   levelFactor = floor(2*50/5) + 2 = 22
-    //   damage = floor(floor(22 * 40 * 400) / 100 / 50) + 2 = floor(3520/50) + 2 = 70 + 2 = 72
+    //   baseDamage = floor(floor(22 * 40 * 400) / 100 / 50) + 2 = floor(3520/50) + 2 = 70 + 2 = 72
+    //   Random factor with seed 42: rng.int(0,15)=9, randomFactor=94
+    //   finalDamage = max(1, floor(72 * 94 / 100)) = max(1, floor(67.68)) = 67
     const pokemon = createTestPokemon(6, 50, {
       calculatedStats: {
         hp: 200,
@@ -440,11 +445,8 @@ describe("BaseRuleset — calculateConfusionDamage", () => {
     // Act
     const damage = ruleset.calculateConfusionDamage(active, emptyState, rng);
 
-    // Assert
-    // +6 stage multiplier = 4x (getStatStageMultiplier(6) = 4)
-    // atk = floor(100 * 4) = 400
-    // damage = floor(floor(22 * 40 * 400) / 100 / 50) + 2 = floor(3520/50) + 2 = 70 + 2 = 72
-    expect(damage).toBe(72);
+    // Assert — baseDamage=72, randomFactor=94, final=floor(72*94/100)=67
+    expect(damage).toBe(67);
   });
 });
 
@@ -760,16 +762,11 @@ describe("BaseRuleset — getEndOfTurnOrder ordering (regression for #555)", () 
     ruleset = new TestRuleset();
   });
 
-  // FIXME(#555): Unskip when getEndOfTurnOrder ordering is fixed
-  it.skip("given the base ruleset, when getEndOfTurnOrder is called, then future-attack comes before weather-damage", () => {
+  it("given the base ruleset, when getEndOfTurnOrder is called, then future-attack comes before weather-damage", () => {
     // Arrange
     // Source: Showdown data/conditions.ts — futuremove onResidualOrder: 3 (first)
     //   weather damage (Sandstorm/Hail) onResidualOrder: 5
     //   future-attack MUST precede weather-damage per Showdown
-    //
-    // BUG: Current BaseRuleset places future-attack AFTER wish, nightmare, curse etc.
-    // This test documents the CORRECT expected behavior per Showdown.
-    // See GitHub issue #555
 
     // Act
     const order = ruleset.getEndOfTurnOrder();
@@ -779,15 +776,12 @@ describe("BaseRuleset — getEndOfTurnOrder ordering (regression for #555)", () 
     // Assert — future-attack (Showdown order 3) must come before weather-damage (order 5)
     expect(futureIdx).toBeGreaterThanOrEqual(0); // must be present
     expect(weatherIdx).toBeGreaterThanOrEqual(0); // must be present
-    // FIXME(#555): This assertion currently FAILS because future-attack is misplaced
     expect(futureIdx).toBeLessThan(weatherIdx);
   });
 
-  // FIXME(#555): Unskip when getEndOfTurnOrder ordering is fixed
-  it.skip("given the base ruleset, when getEndOfTurnOrder is called, then wish comes before weather-damage", () => {
+  it("given the base ruleset, when getEndOfTurnOrder is called, then wish comes before weather-damage", () => {
     // Arrange
     // Source: Showdown data/moves.ts — wish onResidualOrder: 4 (before weather at 5)
-    // BUG: Current BaseRuleset places wish AFTER curse and nightmare (#555)
 
     // Act
     const order = ruleset.getEndOfTurnOrder();
@@ -797,16 +791,13 @@ describe("BaseRuleset — getEndOfTurnOrder ordering (regression for #555)", () 
     // Assert — wish (Showdown order 4) must come before weather-damage (order 5)
     expect(wishIdx).toBeGreaterThanOrEqual(0);
     expect(weatherIdx).toBeGreaterThanOrEqual(0);
-    // FIXME(#555): This assertion currently FAILS because wish is misplaced
     expect(wishIdx).toBeLessThan(weatherIdx);
   });
 
-  // FIXME(#555): Unskip when getEndOfTurnOrder ordering is fixed
-  it.skip("given the base ruleset, when getEndOfTurnOrder is called, then leftovers comes before leech-seed", () => {
+  it("given the base ruleset, when getEndOfTurnOrder is called, then leftovers comes before leech-seed", () => {
     // Arrange
     // Source: Showdown data/items.ts — leftovers onResidualOrder: 5
     //          data/moves.ts — leechseed onResidualOrder: 8
-    // Current order in BaseRuleset: leech-seed BEFORE leftovers — this is WRONG
 
     // Act
     const order = ruleset.getEndOfTurnOrder();
@@ -816,16 +807,13 @@ describe("BaseRuleset — getEndOfTurnOrder ordering (regression for #555)", () 
     // Assert — leftovers (order 5) must come before leech-seed (order 8)
     expect(leftoversIdx).toBeGreaterThanOrEqual(0);
     expect(leechIdx).toBeGreaterThanOrEqual(0);
-    // FIXME(#555): This assertion currently FAILS because leech-seed is before leftovers
     expect(leftoversIdx).toBeLessThan(leechIdx);
   });
 
-  // FIXME(#555): Unskip when getEndOfTurnOrder ordering is fixed
-  it.skip("given the base ruleset, when getEndOfTurnOrder is called, then leech-seed comes before status-damage", () => {
+  it("given the base ruleset, when getEndOfTurnOrder is called, then leech-seed comes before status-damage", () => {
     // Arrange
     // Source: Showdown data/moves.ts — leechseed onResidualOrder: 8
     //          data/conditions.ts — brn onResidualOrder: 10; psn onResidualOrder: 9
-    // Current BaseRuleset: status-damage BEFORE leech-seed — this is WRONG per Showdown
 
     // Act
     const order = ruleset.getEndOfTurnOrder();
@@ -835,16 +823,13 @@ describe("BaseRuleset — getEndOfTurnOrder ordering (regression for #555)", () 
     // Assert — leech-seed (order 8) must come before status-damage (order 9/10)
     expect(leechIdx).toBeGreaterThanOrEqual(0);
     expect(statusIdx).toBeGreaterThanOrEqual(0);
-    // FIXME(#555): This assertion currently FAILS
     expect(leechIdx).toBeLessThan(statusIdx);
   });
 
-  // FIXME(#555): Unskip when getEndOfTurnOrder ordering is fixed
-  it.skip("given the base ruleset, when getEndOfTurnOrder is called, then nightmare comes before bind", () => {
+  it("given the base ruleset, when getEndOfTurnOrder is called, then nightmare comes before bind", () => {
     // Arrange
     // Source: Showdown data/moves.ts — nightmare onResidualOrder: 11
     //          data/conditions.ts — partiallytrapped onResidualOrder: 13
-    // Current BaseRuleset: bind BEFORE nightmare and curse — this is WRONG
 
     // Act
     const order = ruleset.getEndOfTurnOrder();
@@ -854,16 +839,13 @@ describe("BaseRuleset — getEndOfTurnOrder ordering (regression for #555)", () 
     // Assert — nightmare (order 11) must come before bind (order 13)
     expect(nightmareIdx).toBeGreaterThanOrEqual(0);
     expect(bindIdx).toBeGreaterThanOrEqual(0);
-    // FIXME(#555): This assertion currently FAILS because bind is before nightmare
     expect(nightmareIdx).toBeLessThan(bindIdx);
   });
 
-  // FIXME(#555): Unskip when getEndOfTurnOrder ordering is fixed
-  it.skip("given the base ruleset, when getEndOfTurnOrder is called, then curse comes before bind", () => {
+  it("given the base ruleset, when getEndOfTurnOrder is called, then curse comes before bind", () => {
     // Arrange
     // Source: Showdown data/moves.ts — curse onResidualOrder: 12
     //          data/conditions.ts — partiallytrapped onResidualOrder: 13
-    // Current BaseRuleset: bind BEFORE curse — this is WRONG
 
     // Act
     const order = ruleset.getEndOfTurnOrder();
@@ -873,7 +855,6 @@ describe("BaseRuleset — getEndOfTurnOrder ordering (regression for #555)", () 
     // Assert — curse (order 12) must come before bind (order 13)
     expect(curseIdx).toBeGreaterThanOrEqual(0);
     expect(bindIdx).toBeGreaterThanOrEqual(0);
-    // FIXME(#555): This assertion currently FAILS
     expect(curseIdx).toBeLessThan(bindIdx);
   });
 

--- a/packages/battle/tests/ruleset/base-ruleset.test.ts
+++ b/packages/battle/tests/ruleset/base-ruleset.test.ts
@@ -959,12 +959,15 @@ describe("BaseRuleset", () => {
       expect(order).toContain("status-damage");
     });
 
-    it("given a base ruleset, when getEndOfTurnOrder is called, then nightmare is included after curse", () => {
+    // Source: Showdown data/moves.ts — nightmare onResidualOrder: 11, curse onResidualOrder: 12
+    it("given a base ruleset, when getEndOfTurnOrder is called, then nightmare comes before curse", () => {
       const order = ruleset.getEndOfTurnOrder();
       expect(order).toContain("nightmare");
+      expect(order).toContain("curse");
       const curseIdx = order.indexOf("curse");
       const nightmareIdx = order.indexOf("nightmare");
-      expect(nightmareIdx).toBeGreaterThan(curseIdx);
+      // nightmare (Showdown order 11) must come before curse (order 12)
+      expect(nightmareIdx).toBeLessThan(curseIdx);
     });
   });
 

--- a/packages/battle/tests/ruleset/baseruleset-eot-confusion.test.ts
+++ b/packages/battle/tests/ruleset/baseruleset-eot-confusion.test.ts
@@ -1,0 +1,276 @@
+import type { Generation, PokemonType, TypeChart } from "@pokemon-lib-ts/core";
+import { SeededRandom } from "@pokemon-lib-ts/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { DamageContext, DamageResult } from "../../src/context";
+import { BaseRuleset } from "../../src/ruleset/BaseRuleset";
+import type { BattleState } from "../../src/state";
+import { createActivePokemon, createTestPokemon } from "../../src/utils";
+
+// Concrete implementation of BaseRuleset for testing (minimal overrides)
+class TestRuleset extends BaseRuleset {
+  readonly generation: Generation = 5;
+  readonly name = "Test Gen 5";
+
+  getTypeChart(): TypeChart {
+    const types = this.getAvailableTypes();
+    const chart: Record<string, Record<string, number>> = {};
+    for (const atk of types) {
+      const row: Record<string, number> = {};
+      chart[atk] = row;
+      for (const def of types) {
+        row[def] = 1;
+      }
+    }
+    return chart as TypeChart;
+  }
+
+  getAvailableTypes(): readonly PokemonType[] {
+    return [
+      "normal",
+      "fire",
+      "water",
+      "electric",
+      "grass",
+      "ice",
+      "fighting",
+      "poison",
+      "ground",
+      "flying",
+      "psychic",
+      "bug",
+      "rock",
+      "ghost",
+      "dragon",
+      "dark",
+      "steel",
+    ];
+  }
+
+  calculateDamage(_context: DamageContext): DamageResult {
+    return { damage: 50, effectiveness: 1, isCrit: false, randomFactor: 1 };
+  }
+}
+
+describe("BaseRuleset end-of-turn order (#555)", () => {
+  let ruleset: TestRuleset;
+
+  beforeEach(() => {
+    ruleset = new TestRuleset();
+  });
+
+  // Source: Showdown data/conditions.ts -- futuremove onResidualOrder: 3 (first)
+  //         weather damage (Sandstorm/Hail) onResidualOrder: 5
+  it("given default EOT order, when getEndOfTurnOrder is called, then future-attack comes before weather-damage", () => {
+    // Arrange & Act
+    const order = ruleset.getEndOfTurnOrder();
+    const futureIdx = order.indexOf("future-attack");
+    const weatherIdx = order.indexOf("weather-damage");
+
+    // Assert
+    expect(futureIdx).not.toBe(-1);
+    expect(weatherIdx).not.toBe(-1);
+    expect(futureIdx).toBeLessThan(weatherIdx);
+  });
+
+  // Source: Showdown data/moves.ts -- wish onResidualOrder: 4 (before weather at 5)
+  it("given default EOT order, when getEndOfTurnOrder is called, then wish comes before weather-damage", () => {
+    // Arrange & Act
+    const order = ruleset.getEndOfTurnOrder();
+    const wishIdx = order.indexOf("wish");
+    const weatherIdx = order.indexOf("weather-damage");
+
+    // Assert
+    expect(wishIdx).not.toBe(-1);
+    expect(weatherIdx).not.toBe(-1);
+    expect(wishIdx).toBeLessThan(weatherIdx);
+  });
+
+  // Source: Showdown data/items.ts -- leftovers onResidualOrder: 5.2 (before leech-seed at 8)
+  it("given default EOT order, when getEndOfTurnOrder is called, then leftovers comes before leech-seed", () => {
+    // Arrange & Act
+    const order = ruleset.getEndOfTurnOrder();
+    const leftIdx = order.indexOf("leftovers");
+    const leechIdx = order.indexOf("leech-seed");
+
+    // Assert
+    expect(leftIdx).not.toBe(-1);
+    expect(leechIdx).not.toBe(-1);
+    expect(leftIdx).toBeLessThan(leechIdx);
+  });
+
+  // Source: Showdown data/moves.ts -- leechseed onResidualOrder: 8
+  //         data/conditions.ts -- brn onResidualOrder: 10, psn onResidualOrder: 9
+  it("given default EOT order, when getEndOfTurnOrder is called, then leech-seed comes before status-damage", () => {
+    // Arrange & Act
+    const order = ruleset.getEndOfTurnOrder();
+    const leechIdx = order.indexOf("leech-seed");
+    const statusIdx = order.indexOf("status-damage");
+
+    // Assert
+    expect(leechIdx).not.toBe(-1);
+    expect(statusIdx).not.toBe(-1);
+    expect(leechIdx).toBeLessThan(statusIdx);
+  });
+
+  // Source: Showdown data/moves.ts -- nightmare onResidualOrder: 11,
+  //         data/conditions.ts -- partiallytrapped onResidualOrder: 13
+  it("given default EOT order, when getEndOfTurnOrder is called, then nightmare comes before bind", () => {
+    // Arrange & Act
+    const order = ruleset.getEndOfTurnOrder();
+    const nightmareIdx = order.indexOf("nightmare");
+    const bindIdx = order.indexOf("bind");
+
+    // Assert
+    expect(nightmareIdx).not.toBe(-1);
+    expect(bindIdx).not.toBe(-1);
+    expect(nightmareIdx).toBeLessThan(bindIdx);
+  });
+
+  // Source: Showdown data/moves.ts -- curse onResidualOrder: 12,
+  //         data/conditions.ts -- partiallytrapped onResidualOrder: 13
+  it("given default EOT order, when getEndOfTurnOrder is called, then curse comes before bind", () => {
+    // Arrange & Act
+    const order = ruleset.getEndOfTurnOrder();
+    const curseIdx = order.indexOf("curse");
+    const bindIdx = order.indexOf("bind");
+
+    // Assert
+    expect(curseIdx).not.toBe(-1);
+    expect(bindIdx).not.toBe(-1);
+    expect(curseIdx).toBeLessThan(bindIdx);
+  });
+
+  // Source: Showdown data -- comprehensive relative order validation from residualOrder values
+  it("given default EOT order, when getEndOfTurnOrder is called, then full order matches Showdown residualOrder", () => {
+    // Arrange & Act
+    const order = ruleset.getEndOfTurnOrder();
+
+    // Assert: verify key relative orderings from Showdown residualOrder
+    const futureIdx = order.indexOf("future-attack"); // 3
+    const wishIdx = order.indexOf("wish"); // 4
+    const weatherDmgIdx = order.indexOf("weather-damage"); // 5
+    const leftIdx = order.indexOf("leftovers"); // 5.2
+    const blackSludgeIdx = order.indexOf("black-sludge"); // 5.2
+    const leechIdx = order.indexOf("leech-seed"); // 8
+    const statusIdx = order.indexOf("status-damage"); // 9-10
+    const nightmareIdx = order.indexOf("nightmare"); // 11
+    const curseIdx = order.indexOf("curse"); // 12
+    const bindIdx = order.indexOf("bind"); // 13
+    const perishIdx = order.indexOf("perish-song"); // 24
+    const screenIdx = order.indexOf("screen-countdown"); // 26
+    const weatherCountIdx = order.indexOf("weather-countdown"); // 26
+
+    // future-attack(3) -> wish(4) -> weather(5)
+    expect(futureIdx).toBeLessThan(wishIdx);
+    expect(wishIdx).toBeLessThan(weatherDmgIdx);
+
+    // leftovers/black-sludge(5.2) before leech-seed(8)
+    expect(leftIdx).toBeLessThan(leechIdx);
+    expect(blackSludgeIdx).toBeLessThan(leechIdx);
+
+    // leech-seed(8) before status-damage(9-10)
+    expect(leechIdx).toBeLessThan(statusIdx);
+
+    // nightmare(11) before curse(12) before bind(13)
+    expect(nightmareIdx).toBeLessThan(curseIdx);
+    expect(curseIdx).toBeLessThan(bindIdx);
+
+    // bind(13) before perish-song(24)
+    expect(bindIdx).toBeLessThan(perishIdx);
+
+    // perish-song(24) before countdowns(26)
+    expect(perishIdx).toBeLessThan(screenIdx);
+    expect(perishIdx).toBeLessThan(weatherCountIdx);
+  });
+});
+
+describe("BaseRuleset calculateConfusionDamage (#557)", () => {
+  let ruleset: TestRuleset;
+
+  beforeEach(() => {
+    ruleset = new TestRuleset();
+  });
+
+  // Source: Showdown sim/battle-actions.ts -- confusion self-hit applies random 85-100% factor
+  // like normal damage: damage = tr(damage * randomFactor / 100) where randomFactor in [85,100]
+  it("given two different RNG seeds, when calculateConfusionDamage is called, then results differ due to random factor", () => {
+    // Arrange
+    const pokemon = createTestPokemon(6, 50, {
+      calculatedStats: {
+        hp: 153,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 100,
+      },
+    });
+    const active = createActivePokemon(pokemon, 0, ["fire", "flying"]);
+    const state = {} as BattleState;
+
+    const rng1 = new SeededRandom(42);
+    const rng2 = new SeededRandom(12345);
+
+    // Act
+    const damage1 = ruleset.calculateConfusionDamage(active, state, rng1);
+    const damage2 = ruleset.calculateConfusionDamage(active, state, rng2);
+
+    // Assert -- with different seeds, the random factor (85-100) should produce
+    // different damage values at least some of the time.
+    // If the RNG is not being used, both will be identical (the bug).
+    expect(damage1).not.toBe(damage2);
+  });
+
+  // Source: Showdown sim/battle-actions.ts -- confusion damage formula:
+  // baseDamage = floor(floor(2*level/5+2) * 40 * atk / def / 50) + 2
+  // finalDamage = max(1, floor(baseDamage * randomFactor / 100)) where randomFactor in [85,100]
+  //
+  // Inline derivation for L50 pokemon with 100 atk and 100 def:
+  //   levelFactor = floor(2*50/5) + 2 = 22
+  //   baseDamage = floor(floor(22 * 40 * 100) / 100 / 50) + 2
+  //             = floor(88000 / 100 / 50) + 2 = floor(17.6) + 2 = 17 + 2 = 19
+  //   With 85% roll: max(1, floor(19 * 85 / 100)) = max(1, floor(16.15)) = 16
+  //   With 100% roll: max(1, floor(19 * 100 / 100)) = 19
+  // So confusion damage should be in range [16, 19] for this setup.
+  it("given a L50 pokemon with 100 atk/def, when calculateConfusionDamage is called many times, then damage is bounded by 85-100% of base", () => {
+    // Arrange
+    const pokemon = createTestPokemon(6, 50, {
+      calculatedStats: {
+        hp: 153,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 100,
+      },
+    });
+    const active = createActivePokemon(pokemon, 0, ["fire", "flying"]);
+    const state = {} as BattleState;
+
+    // Inline derivation of expected values:
+    // levelFactor = floor(2*50/5) + 2 = 22
+    // baseDamage = floor(22 * 40 * 100 / 100 / 50) + 2 = floor(17.6) + 2 = 19
+    // minDamage = max(1, floor(19 * 85 / 100)) = floor(16.15) = 16
+    // maxDamage = floor(19 * 100 / 100) = 19
+    const expectedBaseDamage = 19;
+    const expectedMin = Math.max(1, Math.floor((expectedBaseDamage * 85) / 100)); // 16
+    const expectedMax = Math.floor((expectedBaseDamage * 100) / 100); // 19
+
+    // Act -- run many times to sample the distribution
+    const damages = new Set<number>();
+    for (let seed = 0; seed < 200; seed++) {
+      const rng = new SeededRandom(seed);
+      const dmg = ruleset.calculateConfusionDamage(active, state, rng);
+      damages.add(dmg);
+    }
+
+    // Assert -- all values should be in [16, 19]
+    for (const d of damages) {
+      expect(d).toBeGreaterThanOrEqual(expectedMin);
+      expect(d).toBeLessThanOrEqual(expectedMax);
+    }
+    // With 200 seeds, we should see at least 2 distinct values
+    // (proves the random factor is actually being applied)
+    expect(damages.size).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary
- **#555**: Fixed end-of-turn ordering in `BaseRuleset.getEndOfTurnOrder()` to match Showdown's `residualOrder` values from `data/conditions.ts`, `data/moves.ts`, and `data/items.ts`:
  - `future-attack`(3) -> `wish`(4) -> `weather-damage`(5) -> `leftovers`/`black-sludge`(5.2) -> `ingrain`(7) -> `leech-seed`(8) -> `status-damage`(9-10) -> `nightmare`(11) -> `curse`(12) -> `bind`(13) -> `perish-song`(24) -> countdowns(26)
  - Unskipped all 6 `FIXME(#555)` tests in `base-ruleset-mechanics.test.ts`
  - Fixed incorrect nightmare/curse ordering test in `base-ruleset.test.ts`
- **#557**: `calculateConfusionDamage()` now applies 85-100% random factor via `rng.int(0, 15)` matching Showdown's confusion self-hit formula. Previously the `_rng` parameter was accepted but never used, so every confusion self-hit dealt identical fixed damage.

## Source
- Showdown `sim/battle-actions.ts` end-of-turn ordering
- Showdown `data/conditions.ts`, `data/moves.ts`, `data/items.ts` residualOrder values
- Showdown confusion self-hit damage formula

## Test plan
- [x] 7 new EOT order regression tests (future-attack before weather, wish before weather, leftovers before leech-seed, leech-seed before status-damage, nightmare before bind, curse before bind, comprehensive order validation)
- [x] 2 new confusion damage randomness tests (two seeds produce different damage, damage bounded in 85-100% range)
- [x] 6 previously skipped FIXME(#555) EOT tests now unskipped and passing
- [x] 4 existing confusion damage tests updated with correct expected values including random factor
- [x] Full battle test suite passes (496 tests)

Closes #555
Closes #557

---
Generated with [Claude Code](https://claude.com/claude-code)