### PR TITLE
fix(battle): Sleep Talk/Snore bypass sleep check + hazard stat-change tests

### DIFF
--- a/.changeset/sleep-usable-hazard-stats.md
+++ b/.changeset/sleep-usable-hazard-stats.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/battle": patch
+---
+
+Sleep Talk and Snore now bypass sleep check in canExecuteMove; add regression tests confirming sendOut applies EntryHazardResult.statChanges (closes #609, closes #524)

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -21,6 +21,14 @@ import {
 } from "../utils";
 
 /**
+ * Moves that can be used while the user is asleep.
+ * Source: Showdown data/moves.ts — sleepUsable flag on sleep-talk and snore
+ * Source: Bulbapedia — "Sleep Talk can only be used while asleep"
+ * Source: Bulbapedia — "Snore can only be used while asleep"
+ */
+const SLEEP_USABLE_MOVES: ReadonlySet<string> = new Set(["sleep-talk", "snore"]);
+
+/**
  * The core battle engine. Manages the battle state machine, delegates
  * generation-specific behavior to the provided ruleset, and emits
  * a stream of BattleEvents for UI/logging consumers.
@@ -2275,6 +2283,8 @@ export class BattleEngine implements BattleEventEmitter {
     }
 
     // Sleep check
+    // Source: Showdown sim/battle-actions.ts — sleepUsable moves (Sleep Talk, Snore)
+    // bypass the sleep immobilization check but still decrement the sleep counter.
     if (actor.pokemon.status === "sleep") {
       const canAct = this.ruleset.processSleepTurn(actor, this.state);
       if (actor.pokemon.status === null) {
@@ -2292,7 +2302,15 @@ export class BattleEngine implements BattleEventEmitter {
           text: `${getPokemonName(actor)} is fast asleep!`,
         });
       }
-      if (!canAct) return false;
+      if (!canAct) {
+        // Sleep Talk and Snore are usable while asleep — they bypass immobilization.
+        // Source: Showdown data/moves.ts — sleepUsable flag on sleep-talk and snore
+        // Source: Bulbapedia — "Sleep Talk can only be used while asleep"
+        // Source: Bulbapedia — "Snore can only be used while asleep"
+        if (!SLEEP_USABLE_MOVES.has(move.id)) {
+          return false;
+        }
+      }
     }
 
     // Freeze check

--- a/packages/battle/tests/engine/hazard-stat-changes.test.ts
+++ b/packages/battle/tests/engine/hazard-stat-changes.test.ts
@@ -1,0 +1,192 @@
+import type { DataManager, PokemonInstance } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import type { BattleConfig, EntryHazardResult } from "../../src/context";
+import { BattleEngine } from "../../src/engine";
+import type { BattleEvent } from "../../src/events";
+import type { ActivePokemon, BattleSide, BattleState } from "../../src/state";
+import { createTestPokemon } from "../../src/utils";
+import { createMockDataManager } from "../helpers/mock-data-manager";
+import { MockRuleset } from "../helpers/mock-ruleset";
+
+/**
+ * Tests for issue #609: sendOut() must apply EntryHazardResult.statChanges.
+ *
+ * Sticky Web lowers the incoming Pokemon's Speed by 1 stage on switch-in.
+ * The ruleset returns statChanges in EntryHazardResult; the engine must apply them.
+ *
+ * Source: Showdown data/moves.ts — stickyweb: this.boost({spe: -1}, pokemon)
+ * Source: Bulbapedia — "Sticky Web lowers the Speed stat of each opposing Pokemon
+ *   that switches in by one stage."
+ */
+
+function createHazardTestEngine(overrides?: {
+  seed?: number;
+  team1?: PokemonInstance[];
+  team2?: PokemonInstance[];
+  ruleset?: MockRuleset;
+  dataManager?: DataManager;
+}): { engine: BattleEngine; ruleset: MockRuleset; events: BattleEvent[] } {
+  const ruleset = overrides?.ruleset ?? new MockRuleset();
+  const dataManager = overrides?.dataManager ?? createMockDataManager();
+  const events: BattleEvent[] = [];
+
+  const team1 = overrides?.team1 ?? [
+    createTestPokemon(6, 50, {
+      uid: "charizard-1",
+      nickname: "Charizard",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 120,
+      },
+      currentHp: 200,
+    }),
+    createTestPokemon(25, 50, {
+      uid: "pikachu-1",
+      nickname: "Pikachu",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 150,
+        attack: 80,
+        defense: 60,
+        spAttack: 80,
+        spDefense: 60,
+        speed: 130,
+      },
+      currentHp: 150,
+    }),
+  ];
+
+  const team2 = overrides?.team2 ?? [
+    createTestPokemon(9, 50, {
+      uid: "blastoise-1",
+      nickname: "Blastoise",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 80,
+      },
+      currentHp: 200,
+    }),
+  ];
+
+  const config: BattleConfig = {
+    generation: 1,
+    format: "singles",
+    teams: [team1, team2],
+    seed: overrides?.seed ?? 12345,
+  };
+
+  const engine = new BattleEngine(config, ruleset, dataManager);
+  engine.on((e) => events.push(e));
+
+  return { engine, ruleset, events };
+}
+
+describe("Entry hazard stat changes in sendOut (issue #609)", () => {
+  it("given Sticky Web on the field, when a Pokemon switches in, then its Speed stage decreases by 1", () => {
+    // Arrange
+    const ruleset = new MockRuleset();
+
+    // Override getAvailableHazards to include sticky-web
+    // Source: Showdown — Sticky Web is an entry hazard type
+    ruleset.getAvailableHazards = () => ["sticky-web"] as any;
+
+    // Override applyEntryHazards to return a Speed drop
+    // Source: Showdown data/moves.ts — stickyweb: this.boost({spe: -1}, pokemon)
+    ruleset.applyEntryHazards = (
+      _pokemon: ActivePokemon,
+      _side: BattleSide,
+      _state?: BattleState,
+    ): EntryHazardResult => {
+      return {
+        damage: 0,
+        statusInflicted: null,
+        statChanges: [{ stat: "speed", stages: -1 }],
+        messages: ["Pikachu was caught in a Sticky Web!"],
+      };
+    };
+
+    const { engine, events } = createHazardTestEngine({ ruleset });
+
+    engine.start();
+
+    // Add sticky-web hazard to side 0 (Charizard's side)
+    const state = engine.getState();
+    state.sides[0].hazards.push({ type: "sticky-web" as any, layers: 1 });
+
+    events.length = 0;
+
+    // Act — Charizard voluntarily switches to Pikachu (normal switch, not faint-forced)
+    engine.submitAction(0, { type: "switch", side: 0, switchTo: 1 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Assert — Pikachu should have speed stat stage = -1
+    const pikachu = state.sides[0].active[0]!;
+    // Source: Bulbapedia — "Sticky Web lowers Speed by one stage on switch-in"
+    expect(pikachu.statStages.speed).toBe(-1);
+
+    // Also verify a stat-change event was emitted
+    const statChangeEvents = events.filter((e) => e.type === "stat-change");
+    expect(statChangeEvents.length).toBeGreaterThanOrEqual(1);
+    const speedChange = statChangeEvents.find(
+      (e) => e.type === "stat-change" && e.stat === "speed",
+    );
+    expect(speedChange).toBeDefined();
+    if (speedChange && speedChange.type === "stat-change") {
+      expect(speedChange.stages).toBe(-1);
+      expect(speedChange.currentStage).toBe(-1);
+    }
+  });
+
+  it("given a hazard that deals both damage and stat changes, when a Pokemon switches in, then both are applied", () => {
+    // Arrange — hypothetical hazard that deals damage AND changes stats
+    // (This tests the combination path)
+    const ruleset = new MockRuleset();
+
+    ruleset.getAvailableHazards = () => ["stealth-rock"] as any;
+
+    ruleset.applyEntryHazards = (
+      _pokemon: ActivePokemon,
+      _side: BattleSide,
+      _state?: BattleState,
+    ): EntryHazardResult => {
+      return {
+        damage: 25,
+        statusInflicted: null,
+        // Source: Hypothetical combined hazard for testing the engine's ability to apply
+        // both damage and stat changes from a single EntryHazardResult
+        statChanges: [{ stat: "attack", stages: -1 }],
+        messages: ["Pointed stones dug into Pikachu!", "Pikachu's Attack fell!"],
+      };
+    };
+
+    const { engine, events } = createHazardTestEngine({ ruleset });
+
+    engine.start();
+
+    const state = engine.getState();
+    state.sides[0].hazards.push({ type: "stealth-rock" as any, layers: 1 });
+
+    events.length = 0;
+
+    // Act — voluntary switch
+    engine.submitAction(0, { type: "switch", side: 0, switchTo: 1 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Assert
+    const pikachu = state.sides[0].active[0]!;
+    // Source: EntryHazardResult.statChanges applied by engine after damage
+    expect(pikachu.statStages.attack).toBe(-1);
+    // Also verify damage was applied (150 - 25 = 125)
+    expect(pikachu.pokemon.currentHp).toBeLessThanOrEqual(125);
+  });
+});

--- a/packages/battle/tests/engine/sleep-usable-moves.test.ts
+++ b/packages/battle/tests/engine/sleep-usable-moves.test.ts
@@ -1,0 +1,251 @@
+import type { DataManager, MoveData, PokemonInstance } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import type { BattleConfig } from "../../src/context";
+import { BattleEngine } from "../../src/engine";
+import type { BattleEvent } from "../../src/events";
+import { createTestPokemon } from "../../src/utils";
+import { createMockDataManager } from "../helpers/mock-data-manager";
+import { MockRuleset } from "../helpers/mock-ruleset";
+
+/**
+ * Tests for issue #524: Sleep Talk and Snore must bypass the sleep check
+ * in canExecuteMove().
+ *
+ * Source: Showdown sim/battle-actions.ts — sleep check skipped for sleepUsable moves
+ * Source: Bulbapedia — "Sleep Talk: This move can only be used while the user is asleep."
+ * Source: Bulbapedia — "Snore: This move can only be used while the user is asleep."
+ */
+
+/** Standard MoveFlags with all false */
+const defaultFlags: MoveData["flags"] = {
+  contact: false,
+  sound: false,
+  bullet: false,
+  pulse: false,
+  punch: false,
+  bite: false,
+  wind: false,
+  slicing: false,
+  powder: false,
+  protect: true,
+  mirror: true,
+  snatch: false,
+  gravity: false,
+  defrost: false,
+  recharge: false,
+  charge: false,
+  bypassSubstitute: false,
+};
+
+function createSleepTestDataManager(): DataManager {
+  const dm = createMockDataManager();
+
+  // Sleep Talk — status move usable while asleep
+  // Source: Showdown data/moves.ts — sleepUsable: true, handler calls randomMove
+  const sleepTalkData: MoveData = {
+    id: "sleep-talk",
+    displayName: "Sleep Talk",
+    type: "normal",
+    category: "status",
+    power: null,
+    accuracy: null,
+    pp: 10,
+    priority: 0,
+    target: "self",
+    flags: { ...defaultFlags, protect: false, mirror: false, snatch: false },
+    effect: { type: "custom", handler: "sleep-talk" },
+    description: "While it is asleep, the user randomly uses one of the moves it knows.",
+    generation: 2,
+  };
+
+  // Snore — damaging move usable while asleep
+  // Source: Showdown data/moves.ts — sleepUsable: true
+  const snoreData: MoveData = {
+    id: "snore",
+    displayName: "Snore",
+    type: "normal",
+    category: "special",
+    power: 50,
+    accuracy: 100,
+    pp: 15,
+    priority: 0,
+    target: "adjacent-foe",
+    flags: { ...defaultFlags, sound: true },
+    effect: null,
+    description:
+      "This attack can be used only if the user is asleep. The harsh noise may also make the target flinch.",
+    generation: 2,
+  };
+
+  dm.loadFromObjects({
+    pokemon: [],
+    moves: [sleepTalkData, snoreData],
+    items: [],
+    typeChart: {} as never,
+  });
+
+  return dm;
+}
+
+function createSleepTestEngine(overrides?: {
+  seed?: number;
+  team1?: PokemonInstance[];
+  team2?: PokemonInstance[];
+  ruleset?: MockRuleset;
+  dataManager?: DataManager;
+}): { engine: BattleEngine; ruleset: MockRuleset; events: BattleEvent[] } {
+  const ruleset = overrides?.ruleset ?? new MockRuleset();
+  const dataManager = overrides?.dataManager ?? createSleepTestDataManager();
+  const events: BattleEvent[] = [];
+
+  const team1 = overrides?.team1 ?? [
+    createTestPokemon(6, 50, {
+      uid: "charizard-1",
+      nickname: "Charizard",
+      moves: [
+        { moveId: "sleep-talk", currentPP: 10, maxPP: 10, ppUps: 0 },
+        { moveId: "snore", currentPP: 15, maxPP: 15, ppUps: 0 },
+        { moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 },
+      ],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 120,
+      },
+      currentHp: 200,
+      status: "sleep",
+    }),
+  ];
+
+  const team2 = overrides?.team2 ?? [
+    createTestPokemon(9, 50, {
+      uid: "blastoise-1",
+      nickname: "Blastoise",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 80,
+      },
+      currentHp: 200,
+    }),
+  ];
+
+  const config: BattleConfig = {
+    generation: 1,
+    format: "singles",
+    teams: [team1, team2],
+    seed: overrides?.seed ?? 12345,
+  };
+
+  const engine = new BattleEngine(config, ruleset, dataManager);
+  engine.on((e) => events.push(e));
+
+  return { engine, ruleset, events };
+}
+
+describe("Sleep-usable moves (issue #524)", () => {
+  it("given a sleeping Pokemon using Sleep Talk, when canExecuteMove runs, then the move is NOT blocked by sleep", () => {
+    // Arrange
+    // Source: Showdown sim/battle-actions.ts — sleepUsable moves bypass the sleep immobilization check
+    const { engine, ruleset, events } = createSleepTestEngine();
+
+    // Make processSleepTurn return false (still asleep) — but Sleep Talk should still execute
+    ruleset.processSleepTurn = (_pokemon, _state) => {
+      return false; // still asleep
+    };
+
+    engine.start();
+    events.length = 0;
+
+    // Act — sleeping Charizard uses Sleep Talk (slot 0)
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Assert — should NOT see a "fast asleep" message followed by no move execution.
+    // Sleep Talk should proceed (PP deducted = evidence of move executing).
+    // Since the MockRuleset executeMoveEffect is a no-op, we mainly confirm the move
+    // was not blocked. We look for PP deduction on sleep-talk.
+    const team = engine.getTeam(0);
+    const sleepTalkSlot = team[0].moves.find((m) => m.moveId === "sleep-talk");
+    // Source: Showdown — PP is deducted when a move is selected and executed, even while asleep
+    // If the move was blocked, PP would not be deducted
+    expect(sleepTalkSlot!.currentPP).toBe(9); // 10 - 1 = 9; move executed
+  });
+
+  it("given a sleeping Pokemon using Snore, when canExecuteMove runs, then the move is NOT blocked by sleep", () => {
+    // Arrange
+    // Source: Showdown sim/battle-actions.ts — Snore has sleepUsable flag
+    const { engine, ruleset, events } = createSleepTestEngine();
+
+    ruleset.processSleepTurn = (_pokemon, _state) => {
+      return false; // still asleep
+    };
+
+    engine.start();
+    events.length = 0;
+
+    // Act — sleeping Charizard uses Snore (slot 1)
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 1 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Assert
+    const team = engine.getTeam(0);
+    const snoreSlot = team[0].moves.find((m) => m.moveId === "snore");
+    // Source: Showdown — PP deducted on execution, proving the move was not blocked
+    expect(snoreSlot!.currentPP).toBe(14); // 15 - 1 = 14; move executed
+  });
+
+  it("given a sleeping Pokemon using Tackle, when canExecuteMove runs, then the move IS blocked by sleep", () => {
+    // Arrange
+    // Source: Showdown sim/battle-actions.ts — normal moves are blocked when asleep
+    const { engine, ruleset, events } = createSleepTestEngine();
+
+    ruleset.processSleepTurn = (_pokemon, _state) => {
+      return false; // still asleep
+    };
+
+    engine.start();
+    events.length = 0;
+
+    // Act — sleeping Charizard uses Tackle (slot 2, a regular move)
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 2 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Assert — Tackle should be blocked; PP should NOT be deducted
+    const team = engine.getTeam(0);
+    const tackleSlot = team[0].moves.find((m) => m.moveId === "tackle");
+    // Source: Showdown — PP is not deducted when a move is blocked by sleep
+    expect(tackleSlot!.currentPP).toBe(35); // unchanged; move was blocked
+  });
+
+  it("given a Pokemon that wakes up, when using Sleep Talk, then the move proceeds normally (wake-up still allows move)", () => {
+    // Arrange
+    // Source: Showdown — if processSleepTurn returns true (woke up), the move executes regardless
+    const { engine, ruleset } = createSleepTestEngine();
+
+    ruleset.processSleepTurn = (pokemon, _state) => {
+      // Pokemon wakes up this turn
+      pokemon.pokemon.status = null;
+      pokemon.volatileStatuses.delete("sleep-counter");
+      return true;
+    };
+
+    engine.start();
+
+    // Act — Charizard uses Sleep Talk (slot 0), but wakes up
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Assert — move should execute (PP deducted)
+    const team = engine.getTeam(0);
+    const sleepTalkSlot = team[0].moves.find((m) => m.moveId === "sleep-talk");
+    expect(sleepTalkSlot!.currentPP).toBe(9);
+  });
+});


### PR DESCRIPTION
## Summary
- **#524**: `canExecuteMove()` now allows Sleep Talk and Snore through the sleep immobilization check. The sleep counter still decrements normally, but these moves proceed to execution instead of being blocked. Uses a `SLEEP_USABLE_MOVES` constant (matching Showdown's `sleepUsable` flag).
- **#609**: Adds regression tests confirming `sendOut()` correctly applies `EntryHazardResult.statChanges` (e.g., Sticky Web Speed drop). The engine-side fix was already merged in PR #605 but lacked test coverage; the issue was never closed.

## Source
- Showdown sim/battle-actions.ts -- sleep check skipped for sleepUsable moves
- Showdown data/moves.ts -- sleepUsable flag on sleep-talk and snore
- Bulbapedia -- Sleep Talk / Snore descriptions
- Showdown data/moves.ts -- stickyweb: this.boost({spe: -1}, pokemon)

## Test plan
- [x] Sleeping Pokemon using Sleep Talk: move executes (PP deducted)
- [x] Sleeping Pokemon using Snore: move executes (PP deducted)
- [x] Sleeping Pokemon using Tackle: move blocked (PP not deducted)
- [x] Pokemon wakes up while using Sleep Talk: move executes normally
- [x] Sticky Web on switch-in: Speed stage decreases by 1
- [x] Combined damage + stat change hazard: both applied on switch-in
- [x] All 539 battle tests pass, all 17 turbo tasks pass

Closes #609
Closes #524

Generated with [Claude Code](https://claude.com/claude-code)