### PR TITLE
fix(gen6): Toxic Spikes respects Misty Terrain on switch-in

### DIFF
--- a/.changeset/misty-terrain-toxic-spikes.md
+++ b/.changeset/misty-terrain-toxic-spikes.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/gen6": patch
+---
+
+Fix Toxic Spikes terrain interaction: Misty Terrain now correctly suppresses both poison status and poison message on switch-in (closes #617)

--- a/packages/gen6/src/Gen6EntryHazards.ts
+++ b/packages/gen6/src/Gen6EntryHazards.ts
@@ -474,10 +474,20 @@ export function applyGen6EntryHazards(
       if (result.absorbed) {
         hazardsToRemove.push("toxic-spikes");
       }
-      if (result.status) {
+      // Source: Showdown data/conditions.ts -- mistyterrain.onSetStatus blocks all status
+      //   for grounded Pokemon. Toxic Spikes calls trySetStatus which checks terrain.
+      //   If Misty Terrain is active and the Pokemon is grounded, the status is blocked
+      //   and no poison message should be emitted.
+      // Note: Electric Terrain only blocks sleep, not poison, so it does not affect
+      //   Toxic Spikes. We inline the check to avoid circular imports with Gen6Terrain.ts.
+      const terrainBlocksStatus =
+        state.terrain?.type === "misty" && isGen6Grounded(switchingIn, gravityActive);
+      if (result.status && !terrainBlocksStatus) {
         statusInflicted = result.status;
       }
-      if (result.message) {
+      // Only suppress the poison message when terrain blocks the status.
+      // Absorption messages (Poison-type absorbing spikes) should still be emitted.
+      if (result.message && !(result.status && terrainBlocksStatus)) {
         messages.push(result.message);
       }
     }

--- a/packages/gen6/tests/entry-hazards.test.ts
+++ b/packages/gen6/tests/entry-hazards.test.ts
@@ -71,9 +71,13 @@ function makeSide(
   } as unknown as BattleSide;
 }
 
-function makeState(gravityActive = false): BattleState {
+function makeState(
+  gravityActive = false,
+  terrain?: { type: string; turnsLeft: number; source: string } | null,
+): BattleState {
   return {
     weather: null,
+    terrain: terrain ?? null,
     sides: [makeSide([]), makeSide([], 1)],
     trickRoom: { active: false, turnsLeft: 0 },
     gravity: { active: gravityActive, turnsLeft: gravityActive ? 5 : 0 },
@@ -759,5 +763,123 @@ describe("Gen6 applyGen6EntryHazards (combined)", () => {
     expect(result.statChanges).toEqual([{ stat: "speed", stages: -1 }]);
     // Messages: SR + sticky web + Defiant trigger
     expect(result.messages.some((m) => m.includes("Defiant"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Terrain + Toxic Spikes Interaction Tests (fix for #617)
+// ---------------------------------------------------------------------------
+
+describe("Gen6 applyGen6EntryHazards -- terrain blocks Toxic Spikes status", () => {
+  it("given Misty Terrain active and Toxic Spikes on the field, when a grounded Normal-type switches in, then no poison status and no poison message", () => {
+    // Source: Showdown data/conditions.ts -- mistyterrain.onSetStatus: blocks all status
+    //   for grounded Pokemon. Toxic Spikes' trySetStatus would fail under Misty Terrain.
+    // Source: Bulbapedia "Misty Terrain" Gen 6 -- "Grounded Pokemon are protected from
+    //   status conditions."
+    const pokemon = makeActivePokemon({ maxHp: 200, types: ["normal"] });
+    const side = makeSide([{ type: "toxic-spikes", layers: 1 }]);
+    const state = makeState(false, {
+      type: "misty",
+      turnsLeft: 5,
+      source: "misty-surge",
+    });
+    const result = applyGen6EntryHazards(pokemon, side, state, GEN6_TYPE_CHART);
+    expect(result.statusInflicted).toBeNull();
+    // No "was poisoned" message should appear
+    expect(result.messages.every((m) => !m.includes("poisoned"))).toBe(true);
+  });
+
+  it("given Misty Terrain active and 2 layers of Toxic Spikes, when a grounded Normal-type switches in, then no badly-poisoned status and no poison message", () => {
+    // Source: Showdown data/conditions.ts -- mistyterrain blocks ALL primary status,
+    //   including badly-poisoned from 2-layer Toxic Spikes
+    const pokemon = makeActivePokemon({ maxHp: 200, types: ["normal"] });
+    const side = makeSide([{ type: "toxic-spikes", layers: 2 }]);
+    const state = makeState(false, {
+      type: "misty",
+      turnsLeft: 3,
+      source: "misty-terrain",
+    });
+    const result = applyGen6EntryHazards(pokemon, side, state, GEN6_TYPE_CHART);
+    expect(result.statusInflicted).toBeNull();
+    expect(result.messages.every((m) => !m.includes("poisoned"))).toBe(true);
+  });
+
+  it("given no terrain active and Toxic Spikes on the field, when a grounded Normal-type switches in, then poison IS applied normally", () => {
+    // Source: Showdown data/moves.ts -- toxicspikes: when no terrain blocks,
+    //   grounded non-Poison/non-Steel gets poisoned
+    const pokemon = makeActivePokemon({ maxHp: 200, types: ["normal"] });
+    const side = makeSide([{ type: "toxic-spikes", layers: 1 }]);
+    const state = makeState();
+    const result = applyGen6EntryHazards(pokemon, side, state, GEN6_TYPE_CHART);
+    expect(result.statusInflicted).toBe("poison");
+    expect(result.messages.some((m) => m.includes("poisoned"))).toBe(true);
+  });
+
+  it("given Electric Terrain active and Toxic Spikes, when a grounded Normal-type switches in, then poison IS applied (Electric Terrain only blocks sleep)", () => {
+    // Source: Showdown data/conditions.ts -- electricterrain.onSetStatus:
+    //   only blocks sleep ('slp'), not poison. Toxic Spikes should still apply.
+    const pokemon = makeActivePokemon({ maxHp: 200, types: ["normal"] });
+    const side = makeSide([{ type: "toxic-spikes", layers: 1 }]);
+    const state = makeState(false, {
+      type: "electric",
+      turnsLeft: 5,
+      source: "electric-surge",
+    });
+    const result = applyGen6EntryHazards(pokemon, side, state, GEN6_TYPE_CHART);
+    expect(result.statusInflicted).toBe("poison");
+    expect(result.messages.some((m) => m.includes("poisoned"))).toBe(true);
+  });
+
+  it("given Misty Terrain active and Toxic Spikes, when a Flying-type switches in, then no status (not grounded, immune to spikes anyway)", () => {
+    // Source: Showdown -- Flying-type is not grounded, so immune to Toxic Spikes
+    //   regardless of terrain. Both grounding and terrain check should pass.
+    const pokemon = makeActivePokemon({ maxHp: 200, types: ["flying"] });
+    const side = makeSide([{ type: "toxic-spikes", layers: 1 }]);
+    const state = makeState(false, {
+      type: "misty",
+      turnsLeft: 5,
+      source: "misty-surge",
+    });
+    const result = applyGen6EntryHazards(pokemon, side, state, GEN6_TYPE_CHART);
+    expect(result.statusInflicted).toBeNull();
+    expect(result.messages.every((m) => !m.includes("poisoned"))).toBe(true);
+  });
+
+  it("given Misty Terrain + Toxic Spikes + Stealth Rock, when grounded Normal-type switches in, then takes SR damage but no poison", () => {
+    // Source: Showdown -- hazards apply independently; terrain only blocks the status
+    //   from Toxic Spikes, not damage from Stealth Rock.
+    // SR damage: floor(200 * 1 / 8) = 25 HP
+    const pokemon = makeActivePokemon({ maxHp: 200, types: ["normal"] });
+    const side = makeSide([
+      { type: "stealth-rock", layers: 1 },
+      { type: "toxic-spikes", layers: 1 },
+    ]);
+    const state = makeState(false, {
+      type: "misty",
+      turnsLeft: 5,
+      source: "misty-surge",
+    });
+    const result = applyGen6EntryHazards(pokemon, side, state, GEN6_TYPE_CHART);
+    expect(result.damage).toBe(25);
+    expect(result.statusInflicted).toBeNull();
+    // Should have SR message but no poison message
+    expect(result.messages.some((m) => m.includes("Pointed stones"))).toBe(true);
+    expect(result.messages.every((m) => !m.includes("poisoned"))).toBe(true);
+  });
+
+  it("given Misty Terrain + Toxic Spikes, when a Poison-type switches in, then absorbs Toxic Spikes normally", () => {
+    // Source: Showdown data/moves.ts -- Poison-type absorbs Toxic Spikes regardless of terrain
+    //   (absorption happens before status would be applied)
+    const pokemon = makeActivePokemon({ maxHp: 200, types: ["poison"] });
+    const side = makeSide([{ type: "toxic-spikes", layers: 2 }]);
+    const state = makeState(false, {
+      type: "misty",
+      turnsLeft: 5,
+      source: "misty-surge",
+    });
+    const result = applyGen6EntryHazards(pokemon, side, state, GEN6_TYPE_CHART);
+    expect(result.statusInflicted).toBeNull();
+    expect(result.hazardsToRemove).toEqual(["toxic-spikes"]);
+    expect(result.messages.some((m) => m.includes("absorbed"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Toxic Spikes no longer poisons grounded Pokemon when Misty Terrain is active
- Both the status infliction AND the poison message are suppressed (previously only the status was blocked by the engine's `applyPrimaryStatus` terrain gate, but the message was emitted from the hazard result)
- Terrain check added inside `applyGen6EntryHazards` before returning status/messages, matching Showdown's `trySetStatus` terrain gate behavior
- Poison-type absorption messages are correctly preserved (only poison status messages are suppressed)

## Source
- Showdown `data/conditions.ts` -- `mistyterrain.onSetStatus` blocks all status for grounded Pokemon
- Showdown `data/moves.ts` -- `toxicspikes.condition.onSwitchIn` calls `trySetStatus` which checks terrain
- Bulbapedia "Misty Terrain" Gen 6 -- "Grounded Pokemon are protected from status conditions."

## Test plan
- [x] Misty Terrain + 1 layer Toxic Spikes: no poison, no poison message
- [x] Misty Terrain + 2 layers Toxic Spikes: no badly-poisoned, no poison message
- [x] No terrain + Toxic Spikes: poison applied normally (regression)
- [x] Electric Terrain + Toxic Spikes: poison applied (Electric only blocks sleep)
- [x] Flying-type + Misty Terrain + Toxic Spikes: no status (not grounded)
- [x] Misty Terrain + Toxic Spikes + Stealth Rock: SR damage applied, no poison
- [x] Misty Terrain + Toxic Spikes + Poison-type: absorbs spikes normally

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)