### PR TITLE
feat(gen7): Wave 5 -- protect variants, Baneful Bunker, drain, two-turn moves, powder immunity

### DIFF
--- a/packages/gen7/src/Gen7MoveEffects.ts
+++ b/packages/gen7/src/Gen7MoveEffects.ts
@@ -576,10 +576,15 @@ function handleTwoTurnMove(ctx: MoveEffectContext): MoveEffectResult | null {
   const messageTemplate = TWO_TURN_MESSAGES[move.id] ?? "{pokemon} is charging up!";
   const message = messageTemplate.replace("{pokemon}", attackerName);
 
+  // If the move is not in the attacker's moveset (e.g., invoked via Mirror Move/Metronome),
+  // gracefully abort charging rather than defaulting to slot 0 which would execute the wrong move.
+  // Source: Showdown -- two-turn moves are only charged from the user's own moveset
+  if (moveIndex < 0) return null;
+
   return {
     ...base,
     forcedMoveSet: {
-      moveIndex: moveIndex >= 0 ? moveIndex : 0,
+      moveIndex,
       moveId: move.id,
       volatileStatus: volatile,
     },
@@ -621,7 +626,6 @@ export function handleDrainEffect(ctx: MoveEffectContext): MoveEffectResult | nu
   // or target already fainted). Without this, Math.max(1, 0) would trigger 1 Liquid Ooze recoil.
   // Source: Showdown sim/battle-actions.ts -- drain only triggers when damage > 0
   if (ctx.damage <= 0) return null;
-
 
   const drainFraction = ctx.move.effect.amount;
   let healAmount = Math.floor(ctx.damage * drainFraction);

--- a/packages/gen7/tests/move-effects.test.ts
+++ b/packages/gen7/tests/move-effects.test.ts
@@ -366,10 +366,10 @@ describe("Gen7 isBlockedByBanefulBunker", () => {
     expect(result.contactPoison).toBe(false);
   });
 
-  it("given physical non-contact move with protect flag, when checking, then blocked without poison", () => {
-    // Source: Showdown -- only contact moves get the poison penalty
-    const result = isBlockedByBanefulBunker(true, false);
-    expect(result.blocked).toBe(true);
+  it("given move without protect flag and no contact, when checking, then NOT blocked and no poison", () => {
+    // Source: Showdown -- if (!move.flags['protect']) return; -- both false means neither blocked nor poisoned
+    const result = isBlockedByBanefulBunker(false, false);
+    expect(result.blocked).toBe(false);
     expect(result.contactPoison).toBe(false);
   });
 
@@ -598,8 +598,10 @@ describe("Gen7 Drain Effects -- handleDrainEffect", () => {
     });
     const result = handleDrainEffect(ctx);
 
-    expect(result).not.toBeNull();
-    expect(result!.recoilDamage).toBe(0);
+    // Wave 6 added an early guard: ctx.damage <= 0 returns null immediately
+    // (before the Liquid Ooze check), so no recoil occurs when drain damage is zero.
+    // Source: Showdown sim/battle-actions.ts -- drain only triggers when damage > 0
+    expect(result).toBeNull();
   });
 
   it("given move without drain effect, when handling, then returns null", () => {
@@ -967,6 +969,27 @@ describe("Gen7 Two-Turn Moves -- executeGen7MoveEffect", () => {
     });
     expect(result!.messages[0]).toBe("Lopunny sprang up!");
   });
+
+  it("given Fly used when move is not in moveset (Mirror Move scenario), when charging, then returns null", () => {
+    // Source: Showdown -- two-turn moves invoked via Mirror Move/Metronome won't be in moveset
+    // When findIndex() returns -1, return null to avoid defaulting to slot 0 (wrong move).
+    const ctx = makeContext("fly", {
+      attacker: {
+        nickname: "Pidgeot",
+        // Moveset does NOT contain fly -- simulates Mirror Move / Metronome scenario
+        moves: [{ moveId: "tackle" }, { moveId: "roost" }],
+      },
+      moveOverrides: {
+        category: "physical",
+        power: 90,
+      },
+    });
+    const rng = new SeededRandom(42);
+    const result = executeGen7MoveEffect(ctx, rng, alwaysSucceedProtect);
+
+    // Should return null (no forced charge) to prevent slot-0 fallback executing wrong move
+    expect(result).toBeNull();
+  });
 });
 
 // ===========================================================================
@@ -1244,7 +1267,9 @@ describe("Gen7Ruleset.executeMoveEffect -- integration", () => {
     });
     const result = ruleset.executeMoveEffect(ctx);
 
-    // Non-Grass target: falls through to BaseRuleset (default empty result)
-    expect(result.messages).not.toContain("doesn't affect");
+    // Non-Grass target: falls through to BaseRuleset (default empty result = no messages, no effects)
+    // Source: Gen7Ruleset delegates to super.executeMoveEffect which returns createBaseResult()
+    expect(result.messages).toEqual([]);
+    expect(result.statusInflicted).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Protect variants: King's Shield (-2 Atk on contact), Spiky Shield (1/8 recoil on contact), **Baneful Bunker** (NEW: blocks all moves + poisons contact attackers), Mat Block (first-turn team protect), Crafty Shield (blocks status)
- Drain effects: 50% heal (75% with Big Root), Liquid Ooze damage penalty
- Two-turn moves: Fly/Dig/Dive semi-invulnerability, Solar Beam fires immediately in Sun, Phantom Force/Shadow Force phase through Protect
- Grass-type powder immunity (Gen 6+ carry-forward)
- 67 new tests; 524 total gen7 tests pass

## Test Plan

- [x] 524 gen7 tests pass (67 new)
- [x] Biome: no errors
- [x] TypeScript: no errors
- [x] All protect variants, drain, and two-turn move interactions tested

## Related Issue

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Crafty Shield to allow field-targeting moves to pass through
  * Fixed two-turn move charging behavior when the move isn't available in the attacker's moveset
  * Improved Liquid Ooze interaction with drain-effect moves, removing unintended recoil in certain scenarios
  
* **Tests**
  * Expanded test coverage for move interactions and ability mechanics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->