### PR TITLE
feat(gen8): Wave 5A -- damage-modifying and stat ability handlers

### DIFF
--- a/.changeset/gen8-wave5a-abilities.md
+++ b/.changeset/gen8-wave5a-abilities.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/gen8": minor
+---
+
+Wave 5A: Gen 8 damage-modifying and stat abilities (Gorilla Tactics, Transistor, Dragon's Maw, Punk Rock, Ice Scales, Steelworker, Intrepid Sword, Dauntless Shield, Cotton Down, Steam Engine, Quick Draw)

--- a/packages/gen8/src/Gen8AbilitiesDamage.ts
+++ b/packages/gen8/src/Gen8AbilitiesDamage.ts
@@ -1,0 +1,880 @@
+import type { AbilityContext, AbilityResult } from "@pokemon-lib-ts/battle";
+import type { MoveEffect, PokemonType } from "@pokemon-lib-ts/core";
+
+/**
+ * Gen 8 damage-modifying ability handlers.
+ *
+ * Carries forward all Gen 7 damage abilities unchanged and adds Gen 8 abilities:
+ *   - Gorilla Tactics (new): 1.5x physical attack (like Choice Band without the item slot)
+ *   - Transistor (new): 1.5x Electric moves
+ *   - Dragon's Maw (new): 1.5x Dragon moves
+ *   - Punk Rock (new): 1.3x outgoing sound moves / 0.5x incoming sound moves
+ *   - Ice Scales (new): 0.5x incoming special damage
+ *   - Steelworker (carry from Gen 7): 1.5x Steel moves
+ *
+ * All numerical damage effects are handled directly in Gen8DamageCalc.ts.
+ * These handler functions return activation signals so the engine can emit
+ * appropriate messages and track ability usage.
+ *
+ * Source: Showdown data/abilities.ts -- Gen 8 ability handlers
+ * Source: Bulbapedia -- individual ability articles
+ */
+
+// ---------------------------------------------------------------------------
+// Recoil detection helper (for Reckless) -- carried from Gen 5/6/7
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a move has recoil (for Reckless boost).
+ *
+ * Source: Showdown data/abilities.ts -- Reckless checks for recoil flag
+ */
+function hasRecoilEffect(effect: MoveEffect | null): boolean {
+  if (!effect) return false;
+  if (effect.type === "recoil") return true;
+  if (effect.type === "multi") {
+    return effect.effects.some((e) => e.type === "recoil");
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Sheer Force secondary effect detection -- carried from Gen 5/6/7
+// ---------------------------------------------------------------------------
+
+/**
+ * Moves whose Sheer Force-eligible secondaries cannot be represented in our
+ * MoveEffect union because Showdown stores them as custom `onHit` functions.
+ *
+ * Source: Showdown data/moves.ts -- triattack: secondary.onHit randomly picks
+ *   from burn/paralysis/freeze with 20% chance
+ */
+const SHEER_FORCE_MOVE_WHITELIST: ReadonlySet<string> = new Set([
+  "tri-attack",
+  "secret-power",
+  "relic-song",
+]);
+
+/**
+ * Check if a move has secondary effects that Sheer Force would suppress.
+ *
+ * Source: Showdown data/abilities.ts -- sheerforce
+ */
+export function hasSheerForceEligibleEffect(effect: MoveEffect | null): boolean {
+  if (!effect) return false;
+
+  switch (effect.type) {
+    case "status-chance":
+      return true;
+    case "stat-change":
+      if (effect.target === "foe" && effect.chance > 0) return true;
+      if (effect.target === "self" && effect.fromSecondary === true) return true;
+      return false;
+    case "volatile-status":
+      return effect.chance > 0;
+    case "multi":
+      return effect.effects.some((e) => hasSheerForceEligibleEffect(e));
+    default:
+      return false;
+  }
+}
+
+/**
+ * Combined check: is a move eligible for Sheer Force?
+ *
+ * Source: Showdown data/abilities.ts -- sheerforce
+ */
+export function isSheerForceEligibleMove(effect: MoveEffect | null, moveId: string): boolean {
+  return hasSheerForceEligibleEffect(effect) || SHEER_FORCE_MOVE_WHITELIST.has(moveId);
+}
+
+// ---------------------------------------------------------------------------
+// Pinch ability type mapping -- carried from Gen 5/6/7
+// ---------------------------------------------------------------------------
+
+/**
+ * Pinch abilities: 1.5x attack stat when HP <= floor(maxHP/3) and move type matches.
+ *
+ * Source: Showdown data/abilities.ts -- Blaze/Overgrow/Torrent/Swarm onModifyAtk/onModifySpA
+ */
+const PINCH_ABILITY_TYPES: Readonly<Record<string, PokemonType>> = {
+  blaze: "fire",
+  overgrow: "grass",
+  torrent: "water",
+  swarm: "bug",
+};
+
+// ---------------------------------------------------------------------------
+// Shared sentinel
+// ---------------------------------------------------------------------------
+
+const NO_ACTIVATION: AbilityResult = {
+  activated: false,
+  effects: [],
+  messages: [],
+};
+
+// ---------------------------------------------------------------------------
+// Public API: damage-calc abilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle damage-calc ability modifiers for Gen 8.
+ *
+ * Covers all Gen 7 damage-calc abilities plus Gen 8 additions:
+ *   - Gorilla Tactics (new): 1.5x physical attack
+ *   - Transistor (new): 1.5x Electric moves
+ *   - Dragon's Maw (new): 1.5x Dragon moves
+ *   - Punk Rock (new): 1.3x outgoing sound moves
+ *   - Steelworker: 1.5x Steel moves
+ *
+ * Source: Showdown data/abilities.ts
+ * Source: Bulbapedia -- individual ability articles
+ */
+export function handleGen8DamageCalcAbility(ctx: AbilityContext): AbilityResult {
+  const abilityId = ctx.pokemon.ability;
+  const name = ctx.pokemon.pokemon.nickname ?? String(ctx.pokemon.pokemon.speciesId);
+
+  switch (abilityId) {
+    // ---- Attacker-side abilities (carried from Gen 7) ----
+
+    case "sheer-force": {
+      // Sheer Force: 1.3x (5325/4096) damage for moves with secondary effects.
+      // Suppresses Life Orb recoil for affected moves.
+      // Source: Showdown data/abilities.ts -- sheerforce onBasePower
+      if (!ctx.move) return NO_ACTIVATION;
+      if (!isSheerForceEligibleMove(ctx.move.effect, ctx.move.id)) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "analytic": {
+      // Analytic: 1.3x (5325/4096) damage if the user moves last.
+      // Source: Showdown data/abilities.ts -- analytic onBasePower
+      if (!ctx.opponent) return NO_ACTIVATION;
+      if (!ctx.opponent.movedThisTurn) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "sand-force": {
+      // Sand Force: 1.3x (5325/4096) to Rock, Ground, Steel moves in sandstorm.
+      // Source: Showdown data/abilities.ts -- sandforce onBasePower
+      if (!ctx.move) return NO_ACTIVATION;
+      const weather = ctx.state.weather?.type ?? null;
+      if (weather !== "sand") return NO_ACTIVATION;
+      const sandForceTypes: PokemonType[] = ["rock", "ground", "steel"];
+      if (!sandForceTypes.includes(ctx.move.type)) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "technician": {
+      // Technician: 1.5x power for moves with base power <= 60.
+      // Source: Showdown data/abilities.ts -- technician onBasePower (priority 30)
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.power === null || ctx.move.power > 60) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "iron-fist": {
+      // Iron Fist: 1.2x (4915/4096) power for punching moves.
+      // Source: Showdown data/abilities.ts -- ironfist: move.flags['punch']
+      if (!ctx.move) return NO_ACTIVATION;
+      if (!ctx.move.flags.punch) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "reckless": {
+      // Reckless: 1.2x (4915/4096) power for recoil AND crash-damage moves.
+      // Source: Showdown data/abilities.ts -- reckless: move.recoil || move.hasCrashDamage
+      if (!ctx.move) return NO_ACTIVATION;
+      if (!hasRecoilEffect(ctx.move.effect) && !ctx.move.hasCrashDamage) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "adaptability": {
+      // Adaptability: STAB becomes 2x instead of 1.5x.
+      // Source: Showdown data/abilities.ts -- adaptability onModifySTAB
+      if (!ctx.move) return NO_ACTIVATION;
+      if (!ctx.pokemon.types.includes(ctx.move.type)) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "hustle": {
+      // Hustle: 1.5x Attack stat for physical moves, 0.8x accuracy.
+      // Source: Showdown data/abilities.ts -- hustle onModifyAtk
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.category !== "physical") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "huge-power":
+    case "pure-power": {
+      // Huge Power / Pure Power: 2x Attack stat.
+      // Source: Showdown data/abilities.ts -- hugepower / purepower onModifyAtk
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.category !== "physical") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "guts": {
+      // Guts: 1.5x Attack when the user has a primary status condition.
+      // Source: Showdown data/abilities.ts -- guts onModifyAtk
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.category !== "physical") return NO_ACTIVATION;
+      if (ctx.pokemon.pokemon.status === null) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "blaze":
+    case "overgrow":
+    case "torrent":
+    case "swarm": {
+      // Pinch abilities: 1.5x when HP <= floor(maxHP/3) and move type matches.
+      // Source: Showdown data/abilities.ts -- blaze/overgrow/torrent/swarm
+      if (!ctx.move) return NO_ACTIVATION;
+      const pinchType = PINCH_ABILITY_TYPES[abilityId];
+      if (!pinchType || ctx.move.type !== pinchType) return NO_ACTIVATION;
+      const maxHp = ctx.pokemon.pokemon.calculatedStats?.hp ?? ctx.pokemon.pokemon.currentHp;
+      const threshold = Math.floor(maxHp / 3);
+      if (ctx.pokemon.pokemon.currentHp > threshold) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "sniper": {
+      // Sniper: crits deal extra damage. The damage calc applies the numeric value.
+      // Source: Showdown data/abilities.ts -- sniper onModifyDamage: if crit, chainModify(1.5)
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "tinted-lens": {
+      // Tinted Lens: "Not very effective" moves deal 2x damage.
+      // Source: Showdown data/abilities.ts -- tintedlens onModifyDamage
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    // ---- Gen 6 carry-forward: Attacker-side ----
+
+    case "tough-claws": {
+      // Tough Claws: 1.3x (5325/4096) power for contact moves.
+      // Source: Bulbapedia "Tough Claws" -- boosts contact moves by 30%
+      // Source: Showdown data/abilities.ts -- toughclaws: move.flags['contact']
+      if (!ctx.move) return NO_ACTIVATION;
+      if (!ctx.move.flags.contact) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name}'s Tough Claws boosted the attack!`],
+      };
+    }
+
+    case "strong-jaw": {
+      // Strong Jaw: 1.5x (6144/4096) power for bite moves.
+      // Source: Bulbapedia "Strong Jaw" -- boosts bite moves by 50%
+      // Source: Showdown data/abilities.ts -- strongjaw: move.flags['bite']
+      if (!ctx.move) return NO_ACTIVATION;
+      if (!ctx.move.flags.bite) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name}'s Strong Jaw boosted the attack!`],
+      };
+    }
+
+    case "mega-launcher": {
+      // Mega Launcher: 1.5x (6144/4096) power for pulse/aura moves.
+      // Source: Bulbapedia "Mega Launcher" -- boosts pulse/aura moves by 50%
+      // Source: Showdown data/abilities.ts -- megalauncher: move.flags['pulse']
+      if (!ctx.move) return NO_ACTIVATION;
+      if (!ctx.move.flags.pulse) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name}'s Mega Launcher boosted the attack!`],
+      };
+    }
+
+    // ---- -ate abilities (Gen 7/8: 1.2x) ----
+
+    case "pixilate": {
+      // Pixilate: Normal moves become Fairy, 1.2x (4915/4096) boost.
+      // Source: Showdown data/abilities.ts -- pixilate: onModifyType + onBasePower
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.type !== "normal") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "type-change", target: "self", types: ["fairy"] }],
+        messages: [`${name}'s Pixilate transformed the move into Fairy type!`],
+      };
+    }
+
+    case "aerilate": {
+      // Aerilate: Normal moves become Flying, 1.2x (4915/4096) boost.
+      // Source: Showdown data/abilities.ts -- aerilate: onModifyType + onBasePower
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.type !== "normal") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "type-change", target: "self", types: ["flying"] }],
+        messages: [`${name}'s Aerilate transformed the move into Flying type!`],
+      };
+    }
+
+    case "refrigerate": {
+      // Refrigerate: Normal moves become Ice, 1.2x (4915/4096) boost.
+      // Source: Showdown data/abilities.ts -- refrigerate: onModifyType + onBasePower
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.type !== "normal") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "type-change", target: "self", types: ["ice"] }],
+        messages: [`${name}'s Refrigerate transformed the move into Ice type!`],
+      };
+    }
+
+    case "galvanize": {
+      // Galvanize: Normal moves become Electric, 1.2x (4915/4096) boost.
+      // Source: Showdown data/abilities.ts -- galvanize: onModifyType + onBasePower
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.type !== "normal") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "type-change", target: "self", types: ["electric"] }],
+        messages: [`${name}'s Galvanize transformed the move into Electric type!`],
+      };
+    }
+
+    case "parental-bond": {
+      // Parental Bond: moves hit twice, second hit at 25% power in Gen 7+.
+      // Source: Showdown data/abilities.ts -- parentalbond: Gen 7+ secondHit 0.25
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.effect?.type === "multi-hit") return NO_ACTIVATION;
+      if (!ctx.move.power || ctx.move.power <= 0) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name}'s Parental Bond lets it attack twice!`],
+      };
+    }
+
+    // ---- NEW Gen 8 attacker-side abilities ----
+
+    case "gorilla-tactics": {
+      // Gorilla Tactics: 1.5x Attack for physical moves (locks into first move used).
+      // Source: Showdown data/abilities.ts -- gorillatactics: onModifyAtk, chainModify(1.5)
+      // Source: Bulbapedia "Gorilla Tactics" -- "boosts Attack by 50% but locks the user
+      //   into the first move it uses"
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.category !== "physical") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name}'s Gorilla Tactics boosted its Attack!`],
+      };
+    }
+
+    case "transistor": {
+      // Transistor: 1.5x (6144/4096) for Electric-type moves.
+      // Source: Showdown data/abilities.ts -- transistor: onModifyAtk/onModifySpA, chainModify(1.5)
+      // Source: Bulbapedia "Transistor" -- "powers up Electric-type moves by 50%"
+      // Note: In Gen 9, nerfed to 1.3333x (5461/4096). Gen 8 is 1.5x.
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.type !== "electric") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name}'s Transistor powered up the move!`],
+      };
+    }
+
+    case "dragons-maw": {
+      // Dragon's Maw: 1.5x (6144/4096) for Dragon-type moves.
+      // Source: Showdown data/abilities.ts -- dragonsmaw: onModifyAtk/onModifySpA, chainModify(1.5)
+      // Source: Bulbapedia "Dragon's Maw" -- "powers up Dragon-type moves by 50%"
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.type !== "dragon") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name}'s Dragon's Maw powered up the move!`],
+      };
+    }
+
+    case "punk-rock": {
+      // Punk Rock (attacker side): 1.3x (5325/4096) for sound-based moves.
+      // Source: Showdown data/abilities.ts -- punkrock: onBasePower, chainModify([5325, 4096])
+      // Source: Bulbapedia "Punk Rock" -- "boosts the power of sound-based moves by 30%"
+      if (!ctx.move) return NO_ACTIVATION;
+      if (!ctx.move.flags.sound) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name}'s Punk Rock boosted the move!`],
+      };
+    }
+
+    case "steelworker": {
+      // Steelworker: 1.5x (6144/4096) for Steel-type moves.
+      // Source: Showdown data/abilities.ts -- steelworker: onModifyAtk/onModifySpA, chainModify(1.5)
+      // Source: Bulbapedia "Steelworker" -- "powers up Steel-type moves by 50%"
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.type !== "steel") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name}'s Steelworker powered up the move!`],
+      };
+    }
+
+    // ---- Defender-side abilities ----
+
+    case "multiscale":
+    case "shadow-shield": {
+      // Multiscale / Shadow Shield: 0.5x damage taken when at full HP.
+      // Source: Showdown data/abilities.ts -- multiscale/shadowshield onSourceModifyDamage
+      const maxHpMs = ctx.pokemon.pokemon.calculatedStats?.hp ?? ctx.pokemon.pokemon.currentHp;
+      if (ctx.pokemon.pokemon.currentHp < maxHpMs) return NO_ACTIVATION;
+      const abilityName = abilityId === "multiscale" ? "Multiscale" : "Shadow Shield";
+      return {
+        activated: true,
+        effects: [{ effectType: "damage-reduction", target: "self" }],
+        messages: [`${name}'s ${abilityName} weakened the attack!`],
+      };
+    }
+
+    case "solid-rock":
+    case "filter": {
+      // Solid Rock / Filter: 0.75x super-effective damage taken.
+      // Source: Showdown data/abilities.ts -- solidrock / filter onSourceModifyDamage
+      return {
+        activated: true,
+        effects: [{ effectType: "damage-reduction", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "prism-armor": {
+      // Prism Armor: 0.75x super-effective damage. Cannot be ignored by Mold Breaker.
+      // Source: Showdown data/abilities.ts -- prismarmor: isBreakable: false
+      return {
+        activated: true,
+        effects: [{ effectType: "damage-reduction", target: "self" }],
+        messages: [`${name}'s Prism Armor weakened the attack!`],
+      };
+    }
+
+    case "thick-fat": {
+      // Thick Fat: 0.5x damage from Fire and Ice type moves.
+      // Source: Showdown data/abilities.ts -- thickfat onSourceModifyAtk/onSourceModifySpA
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.type !== "fire" && ctx.move.type !== "ice") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "damage-reduction", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "marvel-scale": {
+      // Marvel Scale: 1.5x Defense when the holder has a primary status condition.
+      // Source: Showdown data/abilities.ts -- marvelscale onModifyDef
+      if (ctx.pokemon.pokemon.status === null) return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "damage-reduction", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "fur-coat": {
+      // Fur Coat: doubles effective Defense against physical moves.
+      // Source: Showdown data/abilities.ts -- furcoat: onModifyDef, chainModify(2)
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.category !== "physical") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "damage-reduction", target: "self" }],
+        messages: [`${name}'s Fur Coat halved the damage!`],
+      };
+    }
+
+    // ---- NEW Gen 8 defender-side abilities ----
+
+    case "ice-scales": {
+      // Ice Scales: 0.5x (2048/4096) incoming special damage.
+      // Source: Showdown data/abilities.ts -- icescales: onSourceModifyDamage, chainModify(0.5)
+      // Source: Bulbapedia "Ice Scales" -- "halves the damage taken from special moves"
+      if (!ctx.move) return NO_ACTIVATION;
+      if (ctx.move.category !== "special") return NO_ACTIVATION;
+      return {
+        activated: true,
+        effects: [{ effectType: "damage-reduction", target: "self" }],
+        messages: [`${name}'s Ice Scales weakened the attack!`],
+      };
+    }
+
+    default:
+      return NO_ACTIVATION;
+  }
+}
+
+/**
+ * Handle damage-immunity and damage-capping ability checks for Gen 8.
+ *
+ * Sturdy: blocks OHKO moves AND survives any hit from full HP at 1 HP.
+ *
+ * Source: Showdown data/abilities.ts -- sturdy
+ */
+export function handleGen8DamageImmunityAbility(ctx: AbilityContext): AbilityResult {
+  const abilityId = ctx.pokemon.ability;
+  const name = ctx.pokemon.pokemon.nickname ?? String(ctx.pokemon.pokemon.speciesId);
+
+  switch (abilityId) {
+    case "sturdy": {
+      // Sturdy: Block OHKO moves entirely
+      // Source: Showdown data/abilities.ts -- sturdy onTryHit
+      if (ctx.move?.effect?.type === "ohko") {
+        return {
+          activated: true,
+          effects: [{ effectType: "damage-reduction", target: "self" }],
+          messages: [`${name} held on thanks to Sturdy!`],
+          movePrevented: true,
+        };
+      }
+      return NO_ACTIVATION;
+    }
+
+    default:
+      return NO_ACTIVATION;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure utility functions for direct use by the damage calc
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate the Sheer Force damage multiplier for a move.
+ * Returns 5325/4096 (~1.3x) if Sheer Force is active AND the move has secondary effects.
+ *
+ * Source: Showdown data/abilities.ts -- sheerforce onBasePower: chainModify([5325, 4096])
+ */
+export function getSheerForceMultiplier(
+  abilityId: string,
+  effect: MoveEffect | null,
+  moveId?: string,
+): number {
+  if (abilityId !== "sheer-force") return 1;
+  if (!isSheerForceEligibleMove(effect, moveId ?? "")) return 1;
+  return 5325 / 4096;
+}
+
+/**
+ * Check whether Sheer Force suppresses Life Orb recoil for this move.
+ *
+ * Source: Showdown scripts.ts -- if move.hasSheerForce, skip Life Orb recoil
+ */
+export function sheerForceSuppressesLifeOrb(
+  abilityId: string,
+  effect: MoveEffect | null,
+  moveId?: string,
+): boolean {
+  if (abilityId !== "sheer-force") return false;
+  return isSheerForceEligibleMove(effect, moveId ?? "");
+}
+
+/**
+ * Calculate the Multiscale / Shadow Shield damage multiplier.
+ * Returns 0.5 if the defender has Multiscale or Shadow Shield and is at full HP.
+ *
+ * Source: Showdown data/abilities.ts -- multiscale/shadowshield onSourceModifyDamage
+ */
+export function getMultiscaleMultiplier(
+  abilityId: string,
+  currentHp: number,
+  maxHp: number,
+): number {
+  if (abilityId !== "multiscale" && abilityId !== "shadow-shield") return 1;
+  if (currentHp < maxHp) return 1;
+  return 0.5;
+}
+
+/**
+ * Calculate the Sturdy damage cap.
+ * If Sturdy holder is at full HP and damage would KO, returns maxHp - 1.
+ *
+ * Source: Showdown data/abilities.ts -- sturdy onDamage (priority -30)
+ */
+export function getSturdyDamageCap(
+  abilityId: string,
+  damage: number,
+  currentHp: number,
+  maxHp: number,
+): number {
+  if (abilityId !== "sturdy") return damage;
+  if (currentHp !== maxHp) return damage;
+  if (damage < currentHp) return damage;
+  return maxHp - 1;
+}
+
+/**
+ * Check if Sturdy blocks an OHKO move entirely.
+ *
+ * Source: Showdown data/abilities.ts -- sturdy onTryHit
+ */
+export function sturdyBlocksOHKO(abilityId: string, effect: MoveEffect | null): boolean {
+  if (abilityId !== "sturdy") return false;
+  if (!effect) return false;
+  return effect.type === "ohko";
+}
+
+/**
+ * Get the Tough Claws multiplier.
+ * Returns 5325/4096 (~1.3x) for contact moves.
+ *
+ * Source: Showdown data/abilities.ts -- toughclaws: chainModify([5325, 4096])
+ */
+export function getToughClawsMultiplier(abilityId: string, isContact: boolean): number {
+  if (abilityId !== "tough-claws") return 1;
+  if (!isContact) return 1;
+  return 5325 / 4096;
+}
+
+/**
+ * Get the Strong Jaw multiplier.
+ * Returns 1.5x for bite moves.
+ *
+ * Source: Showdown data/abilities.ts -- strongjaw: chainModify(1.5)
+ */
+export function getStrongJawMultiplier(abilityId: string, isBite: boolean): number {
+  if (abilityId !== "strong-jaw") return 1;
+  if (!isBite) return 1;
+  return 1.5;
+}
+
+/**
+ * Get the Mega Launcher multiplier.
+ * Returns 1.5x for pulse/aura moves.
+ *
+ * Source: Showdown data/abilities.ts -- megalauncher: chainModify(1.5)
+ */
+export function getMegaLauncherMultiplier(abilityId: string, isPulse: boolean): number {
+  if (abilityId !== "mega-launcher") return 1;
+  if (!isPulse) return 1;
+  return 1.5;
+}
+
+/**
+ * Get the -ate ability type override and power multiplier for Gen 8.
+ * Pixilate/Aerilate/Refrigerate/Galvanize: change Normal -> X type with 1.2x boost.
+ *
+ * Gen 7/8: 1.2x (4915/4096), was 1.3x (5325/4096) in Gen 6.
+ *
+ * Source: Showdown data/abilities.ts -- Gen 7+: chainModify([4915, 4096])
+ *
+ * @returns { type, multiplier } if the ability activates, or null otherwise
+ */
+export function getAteAbilityOverride(
+  abilityId: string,
+  moveType: PokemonType,
+): { type: PokemonType; multiplier: number } | null {
+  if (moveType !== "normal") return null;
+
+  switch (abilityId) {
+    case "pixilate":
+      return { type: "fairy", multiplier: 4915 / 4096 };
+    case "aerilate":
+      return { type: "flying", multiplier: 4915 / 4096 };
+    case "refrigerate":
+      return { type: "ice", multiplier: 4915 / 4096 };
+    case "galvanize":
+      return { type: "electric", multiplier: 4915 / 4096 };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Check if Parental Bond activates for a move.
+ * Returns true if the move can be doubled (not multi-hit, not status, has power).
+ *
+ * Source: Showdown data/abilities.ts -- parentalbond onModifyMove
+ * Source: Bulbapedia "Parental Bond" -- second hit is 25% in Gen 7+
+ */
+export function isParentalBondEligible(
+  abilityId: string,
+  movePower: number | null,
+  moveEffectType: string | null,
+): boolean {
+  if (abilityId !== "parental-bond") return false;
+  if (!movePower || movePower <= 0) return false;
+  if (moveEffectType === "multi-hit") return false;
+  return true;
+}
+
+/**
+ * Gen 7+ Parental Bond second-hit multiplier: 0.25 (25% of first hit).
+ *
+ * Source: Showdown data/abilities.ts -- Gen 7+: parentalbond secondHit 0.25
+ * Source: Bulbapedia "Parental Bond" -- "nerfed from 50% to 25% in Gen 7"
+ */
+export const PARENTAL_BOND_SECOND_HIT_MULTIPLIER = 0.25;
+
+/**
+ * Get the Fur Coat defense multiplier.
+ * Returns 2.0 against physical moves.
+ *
+ * Source: Showdown data/abilities.ts -- furcoat: onModifyDef, chainModify(2)
+ */
+export function getFurCoatMultiplier(abilityId: string, isPhysical: boolean): number {
+  if (abilityId !== "fur-coat") return 1;
+  if (!isPhysical) return 1;
+  return 2;
+}
+
+// ---------------------------------------------------------------------------
+// NEW Gen 8 pure utility functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the Gorilla Tactics Attack multiplier.
+ * Returns 1.5x (6144/4096) for physical moves when ability is 'gorilla-tactics'.
+ *
+ * Source: Showdown data/abilities.ts -- gorillatactics: onModifyAtk, chainModify(1.5)
+ * Source: Bulbapedia "Gorilla Tactics" -- "boosts Attack by 50%"
+ */
+export function getGorillaTacticsMultiplier(abilityId: string, category: string): number {
+  if (abilityId !== "gorilla-tactics") return 1;
+  if (category !== "physical") return 1;
+  return 6144 / 4096;
+}
+
+/**
+ * Get the Transistor multiplier.
+ * Returns 1.5x (6144/4096) for Electric-type moves when ability is 'transistor'.
+ *
+ * Note: In Gen 9, this was nerfed to ~1.3333x (5461/4096). Gen 8 uses 1.5x.
+ *
+ * Source: Showdown data/abilities.ts -- transistor: chainModify(1.5) in Gen 8
+ * Source: Bulbapedia "Transistor" -- "powers up Electric-type moves by 50%"
+ */
+export function getTransistorMultiplier(abilityId: string, moveType: PokemonType): number {
+  if (abilityId !== "transistor") return 1;
+  if (moveType !== "electric") return 1;
+  return 6144 / 4096;
+}
+
+/**
+ * Get the Dragon's Maw multiplier.
+ * Returns 1.5x (6144/4096) for Dragon-type moves when ability is 'dragons-maw'.
+ *
+ * Source: Showdown data/abilities.ts -- dragonsmaw: chainModify(1.5)
+ * Source: Bulbapedia "Dragon's Maw" -- "powers up Dragon-type moves by 50%"
+ */
+export function getDragonsMawMultiplier(abilityId: string, moveType: PokemonType): number {
+  if (abilityId !== "dragons-maw") return 1;
+  if (moveType !== "dragon") return 1;
+  return 6144 / 4096;
+}
+
+/**
+ * Get the Punk Rock outgoing damage multiplier (attacker side).
+ * Returns 5325/4096 (~1.3x) for sound-based moves when ability is 'punk-rock'.
+ *
+ * Source: Showdown data/abilities.ts -- punkrock: onBasePower, chainModify([5325, 4096])
+ * Source: Bulbapedia "Punk Rock" -- "boosts the power of sound-based moves by 30%"
+ */
+export function getPunkRockMultiplier(abilityId: string, isSound: boolean): number {
+  if (abilityId !== "punk-rock") return 1;
+  if (!isSound) return 1;
+  return 5325 / 4096;
+}
+
+/**
+ * Get the Punk Rock incoming damage multiplier (defender side).
+ * Returns 0.5 for incoming sound-based moves when ability is 'punk-rock'.
+ *
+ * Source: Showdown data/abilities.ts -- punkrock: onSourceModifyDamage, chainModify(0.5)
+ * Source: Bulbapedia "Punk Rock" -- "halves the damage taken from sound-based moves"
+ */
+export function getPunkRockIncomingMultiplier(abilityId: string, isSound: boolean): number {
+  if (abilityId !== "punk-rock") return 1;
+  if (!isSound) return 1;
+  return 0.5;
+}
+
+/**
+ * Get the Ice Scales incoming damage multiplier.
+ * Returns 0.5 (2048/4096) for incoming special attacks when ability is 'ice-scales'.
+ *
+ * Source: Showdown data/abilities.ts -- icescales: onSourceModifyDamage, chainModify(0.5)
+ * Source: Bulbapedia "Ice Scales" -- "halves the damage taken from special moves"
+ */
+export function getIceScalesMultiplier(abilityId: string, category: string): number {
+  if (abilityId !== "ice-scales") return 1;
+  if (category !== "special") return 1;
+  return 0.5;
+}
+
+/**
+ * Get the Steelworker multiplier.
+ * Returns 1.5x (6144/4096) for Steel-type moves when ability is 'steelworker'.
+ *
+ * Source: Showdown data/abilities.ts -- steelworker: chainModify(1.5)
+ * Source: Bulbapedia "Steelworker" -- "powers up Steel-type moves by 50%"
+ */
+export function getSteelworkerMultiplier(abilityId: string, moveType: PokemonType): number {
+  if (abilityId !== "steelworker") return 1;
+  if (moveType !== "steel") return 1;
+  return 6144 / 4096;
+}

--- a/packages/gen8/src/Gen8AbilitiesStat.ts
+++ b/packages/gen8/src/Gen8AbilitiesStat.ts
@@ -1,0 +1,996 @@
+import type { AbilityContext, AbilityEffect, AbilityResult } from "@pokemon-lib-ts/battle";
+import type { MoveCategory } from "@pokemon-lib-ts/core";
+
+/**
+ * Gen 8 stat-modifying, priority, and KO-trigger ability handlers.
+ *
+ * Carries forward all Gen 7 stat/priority abilities and adds Gen 8 abilities:
+ *   - Intrepid Sword (new): +1 Attack on every switch-in (Gen 8 pre-nerf: no once-per-battle limit)
+ *   - Dauntless Shield (new): +1 Defense on every switch-in (Gen 8 pre-nerf)
+ *   - Cotton Down (new): when hit, lower all adjacent foes' Speed by 1
+ *   - Steam Engine (new): +6 Speed when hit by Fire or Water move
+ *   - Quick Draw (new): 30% chance to move first
+ *   - Moody: Gen 8 excludes accuracy/evasion (only 5 stats eligible, unlike Gen 5-7)
+ *
+ * Source: Showdown data/abilities.ts
+ * Source: Bulbapedia -- individual ability articles
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The 5 stats eligible for Moody in Gen 8+ (accuracy/evasion EXCLUDED).
+ * Source: Showdown data/abilities.ts -- Moody in Gen 8 only uses atk/def/spa/spd/spe
+ * Source: Bulbapedia "Moody" -- "From Generation VIII onwards, Moody can no longer
+ *   raise or lower Accuracy or Evasion"
+ */
+const GEN8_MOODY_STATS = ["attack", "defense", "spAttack", "spDefense", "speed"] as const;
+
+type MoodyStat = (typeof GEN8_MOODY_STATS)[number];
+
+/**
+ * The 5 battle stats for Beast Boost (excludes HP, accuracy, evasion).
+ * Source: Showdown data/abilities.ts -- beastboost: checks atk/def/spa/spd/spe
+ */
+const BEAST_BOOST_STATS = ["attack", "defense", "spAttack", "spDefense", "speed"] as const;
+
+type BeastBoostStat = (typeof BEAST_BOOST_STATS)[number];
+
+// ---------------------------------------------------------------------------
+// Inactive result sentinel
+// ---------------------------------------------------------------------------
+
+const INACTIVE: AbilityResult = { activated: false, effects: [], messages: [] };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Get the display name for a Pokemon, falling back to speciesId. */
+function getName(ctx: AbilityContext): string {
+  return ctx.pokemon.pokemon.nickname ?? String(ctx.pokemon.pokemon.speciesId);
+}
+
+// ---------------------------------------------------------------------------
+// Public dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Main entry point for Gen 8 stat/priority ability handling.
+ */
+export function handleGen8StatAbility(ctx: AbilityContext): AbilityResult {
+  const abilityId = ctx.pokemon.ability;
+
+  switch (ctx.trigger) {
+    case "on-priority-check":
+      return handlePriorityCheck(abilityId, ctx);
+    case "on-switch-in":
+      return handleSwitchIn(abilityId, ctx);
+    case "on-after-move-used":
+      return handleAfterMoveUsed(abilityId, ctx);
+    case "on-stat-change":
+      return handleStatChange(abilityId, ctx);
+    case "on-damage-taken":
+      return handleDamageTaken(abilityId, ctx);
+    case "on-turn-end":
+      return handleTurnEnd(abilityId, ctx);
+    case "on-flinch":
+      return handleFlinch(abilityId, ctx);
+    case "on-item-use":
+      return handleItemUse(abilityId, ctx);
+    case "on-before-move":
+      return handleBeforeMove(abilityId, ctx);
+    case "passive-immunity":
+      return handlePassiveImmunity((_abilityId) => INACTIVE, abilityId, ctx);
+    default:
+      return INACTIVE;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// on-priority-check
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-priority-check" abilities.
+ *
+ * Prankster: +1 priority to status moves. In Gen 7+, status moves with Prankster
+ * priority FAIL against Dark-type targets.
+ * Gale Wings (Gen 7+): +1 priority to Flying moves ONLY when at full HP.
+ * Triage (Gen 7+): +3 priority to healing moves.
+ * Quick Draw (new Gen 8): 30% chance to move first.
+ *
+ * Source: Showdown data/abilities.ts -- Prankster, Gale Wings, Triage, Quick Draw
+ */
+function handlePriorityCheck(abilityId: string, ctx: AbilityContext): AbilityResult {
+  switch (abilityId) {
+    case "prankster": {
+      if (!ctx.move) return INACTIVE;
+      if (ctx.move.category !== "status") return INACTIVE;
+      const name = getName(ctx);
+      return {
+        activated: true,
+        effects: [],
+        messages: [`${name}'s Prankster boosted the move's priority!`],
+      };
+    }
+
+    case "gale-wings": {
+      // Gale Wings (Gen 7+): +1 priority to Flying moves ONLY at full HP.
+      // Source: Showdown data/abilities.ts -- galeWings: requires pokemon.hp === pokemon.maxhp
+      if (!ctx.move) return INACTIVE;
+      if (ctx.move.type !== "flying") return INACTIVE;
+      const maxHp = ctx.pokemon.pokemon.calculatedStats?.hp ?? ctx.pokemon.pokemon.currentHp;
+      if (ctx.pokemon.pokemon.currentHp < maxHp) return INACTIVE;
+      const name = getName(ctx);
+      return {
+        activated: true,
+        effects: [],
+        messages: [`${name}'s Gale Wings boosted the move's priority!`],
+      };
+    }
+
+    case "triage": {
+      // Triage: +3 priority to healing moves.
+      // Source: Showdown data/abilities.ts -- triage: onModifyPriority +3 for heal moves
+      if (!ctx.move) return INACTIVE;
+      if (!isHealingMove(ctx.move.id, ctx.move.effect?.type ?? null)) return INACTIVE;
+      const name = getName(ctx);
+      return {
+        activated: true,
+        effects: [],
+        messages: [`${name}'s Triage boosted the move's priority!`],
+      };
+    }
+
+    case "quick-draw": {
+      // Quick Draw (new in Gen 8): 30% chance to move first.
+      // Source: Showdown data/abilities.ts -- quickdraw: onFractionalPriority, 30% chance
+      // Source: Bulbapedia "Quick Draw" -- "30% chance to move first in its priority bracket"
+      if (!ctx.move) return INACTIVE;
+      // Use RNG to check for 30% activation
+      if (!ctx.rng.chance(0.3)) return INACTIVE;
+      const name = getName(ctx);
+      return {
+        activated: true,
+        effects: [],
+        messages: [`${name}'s Quick Draw made it move first!`],
+      };
+    }
+
+    case "stall": {
+      // Stall: user always goes last in its priority bracket.
+      // Source: Showdown data/abilities.ts -- stall: onModifyPriority: -0.1
+      return INACTIVE; // Handled in resolveTurnOrder
+    }
+
+    default:
+      return INACTIVE;
+  }
+}
+
+/**
+ * Check if a move is considered a "healing move" for Triage.
+ * Source: Showdown data/abilities.ts -- triage: move.flags.heal
+ */
+function isHealingMove(moveId: string, effectType: string | null): boolean {
+  const HEALING_MOVES: ReadonlySet<string> = new Set([
+    "absorb",
+    "drain-punch",
+    "draining-kiss",
+    "giga-drain",
+    "horn-leech",
+    "leech-life",
+    "mega-drain",
+    "oblivion-wing",
+    "parabolic-charge",
+    // Recovery moves
+    "heal-order",
+    "heal-pulse",
+    "milk-drink",
+    "moonlight",
+    "morning-sun",
+    "recover",
+    "rest",
+    "roost",
+    "slack-off",
+    "soft-boiled",
+    "synthesis",
+    "wish",
+    "floral-healing",
+    "purify",
+    "shore-up",
+    "strength-sap",
+  ]);
+
+  if (HEALING_MOVES.has(moveId)) return true;
+  if (effectType === "drain") return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Prankster Dark-type immunity check
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a Prankster-boosted status move fails against a Dark-type target.
+ *
+ * Gen 7+ nerf: status moves boosted by Prankster have no effect on Dark-type Pokemon.
+ *
+ * Source: Showdown data/abilities.ts -- prankster: Dark targets check pranksterBoosted flag
+ * Source: Bulbapedia "Prankster" Gen 7+ -- "status moves fail against Dark-type targets"
+ */
+export function isPranksterBlockedByDarkType(
+  attackerAbility: string,
+  moveCategory: MoveCategory,
+  defenderTypes: readonly string[],
+): boolean {
+  if (attackerAbility !== "prankster") return false;
+  if (moveCategory !== "status") return false;
+  return defenderTypes.includes("dark");
+}
+
+// ---------------------------------------------------------------------------
+// Gale Wings full-HP check
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if Gale Wings grants priority in Gen 8 (requires full HP, same as Gen 7).
+ *
+ * Source: Showdown data/abilities.ts -- galeWings: requires full HP
+ */
+export function isGaleWingsActive(
+  abilityId: string,
+  moveType: string,
+  currentHp: number,
+  maxHp: number,
+): boolean {
+  if (abilityId !== "gale-wings") return false;
+  if (moveType !== "flying") return false;
+  return currentHp >= maxHp;
+}
+
+// ---------------------------------------------------------------------------
+// Triage priority check
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the Triage priority bonus for a move (+3 for healing moves, 0 otherwise).
+ *
+ * Source: Showdown data/abilities.ts -- triage: onModifyPriority +3
+ */
+export function getTriagePriorityBonus(
+  abilityId: string,
+  moveId: string,
+  effectType: string | null,
+): number {
+  if (abilityId !== "triage") return 0;
+  if (!isHealingMove(moveId, effectType)) return 0;
+  return 3;
+}
+
+// ---------------------------------------------------------------------------
+// on-switch-in (NEW Gen 8)
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-switch-in" abilities.
+ *
+ * Intrepid Sword (new in Gen 8): +1 Attack on every switch-in.
+ * Dauntless Shield (new in Gen 8): +1 Defense on every switch-in.
+ *
+ * Note: In Gen 9, these were nerfed to once-per-battle. Gen 8 triggers every switch-in.
+ *
+ * Source: Showdown data/abilities.ts -- intrepidsword/dauntlessshield: onStart
+ * Source: Showdown data/mods/gen8/abilities.ts -- no once flag in Gen 8
+ * Source: Bulbapedia "Intrepid Sword" -- "raises Attack by one stage upon entering battle"
+ * Source: Bulbapedia "Dauntless Shield" -- "raises Defense by one stage upon entering battle"
+ */
+function handleSwitchIn(abilityId: string, ctx: AbilityContext): AbilityResult {
+  switch (abilityId) {
+    case "intrepid-sword": {
+      const name = getName(ctx);
+      const effect: AbilityEffect = {
+        effectType: "stat-change",
+        target: "self",
+        stat: "attack",
+        stages: 1,
+      };
+      return {
+        activated: true,
+        effects: [effect],
+        messages: [`${name}'s Intrepid Sword raised its Attack!`],
+      };
+    }
+
+    case "dauntless-shield": {
+      const name = getName(ctx);
+      const effect: AbilityEffect = {
+        effectType: "stat-change",
+        target: "self",
+        stat: "defense",
+        stages: 1,
+      };
+      return {
+        activated: true,
+        effects: [effect],
+        messages: [`${name}'s Dauntless Shield raised its Defense!`],
+      };
+    }
+
+    default:
+      return INACTIVE;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// on-before-move
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-before-move" abilities.
+ *
+ * Protean/Libero: change the user's type to match the move type before attacking.
+ * Libero is new in Gen 8 but mechanically identical to Protean.
+ *
+ * Source: Showdown data/abilities.ts -- protean/libero: onPrepareHit
+ * Source: Bulbapedia "Libero" -- same effect as Protean, introduced in Gen 8
+ */
+function handleBeforeMove(abilityId: string, ctx: AbilityContext): AbilityResult {
+  if (abilityId !== "protean" && abilityId !== "libero") return INACTIVE;
+  if (!ctx.move) return INACTIVE;
+
+  const moveType = ctx.move.type;
+  if (ctx.pokemon.types.includes(moveType)) return INACTIVE;
+
+  const name = getName(ctx);
+  const abilityName = abilityId === "protean" ? "Protean" : "Libero";
+  return {
+    activated: true,
+    effects: [
+      {
+        effectType: "type-change",
+        target: "self",
+        types: [moveType],
+      },
+    ],
+    messages: [`${name}'s ${abilityName} changed its type to ${moveType}!`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// on-after-move-used (KO triggers)
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-after-move-used" abilities.
+ *
+ * Moxie: +1 Attack when causing a faint.
+ * Beast Boost: +1 to highest stat when causing a faint.
+ *
+ * Source: Showdown data/abilities.ts -- Moxie, Beast Boost onSourceAfterFaint
+ */
+function handleAfterMoveUsed(abilityId: string, ctx: AbilityContext): AbilityResult {
+  switch (abilityId) {
+    case "moxie":
+      return handleMoxie(ctx);
+    case "beast-boost":
+      return handleBeastBoost(ctx);
+    default:
+      return INACTIVE;
+  }
+}
+
+/**
+ * Moxie: raises Attack by 1 stage when the user's move KOs the target.
+ *
+ * Source: Showdown data/abilities.ts -- Moxie onSourceAfterFaint
+ */
+function handleMoxie(ctx: AbilityContext): AbilityResult {
+  if (!ctx.opponent) return INACTIVE;
+  if (ctx.opponent.pokemon.currentHp > 0) return INACTIVE;
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "attack",
+    stages: 1,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Moxie raised its Attack!`],
+  };
+}
+
+/**
+ * Beast Boost: raises the user's HIGHEST stat by +1 when it causes a faint.
+ *
+ * Source: Showdown data/abilities.ts -- beastboost: onSourceAfterFaint
+ * Source: Bulbapedia "Beast Boost" -- "raises the user's highest stat by one stage"
+ */
+function handleBeastBoost(ctx: AbilityContext): AbilityResult {
+  if (!ctx.opponent) return INACTIVE;
+  if (ctx.opponent.pokemon.currentHp > 0) return INACTIVE;
+
+  const stats = ctx.pokemon.pokemon.calculatedStats;
+  if (!stats) return INACTIVE;
+
+  let bestStat: BeastBoostStat = "attack";
+  let bestValue = stats.attack;
+
+  for (const stat of BEAST_BOOST_STATS) {
+    const value = stats[stat];
+    if (value > bestValue) {
+      bestValue = value;
+      bestStat = stat;
+    }
+  }
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: bestStat,
+    stages: 1,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Beast Boost raised its ${formatStatName(bestStat)}!`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// on-stat-change
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-stat-change" abilities.
+ *
+ * Defiant: +2 Attack when any stat is lowered by opponent.
+ * Competitive: +2 SpAtk when any stat is lowered by opponent.
+ * Contrary: ALL stat changes are reversed.
+ * Simple: ALL stat changes are doubled.
+ *
+ * Source: Showdown data/abilities.ts
+ */
+function handleStatChange(abilityId: string, ctx: AbilityContext): AbilityResult {
+  switch (abilityId) {
+    case "defiant":
+      return handleDefiant(ctx);
+    case "competitive":
+      return handleCompetitive(ctx);
+    case "contrary":
+      return handleContrary();
+    case "simple":
+      return handleSimple();
+    default:
+      return INACTIVE;
+  }
+}
+
+/**
+ * Defiant: +2 Attack when any of the user's stats are lowered by an opponent.
+ *
+ * Source: Showdown data/abilities.ts -- Defiant onAfterEachBoost
+ */
+function handleDefiant(ctx: AbilityContext): AbilityResult {
+  if (!ctx.statChange || ctx.statChange.stages >= 0 || ctx.statChange.source !== "opponent") {
+    return INACTIVE;
+  }
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "attack",
+    stages: 2,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Defiant sharply raised its Attack!`],
+  };
+}
+
+/**
+ * Competitive: +2 SpAtk when any of the user's stats are lowered by an opponent.
+ *
+ * Source: Showdown data/abilities.ts -- Competitive onAfterEachBoost
+ */
+function handleCompetitive(ctx: AbilityContext): AbilityResult {
+  if (!ctx.statChange || ctx.statChange.stages >= 0 || ctx.statChange.source !== "opponent") {
+    return INACTIVE;
+  }
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "spAttack",
+    stages: 2,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Competitive sharply raised its Special Attack!`],
+  };
+}
+
+function handleContrary(): AbilityResult {
+  return { activated: true, effects: [], messages: [] };
+}
+
+function handleSimple(): AbilityResult {
+  return { activated: true, effects: [], messages: [] };
+}
+
+// ---------------------------------------------------------------------------
+// on-damage-taken
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-damage-taken" abilities.
+ *
+ * Justified: +1 Attack when hit by a Dark-type move.
+ * Weak Armor (Gen 7+): -1 Def, +2 Speed on physical hit.
+ * Stamina: +1 Defense when hit by any damaging move.
+ * Rattled: +1 Speed when hit by Bug, Ghost, or Dark-type move.
+ * Cotton Down (new Gen 8): lower Speed of all adjacent foes by 1 when hit.
+ * Steam Engine (new Gen 8): +6 Speed when hit by Fire or Water move.
+ *
+ * Source: Showdown data/abilities.ts
+ */
+function handleDamageTaken(abilityId: string, ctx: AbilityContext): AbilityResult {
+  switch (abilityId) {
+    case "justified":
+      return handleJustified(ctx);
+    case "weak-armor":
+      return handleWeakArmor(ctx);
+    case "stamina":
+      return handleStamina(ctx);
+    case "rattled":
+      return handleRattled(ctx);
+    case "cotton-down":
+      return handleCottonDown(ctx);
+    case "steam-engine":
+      return handleSteamEngine(ctx);
+    default:
+      return INACTIVE;
+  }
+}
+
+/**
+ * Justified: raises Attack by 1 stage when hit by a Dark-type move.
+ *
+ * Source: Showdown data/abilities.ts -- Justified onDamagingHit
+ */
+function handleJustified(ctx: AbilityContext): AbilityResult {
+  if (!ctx.move) return INACTIVE;
+  if (ctx.move.type !== "dark") return INACTIVE;
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "attack",
+    stages: 1,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Justified raised its Attack!`],
+  };
+}
+
+/**
+ * Weak Armor (Gen 7+): -1 Def, +2 Speed when hit by a physical move.
+ *
+ * Source: Showdown data/abilities.ts -- Weak Armor Gen 7+: spe +2
+ * Source: Bulbapedia "Weak Armor" -- "+2 Speed from Gen VII onwards"
+ */
+function handleWeakArmor(ctx: AbilityContext): AbilityResult {
+  if (!ctx.move) return INACTIVE;
+  if (ctx.move.category !== "physical") return INACTIVE;
+
+  const name = getName(ctx);
+  const defEffect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "defense",
+    stages: -1,
+  };
+  const spdEffect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "speed",
+    stages: 2,
+  };
+  return {
+    activated: true,
+    effects: [defEffect, spdEffect],
+    messages: [`${name}'s Weak Armor lowered its Defense and sharply raised its Speed!`],
+  };
+}
+
+/**
+ * Stamina: raises Defense by 1 stage when hit by any damaging move.
+ *
+ * Source: Showdown data/abilities.ts -- Stamina onDamagingHit
+ */
+function handleStamina(ctx: AbilityContext): AbilityResult {
+  if (!ctx.move) return INACTIVE;
+  if (ctx.move.category === "status") return INACTIVE;
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "defense",
+    stages: 1,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Stamina raised its Defense!`],
+  };
+}
+
+/**
+ * Rattled: raises Speed by 1 stage when hit by a Bug, Ghost, or Dark-type move.
+ *
+ * Source: Showdown data/abilities.ts -- Rattled onDamagingHit
+ */
+function handleRattled(ctx: AbilityContext): AbilityResult {
+  if (!ctx.move) return INACTIVE;
+  if (ctx.move.type !== "bug" && ctx.move.type !== "ghost" && ctx.move.type !== "dark") {
+    return INACTIVE;
+  }
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "speed",
+    stages: 1,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Rattled raised its Speed!`],
+  };
+}
+
+/**
+ * Cotton Down (new in Gen 8): when hit by a damaging move, lowers all adjacent
+ * Pokemon's Speed by 1 stage (including allies in doubles, but in singles: just the foe).
+ *
+ * Source: Showdown data/abilities.ts -- cottondown: onDamagingHit, lowers all adjacent Speed
+ * Source: Bulbapedia "Cotton Down" -- "When the Pokemon is hit by an attack, it scatters
+ *   cotton fluff around, lowering the Speed stat of all other Pokemon on the field."
+ */
+function handleCottonDown(ctx: AbilityContext): AbilityResult {
+  if (!ctx.move) return INACTIVE;
+  if (ctx.move.category === "status") return INACTIVE;
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "opponent",
+    stat: "speed",
+    stages: -1,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Cotton Down lowered the opponent's Speed!`],
+  };
+}
+
+/**
+ * Steam Engine (new in Gen 8): raises Speed by 6 stages when hit by Fire or Water move.
+ *
+ * Source: Showdown data/abilities.ts -- steamengine: onDamagingHit, boost spe: 6
+ * Source: Bulbapedia "Steam Engine" -- "raises Speed by 6 stages when hit by a Fire- or
+ *   Water-type move"
+ */
+function handleSteamEngine(ctx: AbilityContext): AbilityResult {
+  if (!ctx.move) return INACTIVE;
+  if (ctx.move.type !== "fire" && ctx.move.type !== "water") return INACTIVE;
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "speed",
+    stages: 6,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Steam Engine drastically raised its Speed!`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// on-turn-end
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-turn-end" abilities.
+ *
+ * Speed Boost: +1 Speed at end of each turn.
+ * Moody (Gen 8): +2 random stat, -1 different random stat at end of turn.
+ *   Gen 8 CHANGE: accuracy/evasion excluded from Moody pool.
+ *
+ * Source: Showdown data/abilities.ts -- Speed Boost, Moody onResidual
+ */
+function handleTurnEnd(abilityId: string, ctx: AbilityContext): AbilityResult {
+  switch (abilityId) {
+    case "speed-boost":
+      return handleSpeedBoost(ctx);
+    case "moody":
+      return handleMoody(ctx);
+    default:
+      return INACTIVE;
+  }
+}
+
+/**
+ * Speed Boost: raises Speed by 1 stage at the end of each turn.
+ * Only triggers if turnsOnField > 0.
+ *
+ * Source: Showdown data/abilities.ts -- Speed Boost onResidual
+ */
+function handleSpeedBoost(ctx: AbilityContext): AbilityResult {
+  if (ctx.pokemon.turnsOnField === 0) return INACTIVE;
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "speed",
+    stages: 1,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Speed Boost raised its Speed!`],
+  };
+}
+
+/**
+ * Moody (Gen 8): raises one random stat by 2 stages and lowers a different random stat
+ * by 1 stage at the end of each turn.
+ *
+ * Gen 8 CHANGE: Only 5 stats eligible (accuracy/evasion excluded).
+ *
+ * Source: Showdown data/abilities.ts -- Moody onResidual (Gen 8: no accuracy/evasion)
+ * Source: Bulbapedia "Moody" -- "From Generation VIII onwards, Moody can no longer
+ *   raise or lower Accuracy or Evasion"
+ */
+function handleMoody(ctx: AbilityContext): AbilityResult {
+  const stages = ctx.pokemon.statStages;
+  const name = getName(ctx);
+
+  // Build pool of stats eligible for +2 (not already at +6)
+  const plusPool: MoodyStat[] = [];
+  for (const stat of GEN8_MOODY_STATS) {
+    if ((stages[stat] ?? 0) < 6) {
+      plusPool.push(stat);
+    }
+  }
+
+  const raisedStat: MoodyStat | undefined =
+    plusPool.length > 0 ? ctx.rng.pick(plusPool) : undefined;
+
+  // Build pool of stats eligible for -1 (not already at -6, different from raised)
+  const minusPool: MoodyStat[] = [];
+  for (const stat of GEN8_MOODY_STATS) {
+    if ((stages[stat] ?? 0) > -6 && stat !== raisedStat) {
+      minusPool.push(stat);
+    }
+  }
+
+  const loweredStat: MoodyStat | undefined =
+    minusPool.length > 0 ? ctx.rng.pick(minusPool) : undefined;
+
+  const effects: AbilityEffect[] = [];
+  const messages: string[] = [];
+
+  if (raisedStat) {
+    effects.push({
+      effectType: "stat-change",
+      target: "self",
+      stat: raisedStat,
+      stages: 2,
+    });
+    messages.push(`${name}'s Moody sharply raised its ${formatStatName(raisedStat)}!`);
+  }
+
+  if (loweredStat) {
+    effects.push({
+      effectType: "stat-change",
+      target: "self",
+      stat: loweredStat,
+      stages: -1,
+    });
+    messages.push(`${name}'s Moody lowered its ${formatStatName(loweredStat)}!`);
+  }
+
+  return {
+    activated: effects.length > 0,
+    effects,
+    messages,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// on-flinch
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-flinch" abilities.
+ *
+ * Steadfast: +1 Speed when flinched.
+ *
+ * Source: Showdown data/abilities.ts -- Steadfast onFlinch
+ */
+function handleFlinch(abilityId: string, ctx: AbilityContext): AbilityResult {
+  if (abilityId !== "steadfast") return INACTIVE;
+
+  const name = getName(ctx);
+  const effect: AbilityEffect = {
+    effectType: "stat-change",
+    target: "self",
+    stat: "speed",
+    stages: 1,
+  };
+  return {
+    activated: true,
+    effects: [effect],
+    messages: [`${name}'s Steadfast raised its Speed!`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// on-item-use
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-item-use" abilities.
+ *
+ * Unnerve: prevents the opponent from consuming Berries.
+ *
+ * Source: Showdown data/abilities.ts -- Unnerve onFoeTryEatItem
+ */
+function handleItemUse(abilityId: string, ctx: AbilityContext): AbilityResult {
+  if (abilityId !== "unnerve") return INACTIVE;
+
+  const name = getName(ctx);
+  return {
+    activated: true,
+    effects: [],
+    messages: [`${name}'s Unnerve prevents the opponent from eating Berries!`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// passive-immunity (unused stub)
+// ---------------------------------------------------------------------------
+
+function handlePassiveImmunity(
+  _fn: (id: string) => AbilityResult,
+  _abilityId: string,
+  _ctx: AbilityContext,
+): AbilityResult {
+  return INACTIVE;
+}
+
+// ---------------------------------------------------------------------------
+// Pure utility functions for new Gen 8 abilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if Intrepid Sword triggers on switch-in.
+ * In Gen 8, it triggers every switch-in (no once-per-battle limit).
+ *
+ * Source: Showdown data/abilities.ts -- intrepidsword: onStart (no once flag in Gen 8)
+ * Source: Showdown data/mods/gen9/abilities.ts -- Gen 9 adds once flag
+ * Source: Bulbapedia "Intrepid Sword" -- "From Gen IX, only activates once per battle"
+ */
+export function isIntrepidSwordTrigger(abilityId: string, turnsOnField: number): boolean {
+  if (abilityId !== "intrepid-sword") return false;
+  return turnsOnField === 0;
+}
+
+/**
+ * Check if Dauntless Shield triggers on switch-in.
+ * In Gen 8, it triggers every switch-in (no once-per-battle limit).
+ *
+ * Source: Showdown data/abilities.ts -- dauntlessshield: onStart (no once flag in Gen 8)
+ * Source: Bulbapedia "Dauntless Shield" -- "From Gen IX, only activates once per battle"
+ */
+export function isDauntlessShieldTrigger(abilityId: string, turnsOnField: number): boolean {
+  if (abilityId !== "dauntless-shield") return false;
+  return turnsOnField === 0;
+}
+
+/**
+ * Check if Cotton Down triggers when hit by a damaging move.
+ *
+ * Source: Showdown data/abilities.ts -- cottondown: onDamagingHit
+ * Source: Bulbapedia "Cotton Down" -- triggers on any damaging move
+ */
+export function isCottonDownTrigger(abilityId: string): boolean {
+  return abilityId === "cotton-down";
+}
+
+/**
+ * Check if Steam Engine triggers from the incoming move type.
+ * Triggers on Fire or Water hits.
+ *
+ * Source: Showdown data/abilities.ts -- steamengine: onDamagingHit, Fire or Water
+ * Source: Bulbapedia "Steam Engine" -- "Fire or Water type move"
+ */
+export function isSteamEngineTrigger(abilityId: string, moveType: string): boolean {
+  if (abilityId !== "steam-engine") return false;
+  return moveType === "fire" || moveType === "water";
+}
+
+/**
+ * Check if Quick Draw activates (30% chance to move first).
+ *
+ * Source: Showdown data/abilities.ts -- quickdraw: onFractionalPriority, 30% chance
+ * Source: Bulbapedia "Quick Draw" -- "30% chance of acting first in its priority bracket"
+ *
+ * @param rngValue - A float in [0, 1) from the PRNG
+ * @returns true if Quick Draw activates (roll < 0.3)
+ */
+export function isQuickDrawTrigger(abilityId: string, rngValue: number): boolean {
+  if (abilityId !== "quick-draw") return false;
+  return rngValue < 0.3;
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports for testing convenience
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a move category qualifies as a status move for Prankster.
+ *
+ * Source: Showdown data/abilities.ts -- Prankster checks move.category === 'Status'
+ */
+export function isPranksterEligible(category: MoveCategory): boolean {
+  return category === "status";
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+/** Format a stat ID as a human-readable name for messages. */
+function formatStatName(stat: string): string {
+  switch (stat) {
+    case "attack":
+      return "Attack";
+    case "defense":
+      return "Defense";
+    case "spAttack":
+      return "Special Attack";
+    case "spDefense":
+      return "Special Defense";
+    case "speed":
+      return "Speed";
+    case "accuracy":
+      return "Accuracy";
+    case "evasion":
+      return "Evasion";
+    default:
+      return stat;
+  }
+}

--- a/packages/gen8/src/index.ts
+++ b/packages/gen8/src/index.ts
@@ -1,6 +1,43 @@
 // @pokemon-lib-ts/gen8 -- Gen8Ruleset + complete Gen 8 data
 
 export { createGen8DataManager } from "./data/index.js";
+export {
+  getAteAbilityOverride,
+  getDragonsMawMultiplier,
+  getFurCoatMultiplier,
+  getGorillaTacticsMultiplier,
+  getIceScalesMultiplier,
+  getMegaLauncherMultiplier,
+  getMultiscaleMultiplier,
+  getPunkRockIncomingMultiplier,
+  getPunkRockMultiplier,
+  getSheerForceMultiplier,
+  getSteelworkerMultiplier,
+  getStrongJawMultiplier,
+  getSturdyDamageCap,
+  getToughClawsMultiplier,
+  getTransistorMultiplier,
+  handleGen8DamageCalcAbility,
+  handleGen8DamageImmunityAbility,
+  hasSheerForceEligibleEffect,
+  isParentalBondEligible,
+  isSheerForceEligibleMove,
+  PARENTAL_BOND_SECOND_HIT_MULTIPLIER,
+  sheerForceSuppressesLifeOrb,
+  sturdyBlocksOHKO,
+} from "./Gen8AbilitiesDamage.js";
+export {
+  getTriagePriorityBonus,
+  handleGen8StatAbility,
+  isCottonDownTrigger,
+  isDauntlessShieldTrigger,
+  isGaleWingsActive,
+  isIntrepidSwordTrigger,
+  isPranksterBlockedByDarkType,
+  isPranksterEligible,
+  isQuickDrawTrigger,
+  isSteamEngineTrigger,
+} from "./Gen8AbilitiesStat.js";
 export { GEN8_CRIT_MULTIPLIER, GEN8_CRIT_RATE_TABLE } from "./Gen8CritCalc.js";
 export {
   calculateGen8Damage,

--- a/packages/gen8/tests/abilities-damage.test.ts
+++ b/packages/gen8/tests/abilities-damage.test.ts
@@ -1,0 +1,689 @@
+import type { AbilityContext, ActivePokemon, BattleState } from "@pokemon-lib-ts/battle";
+import type { MoveData, MoveEffect, PokemonType } from "@pokemon-lib-ts/core";
+import { SeededRandom } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import {
+  getAteAbilityOverride,
+  getDragonsMawMultiplier,
+  getFurCoatMultiplier,
+  getGorillaTacticsMultiplier,
+  getIceScalesMultiplier,
+  getMegaLauncherMultiplier,
+  getMultiscaleMultiplier,
+  getPunkRockIncomingMultiplier,
+  getPunkRockMultiplier,
+  getSheerForceMultiplier,
+  getSteelworkerMultiplier,
+  getStrongJawMultiplier,
+  getSturdyDamageCap,
+  getToughClawsMultiplier,
+  getTransistorMultiplier,
+  handleGen8DamageCalcAbility,
+  handleGen8DamageImmunityAbility,
+  hasSheerForceEligibleEffect,
+  isParentalBondEligible,
+  PARENTAL_BOND_SECOND_HIT_MULTIPLIER,
+  sheerForceSuppressesLifeOrb,
+  sturdyBlocksOHKO,
+} from "../src/Gen8AbilitiesDamage";
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeActive(overrides: {
+  level?: number;
+  attack?: number;
+  defense?: number;
+  spAttack?: number;
+  spDefense?: number;
+  speed?: number;
+  hp?: number;
+  currentHp?: number;
+  types?: PokemonType[];
+  ability?: string;
+  heldItem?: string | null;
+  status?: string | null;
+  speciesId?: number;
+  nickname?: string | null;
+  movedThisTurn?: boolean;
+}): ActivePokemon {
+  const hp = overrides.hp ?? 200;
+  const attack = overrides.attack ?? 100;
+  const defense = overrides.defense ?? 100;
+  const spAttack = overrides.spAttack ?? 100;
+  const spDefense = overrides.spDefense ?? 100;
+  const speed = overrides.speed ?? 100;
+  return {
+    pokemon: {
+      uid: "test",
+      speciesId: overrides.speciesId ?? 1,
+      nickname: overrides.nickname ?? null,
+      level: overrides.level ?? 50,
+      experience: 0,
+      nature: "hardy",
+      ivs: { hp: 31, attack: 31, defense: 31, spAttack: 31, spDefense: 31, speed: 31 },
+      evs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+      currentHp: overrides.currentHp ?? hp,
+      moves: [],
+      ability: overrides.ability ?? "none",
+      abilitySlot: "normal1" as const,
+      heldItem: overrides.heldItem ?? null,
+      status: (overrides.status ?? null) as any,
+      friendship: 0,
+      gender: "male" as any,
+      isShiny: false,
+      metLocation: "",
+      metLevel: 1,
+      originalTrainer: "",
+      originalTrainerId: 0,
+      pokeball: "pokeball",
+      calculatedStats: { hp, attack, defense, spAttack, spDefense, speed },
+    },
+    teamSlot: 0,
+    statStages: {
+      attack: 0,
+      defense: 0,
+      spAttack: 0,
+      spDefense: 0,
+      speed: 0,
+      accuracy: 0,
+      evasion: 0,
+    },
+    volatileStatuses: new Map(),
+    types: overrides.types ?? ["normal"],
+    ability: overrides.ability ?? "none",
+    lastMoveUsed: null,
+    lastDamageTaken: 0,
+    lastDamageType: null,
+    lastDamageCategory: null,
+    turnsOnField: 0,
+    movedThisTurn: overrides.movedThisTurn ?? false,
+    consecutiveProtects: 0,
+    substituteHp: 0,
+    itemKnockedOff: false,
+    transformed: false,
+    transformedSpecies: null,
+    isMega: false,
+    isDynamaxed: false,
+    dynamaxTurnsLeft: 0,
+    isTerastallized: false,
+    teraType: null,
+    suppressedAbility: null,
+    forcedMove: null,
+  } as ActivePokemon;
+}
+
+function makeMove(overrides: {
+  id?: string;
+  type?: PokemonType;
+  category?: "physical" | "special" | "status";
+  power?: number | null;
+  flags?: Partial<MoveData["flags"]>;
+  effect?: MoveData["effect"];
+  hasCrashDamage?: boolean;
+}): MoveData {
+  return {
+    id: overrides.id ?? "tackle",
+    displayName: overrides.id ?? "Tackle",
+    type: overrides.type ?? "normal",
+    category: overrides.category ?? "physical",
+    power: overrides.power ?? 50,
+    accuracy: 100,
+    pp: 35,
+    priority: 0,
+    target: "adjacent-foe",
+    flags: {
+      contact: true,
+      sound: false,
+      bullet: false,
+      pulse: false,
+      punch: false,
+      bite: false,
+      wind: false,
+      slicing: false,
+      powder: false,
+      protect: true,
+      mirror: true,
+      snatch: false,
+      gravity: false,
+      defrost: false,
+      recharge: false,
+      charge: false,
+      bypassSubstitute: false,
+      ...overrides.flags,
+    },
+    effect: overrides.effect ?? null,
+    description: "",
+    generation: 8,
+    critRatio: 0,
+    hasCrashDamage: overrides.hasCrashDamage ?? false,
+  } as MoveData;
+}
+
+function makeState(overrides?: {
+  weather?: { type: string; turnsLeft: number; source: string } | null;
+}): BattleState {
+  return {
+    weather: overrides?.weather ?? null,
+    terrain: null,
+    trickRoom: { active: false, turnsLeft: 0 },
+    magicRoom: { active: false, turnsLeft: 0 },
+    wonderRoom: { active: false, turnsLeft: 0 },
+    gravity: { active: false, turnsLeft: 0 },
+    format: "singles",
+    generation: 8,
+    turnNumber: 1,
+    sides: [{}, {}],
+  } as unknown as BattleState;
+}
+
+function makeCtx(overrides: {
+  ability: string;
+  move?: MoveData;
+  currentHp?: number;
+  maxHp?: number;
+  status?: string | null;
+  types?: PokemonType[];
+  nickname?: string | null;
+  opponent?: ActivePokemon;
+  weather?: string | null;
+}): AbilityContext {
+  const hp = overrides.maxHp ?? 200;
+  return {
+    pokemon: makeActive({
+      ability: overrides.ability,
+      currentHp: overrides.currentHp ?? hp,
+      hp: hp,
+      status: overrides.status ?? null,
+      types: overrides.types ?? ["normal"],
+      nickname: overrides.nickname ?? null,
+    }),
+    opponent: overrides.opponent ?? makeActive({}),
+    state: makeState(
+      overrides.weather ? { weather: { type: overrides.weather, turnsLeft: 5, source: "" } } : {},
+    ),
+    rng: new SeededRandom(42),
+    trigger: "on-damage-calc",
+    move: overrides.move,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Damage Abilities", () => {
+  // ---- Sheer Force ----
+
+  describe("Sheer Force", () => {
+    it("given a move with status-chance effect, when Sheer Force is active, then returns ~1.3x multiplier", () => {
+      // Source: Showdown data/abilities.ts -- sheerforce onBasePower: chainModify([5325, 4096])
+      // 5325 / 4096 = 1.2998046875
+      const effect: MoveEffect = {
+        type: "status-chance",
+        status: "burn",
+        chance: 10,
+      };
+      const mult = getSheerForceMultiplier("sheer-force", effect);
+      expect(mult).toBe(5325 / 4096);
+    });
+
+    it("given a move without secondary effects, when Sheer Force is active, then returns 1.0x", () => {
+      // Source: Showdown data/abilities.ts -- sheerforce: only boosts moves with secondaries
+      const mult = getSheerForceMultiplier("sheer-force", null);
+      expect(mult).toBe(1);
+    });
+
+    it("given Sheer Force and an eligible move, when checking Life Orb suppression, then returns true", () => {
+      // Source: Showdown scripts.ts -- if move.hasSheerForce, skip Life Orb recoil
+      const effect: MoveEffect = {
+        type: "status-chance",
+        status: "paralysis",
+        chance: 30,
+      };
+      expect(sheerForceSuppressesLifeOrb("sheer-force", effect)).toBe(true);
+    });
+
+    it("given non-Sheer-Force ability, when checking Life Orb suppression, then returns false", () => {
+      const effect: MoveEffect = {
+        type: "status-chance",
+        status: "burn",
+        chance: 10,
+      };
+      expect(sheerForceSuppressesLifeOrb("iron-fist", effect)).toBe(false);
+    });
+
+    it("given the dispatcher, when Sheer Force user uses eligible move, then returns activated:true", () => {
+      // Source: Showdown data/abilities.ts -- sheerforce
+      const ctx = makeCtx({
+        ability: "sheer-force",
+        move: makeMove({
+          effect: { type: "status-chance", status: "burn", chance: 10 },
+        }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+
+    it("given the dispatcher, when Sheer Force user uses non-eligible move, then returns activated:false", () => {
+      const ctx = makeCtx({
+        ability: "sheer-force",
+        move: makeMove({ effect: null }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(false);
+    });
+  });
+
+  // ---- Tough Claws ----
+
+  describe("Tough Claws", () => {
+    it("given a contact move, when Tough Claws is active, then returns 5325/4096 (~1.3x)", () => {
+      // Source: Showdown data/abilities.ts -- toughclaws: chainModify([5325, 4096])
+      const mult = getToughClawsMultiplier("tough-claws", true);
+      expect(mult).toBe(5325 / 4096);
+    });
+
+    it("given a non-contact move, when Tough Claws is active, then returns 1.0x", () => {
+      const mult = getToughClawsMultiplier("tough-claws", false);
+      expect(mult).toBe(1);
+    });
+
+    it("given a different ability, when checking Tough Claws for contact move, then returns 1.0x", () => {
+      const mult = getToughClawsMultiplier("iron-fist", true);
+      expect(mult).toBe(1);
+    });
+  });
+
+  // ---- Strong Jaw ----
+
+  describe("Strong Jaw", () => {
+    it("given a bite move, when Strong Jaw is active, then returns 1.5x", () => {
+      // Source: Showdown data/abilities.ts -- strongjaw: chainModify(1.5)
+      const mult = getStrongJawMultiplier("strong-jaw", true);
+      expect(mult).toBe(1.5);
+    });
+
+    it("given a non-bite move, when Strong Jaw is active, then returns 1.0x", () => {
+      const mult = getStrongJawMultiplier("strong-jaw", false);
+      expect(mult).toBe(1);
+    });
+  });
+
+  // ---- Mega Launcher ----
+
+  describe("Mega Launcher", () => {
+    it("given a pulse move, when Mega Launcher is active, then returns 1.5x", () => {
+      // Source: Showdown data/abilities.ts -- megalauncher: chainModify(1.5)
+      const mult = getMegaLauncherMultiplier("mega-launcher", true);
+      expect(mult).toBe(1.5);
+    });
+
+    it("given a non-pulse move, when Mega Launcher is active, then returns 1.0x", () => {
+      const mult = getMegaLauncherMultiplier("mega-launcher", false);
+      expect(mult).toBe(1);
+    });
+  });
+
+  // ---- Multiscale ----
+
+  describe("Multiscale", () => {
+    it("given full HP, when Multiscale is active, then returns 0.5x", () => {
+      // Source: Showdown data/abilities.ts -- multiscale: at full HP, halve damage
+      const mult = getMultiscaleMultiplier("multiscale", 200, 200);
+      expect(mult).toBe(0.5);
+    });
+
+    it("given less than full HP, when Multiscale is active, then returns 1.0x", () => {
+      const mult = getMultiscaleMultiplier("multiscale", 199, 200);
+      expect(mult).toBe(1);
+    });
+
+    it("given Shadow Shield at full HP, when checking multiplier, then returns 0.5x", () => {
+      // Source: Showdown data/abilities.ts -- shadowshield: same as multiscale
+      const mult = getMultiscaleMultiplier("shadow-shield", 300, 300);
+      expect(mult).toBe(0.5);
+    });
+
+    it("given a different ability, when checking Multiscale, then returns 1.0x", () => {
+      const mult = getMultiscaleMultiplier("intimidate", 200, 200);
+      expect(mult).toBe(1);
+    });
+  });
+
+  // ---- Fur Coat ----
+
+  describe("Fur Coat", () => {
+    it("given a physical move, when Fur Coat is active, then returns 2.0x defense multiplier", () => {
+      // Source: Showdown data/abilities.ts -- furcoat: onModifyDef, chainModify(2)
+      const mult = getFurCoatMultiplier("fur-coat", true);
+      expect(mult).toBe(2);
+    });
+
+    it("given a special move, when Fur Coat is active, then returns 1.0x", () => {
+      const mult = getFurCoatMultiplier("fur-coat", false);
+      expect(mult).toBe(1);
+    });
+  });
+
+  // ---- -ate abilities ----
+
+  describe("-ate abilities", () => {
+    it("given Pixilate and a Normal move, when checking type override, then returns Fairy + 1.2x", () => {
+      // Source: Showdown data/abilities.ts -- pixilate Gen 7+: chainModify([4915, 4096])
+      // 4915 / 4096 = 1.1999...
+      const result = getAteAbilityOverride("pixilate", "normal");
+      expect(result).toEqual({ type: "fairy", multiplier: 4915 / 4096 });
+    });
+
+    it("given Aerilate and a Normal move, when checking type override, then returns Flying + 1.2x", () => {
+      // Source: Showdown data/abilities.ts -- aerilate Gen 7+: chainModify([4915, 4096])
+      const result = getAteAbilityOverride("aerilate", "normal");
+      expect(result).toEqual({ type: "flying", multiplier: 4915 / 4096 });
+    });
+
+    it("given Refrigerate and a Normal move, when checking type override, then returns Ice + 1.2x", () => {
+      const result = getAteAbilityOverride("refrigerate", "normal");
+      expect(result).toEqual({ type: "ice", multiplier: 4915 / 4096 });
+    });
+
+    it("given Galvanize and a Normal move, when checking type override, then returns Electric + 1.2x", () => {
+      const result = getAteAbilityOverride("galvanize", "normal");
+      expect(result).toEqual({ type: "electric", multiplier: 4915 / 4096 });
+    });
+
+    it("given Pixilate and a Fire move (non-Normal), when checking type override, then returns null", () => {
+      // Source: -ate abilities only change Normal moves
+      const result = getAteAbilityOverride("pixilate", "fire");
+      expect(result).toBeNull();
+    });
+
+    it("given a non-ate ability and Normal move, when checking type override, then returns null", () => {
+      const result = getAteAbilityOverride("intimidate", "normal");
+      expect(result).toBeNull();
+    });
+  });
+
+  // ---- Parental Bond ----
+
+  describe("Parental Bond", () => {
+    it("given Parental Bond and a powered move, when checking eligibility, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- parentalbond: Gen 7+ secondHit 0.25
+      expect(isParentalBondEligible("parental-bond", 50, null)).toBe(true);
+    });
+
+    it("given Parental Bond and a multi-hit move, when checking eligibility, then returns false", () => {
+      // Source: Showdown data/abilities.ts -- parentalbond: excluded for multi-hit
+      expect(isParentalBondEligible("parental-bond", 50, "multi-hit")).toBe(false);
+    });
+
+    it("given Parental Bond and a zero-power move, when checking eligibility, then returns false", () => {
+      expect(isParentalBondEligible("parental-bond", 0, null)).toBe(false);
+    });
+
+    it("given second hit multiplier, then it equals 0.25 (25%)", () => {
+      // Source: Showdown data/abilities.ts -- Gen 7+: parentalbond secondHit 0.25
+      // Source: Bulbapedia "Parental Bond" -- "nerfed from 50% to 25% in Gen 7"
+      expect(PARENTAL_BOND_SECOND_HIT_MULTIPLIER).toBe(0.25);
+    });
+  });
+
+  // ---- Gorilla Tactics (NEW Gen 8) ----
+
+  describe("Gorilla Tactics", () => {
+    it("given a physical move, when Gorilla Tactics is active, then returns 6144/4096 (1.5x)", () => {
+      // Source: Showdown data/abilities.ts -- gorillatactics: onModifyAtk, chainModify(1.5)
+      // 6144 / 4096 = 1.5
+      const mult = getGorillaTacticsMultiplier("gorilla-tactics", "physical");
+      expect(mult).toBe(6144 / 4096);
+    });
+
+    it("given a special move, when Gorilla Tactics is active, then returns 1.0x", () => {
+      // Source: Showdown data/abilities.ts -- gorillatactics: only boosts physical Attack
+      const mult = getGorillaTacticsMultiplier("gorilla-tactics", "special");
+      expect(mult).toBe(1);
+    });
+
+    it("given the dispatcher, when Gorilla Tactics user uses physical move, then returns activated:true", () => {
+      const ctx = makeCtx({
+        ability: "gorilla-tactics",
+        move: makeMove({ category: "physical" }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+
+    it("given the dispatcher, when Gorilla Tactics user uses special move, then returns activated:false", () => {
+      const ctx = makeCtx({
+        ability: "gorilla-tactics",
+        move: makeMove({ category: "special" }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(false);
+    });
+  });
+
+  // ---- Transistor (NEW Gen 8) ----
+
+  describe("Transistor", () => {
+    it("given an Electric move, when Transistor is active, then returns 6144/4096 (1.5x)", () => {
+      // Source: Showdown data/abilities.ts -- transistor: chainModify(1.5) in Gen 8
+      // Source: Bulbapedia "Transistor" -- "powers up Electric-type moves by 50%"
+      const mult = getTransistorMultiplier("transistor", "electric");
+      expect(mult).toBe(6144 / 4096);
+    });
+
+    it("given a non-Electric move, when Transistor is active, then returns 1.0x", () => {
+      const mult = getTransistorMultiplier("transistor", "fire");
+      expect(mult).toBe(1);
+    });
+
+    it("given the dispatcher, when Transistor user uses Thunderbolt, then returns activated:true", () => {
+      const ctx = makeCtx({
+        ability: "transistor",
+        move: makeMove({ type: "electric", id: "thunderbolt" }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+
+    it("given the dispatcher, when Transistor user uses Flamethrower, then returns activated:false", () => {
+      const ctx = makeCtx({
+        ability: "transistor",
+        move: makeMove({ type: "fire", id: "flamethrower" }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(false);
+    });
+  });
+
+  // ---- Dragon's Maw (NEW Gen 8) ----
+
+  describe("Dragon's Maw", () => {
+    it("given a Dragon move, when Dragon's Maw is active, then returns 6144/4096 (1.5x)", () => {
+      // Source: Showdown data/abilities.ts -- dragonsmaw: chainModify(1.5)
+      // Source: Bulbapedia "Dragon's Maw" -- "powers up Dragon-type moves by 50%"
+      const mult = getDragonsMawMultiplier("dragons-maw", "dragon");
+      expect(mult).toBe(6144 / 4096);
+    });
+
+    it("given a non-Dragon move, when Dragon's Maw is active, then returns 1.0x", () => {
+      const mult = getDragonsMawMultiplier("dragons-maw", "fire");
+      expect(mult).toBe(1);
+    });
+
+    it("given the dispatcher, when Dragon's Maw user uses Dragon Pulse, then returns activated:true", () => {
+      const ctx = makeCtx({
+        ability: "dragons-maw",
+        move: makeMove({ type: "dragon", id: "dragon-pulse" }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+  });
+
+  // ---- Punk Rock (NEW Gen 8) ----
+
+  describe("Punk Rock", () => {
+    it("given a sound move, when Punk Rock attacker checks outgoing multiplier, then returns 5325/4096 (~1.3x)", () => {
+      // Source: Showdown data/abilities.ts -- punkrock: onBasePower, chainModify([5325, 4096])
+      // Source: Bulbapedia "Punk Rock" -- "boosts the power of sound-based moves by 30%"
+      const mult = getPunkRockMultiplier("punk-rock", true);
+      expect(mult).toBe(5325 / 4096);
+    });
+
+    it("given a non-sound move, when Punk Rock attacker checks outgoing multiplier, then returns 1.0x", () => {
+      const mult = getPunkRockMultiplier("punk-rock", false);
+      expect(mult).toBe(1);
+    });
+
+    it("given a sound move, when Punk Rock defender checks incoming multiplier, then returns 0.5x", () => {
+      // Source: Showdown data/abilities.ts -- punkrock: onSourceModifyDamage, chainModify(0.5)
+      // Source: Bulbapedia "Punk Rock" -- "halves the damage taken from sound-based moves"
+      const mult = getPunkRockIncomingMultiplier("punk-rock", true);
+      expect(mult).toBe(0.5);
+    });
+
+    it("given a non-sound move, when Punk Rock defender checks incoming multiplier, then returns 1.0x", () => {
+      const mult = getPunkRockIncomingMultiplier("punk-rock", false);
+      expect(mult).toBe(1);
+    });
+
+    it("given a different ability, when checking Punk Rock outgoing, then returns 1.0x", () => {
+      const mult = getPunkRockMultiplier("intimidate", true);
+      expect(mult).toBe(1);
+    });
+
+    it("given the dispatcher, when Punk Rock user uses sound move, then returns activated:true", () => {
+      const ctx = makeCtx({
+        ability: "punk-rock",
+        move: makeMove({ flags: { sound: true } }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+  });
+
+  // ---- Ice Scales (NEW Gen 8) ----
+
+  describe("Ice Scales", () => {
+    it("given a special move, when Ice Scales defender is active, then returns 0.5x", () => {
+      // Source: Showdown data/abilities.ts -- icescales: onSourceModifyDamage, chainModify(0.5)
+      // Source: Bulbapedia "Ice Scales" -- "halves the damage taken from special moves"
+      const mult = getIceScalesMultiplier("ice-scales", "special");
+      expect(mult).toBe(0.5);
+    });
+
+    it("given a physical move, when Ice Scales defender is active, then returns 1.0x", () => {
+      const mult = getIceScalesMultiplier("ice-scales", "physical");
+      expect(mult).toBe(1);
+    });
+
+    it("given a different ability, when checking Ice Scales for special move, then returns 1.0x", () => {
+      const mult = getIceScalesMultiplier("thick-fat", "special");
+      expect(mult).toBe(1);
+    });
+
+    it("given the dispatcher, when Ice Scales defender is hit by special move, then returns activated:true", () => {
+      const ctx = makeCtx({
+        ability: "ice-scales",
+        move: makeMove({ category: "special" }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+
+    it("given the dispatcher, when Ice Scales defender is hit by physical move, then returns activated:false", () => {
+      const ctx = makeCtx({
+        ability: "ice-scales",
+        move: makeMove({ category: "physical" }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(false);
+    });
+  });
+
+  // ---- Steelworker ----
+
+  describe("Steelworker", () => {
+    it("given a Steel move, when Steelworker is active, then returns 6144/4096 (1.5x)", () => {
+      // Source: Showdown data/abilities.ts -- steelworker: chainModify(1.5)
+      // Source: Bulbapedia "Steelworker" -- "powers up Steel-type moves by 50%"
+      const mult = getSteelworkerMultiplier("steelworker", "steel");
+      expect(mult).toBe(6144 / 4096);
+    });
+
+    it("given a non-Steel move, when Steelworker is active, then returns 1.0x", () => {
+      const mult = getSteelworkerMultiplier("steelworker", "fire");
+      expect(mult).toBe(1);
+    });
+
+    it("given the dispatcher, when Steelworker user uses Steel move, then returns activated:true", () => {
+      const ctx = makeCtx({
+        ability: "steelworker",
+        move: makeMove({ type: "steel", id: "iron-head" }),
+      });
+      const result = handleGen8DamageCalcAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+  });
+
+  // ---- Sturdy / Wonder Guard ----
+
+  describe("Sturdy", () => {
+    it("given Sturdy at full HP and lethal damage, when checking cap, then caps at maxHp - 1", () => {
+      // Source: Showdown data/abilities.ts -- sturdy onDamage (priority -30)
+      const capped = getSturdyDamageCap("sturdy", 300, 200, 200);
+      expect(capped).toBe(199);
+    });
+
+    it("given Sturdy not at full HP and lethal damage, when checking cap, then does not cap", () => {
+      const capped = getSturdyDamageCap("sturdy", 300, 150, 200);
+      expect(capped).toBe(300);
+    });
+
+    it("given Sturdy at full HP and non-lethal damage, when checking cap, then does not cap", () => {
+      const capped = getSturdyDamageCap("sturdy", 50, 200, 200);
+      expect(capped).toBe(50);
+    });
+
+    it("given Sturdy and an OHKO move, when checking block, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- sturdy onTryHit
+      const ohkoEffect: MoveEffect = { type: "ohko" };
+      expect(sturdyBlocksOHKO("sturdy", ohkoEffect)).toBe(true);
+    });
+
+    it("given Sturdy and a non-OHKO move, when checking block, then returns false", () => {
+      expect(sturdyBlocksOHKO("sturdy", null)).toBe(false);
+    });
+
+    it("given the immunity dispatcher, when Sturdy faces OHKO move, then returns movePrevented:true", () => {
+      const ctx = makeCtx({
+        ability: "sturdy",
+        move: makeMove({ effect: { type: "ohko" } }),
+      });
+      const result = handleGen8DamageImmunityAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.movePrevented).toBe(true);
+    });
+  });
+
+  // ---- hasSheerForceEligibleEffect edge cases ----
+
+  describe("hasSheerForceEligibleEffect", () => {
+    it("given a volatile-status with chance > 0, when checking eligibility, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- sheerforce: volatile with chance
+      const effect: MoveEffect = {
+        type: "volatile-status",
+        volatile: "flinch",
+        chance: 30,
+      };
+      expect(hasSheerForceEligibleEffect(effect)).toBe(true);
+    });
+
+    it("given null effect, when checking eligibility, then returns false", () => {
+      expect(hasSheerForceEligibleEffect(null)).toBe(false);
+    });
+  });
+});

--- a/packages/gen8/tests/abilities-stat.test.ts
+++ b/packages/gen8/tests/abilities-stat.test.ts
@@ -1,0 +1,688 @@
+import type { AbilityContext, ActivePokemon, BattleState } from "@pokemon-lib-ts/battle";
+import type { MoveData, PokemonType } from "@pokemon-lib-ts/core";
+import { SeededRandom } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import {
+  getTriagePriorityBonus,
+  handleGen8StatAbility,
+  isCottonDownTrigger,
+  isDauntlessShieldTrigger,
+  isGaleWingsActive,
+  isIntrepidSwordTrigger,
+  isPranksterBlockedByDarkType,
+  isPranksterEligible,
+  isQuickDrawTrigger,
+  isSteamEngineTrigger,
+} from "../src/Gen8AbilitiesStat";
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeActive(overrides: {
+  level?: number;
+  attack?: number;
+  defense?: number;
+  spAttack?: number;
+  spDefense?: number;
+  speed?: number;
+  hp?: number;
+  currentHp?: number;
+  types?: PokemonType[];
+  ability?: string;
+  heldItem?: string | null;
+  status?: string | null;
+  speciesId?: number;
+  nickname?: string | null;
+  movedThisTurn?: boolean;
+  turnsOnField?: number;
+}): ActivePokemon {
+  const hp = overrides.hp ?? 200;
+  const attack = overrides.attack ?? 100;
+  const defense = overrides.defense ?? 100;
+  const spAttack = overrides.spAttack ?? 100;
+  const spDefense = overrides.spDefense ?? 100;
+  const speed = overrides.speed ?? 100;
+  return {
+    pokemon: {
+      uid: "test",
+      speciesId: overrides.speciesId ?? 1,
+      nickname: overrides.nickname ?? null,
+      level: overrides.level ?? 50,
+      experience: 0,
+      nature: "hardy",
+      ivs: { hp: 31, attack: 31, defense: 31, spAttack: 31, spDefense: 31, speed: 31 },
+      evs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+      currentHp: overrides.currentHp ?? hp,
+      moves: [],
+      ability: overrides.ability ?? "none",
+      abilitySlot: "normal1" as const,
+      heldItem: overrides.heldItem ?? null,
+      status: (overrides.status ?? null) as any,
+      friendship: 0,
+      gender: "male" as any,
+      isShiny: false,
+      metLocation: "",
+      metLevel: 1,
+      originalTrainer: "",
+      originalTrainerId: 0,
+      pokeball: "pokeball",
+      calculatedStats: { hp, attack, defense, spAttack, spDefense, speed },
+    },
+    teamSlot: 0,
+    statStages: {
+      attack: 0,
+      defense: 0,
+      spAttack: 0,
+      spDefense: 0,
+      speed: 0,
+      accuracy: 0,
+      evasion: 0,
+    },
+    volatileStatuses: new Map(),
+    types: overrides.types ?? ["normal"],
+    ability: overrides.ability ?? "none",
+    lastMoveUsed: null,
+    lastDamageTaken: 0,
+    lastDamageType: null,
+    lastDamageCategory: null,
+    turnsOnField: overrides.turnsOnField ?? 0,
+    movedThisTurn: overrides.movedThisTurn ?? false,
+    consecutiveProtects: 0,
+    substituteHp: 0,
+    itemKnockedOff: false,
+    transformed: false,
+    transformedSpecies: null,
+    isMega: false,
+    isDynamaxed: false,
+    dynamaxTurnsLeft: 0,
+    isTerastallized: false,
+    teraType: null,
+    suppressedAbility: null,
+    forcedMove: null,
+  } as ActivePokemon;
+}
+
+function makeMove(overrides: {
+  id?: string;
+  type?: PokemonType;
+  category?: "physical" | "special" | "status";
+  power?: number | null;
+  flags?: Partial<MoveData["flags"]>;
+  effect?: MoveData["effect"];
+}): MoveData {
+  return {
+    id: overrides.id ?? "tackle",
+    displayName: overrides.id ?? "Tackle",
+    type: overrides.type ?? "normal",
+    category: overrides.category ?? "physical",
+    power: overrides.power ?? 50,
+    accuracy: 100,
+    pp: 35,
+    priority: 0,
+    target: "adjacent-foe",
+    flags: {
+      contact: true,
+      sound: false,
+      bullet: false,
+      pulse: false,
+      punch: false,
+      bite: false,
+      wind: false,
+      slicing: false,
+      powder: false,
+      protect: true,
+      mirror: true,
+      snatch: false,
+      gravity: false,
+      defrost: false,
+      recharge: false,
+      charge: false,
+      bypassSubstitute: false,
+      ...overrides.flags,
+    },
+    effect: overrides.effect ?? null,
+    description: "",
+    generation: 8,
+    critRatio: 0,
+  } as MoveData;
+}
+
+function makeState(): BattleState {
+  return {
+    weather: null,
+    terrain: null,
+    trickRoom: { active: false, turnsLeft: 0 },
+    magicRoom: { active: false, turnsLeft: 0 },
+    wonderRoom: { active: false, turnsLeft: 0 },
+    gravity: { active: false, turnsLeft: 0 },
+    format: "singles",
+    generation: 8,
+    turnNumber: 1,
+    sides: [{}, {}],
+  } as unknown as BattleState;
+}
+
+function makeCtx(overrides: {
+  ability: string;
+  trigger: string;
+  move?: MoveData;
+  currentHp?: number;
+  maxHp?: number;
+  types?: PokemonType[];
+  nickname?: string | null;
+  opponent?: ActivePokemon;
+  turnsOnField?: number;
+  seed?: number;
+  statChange?: { stat: string; stages: number; source: "self" | "opponent" };
+}): AbilityContext {
+  const hp = overrides.maxHp ?? 200;
+  return {
+    pokemon: makeActive({
+      ability: overrides.ability,
+      currentHp: overrides.currentHp ?? hp,
+      hp: hp,
+      types: overrides.types ?? ["normal"],
+      nickname: overrides.nickname ?? null,
+      turnsOnField: overrides.turnsOnField ?? 0,
+    }),
+    opponent: overrides.opponent ?? makeActive({}),
+    state: makeState(),
+    rng: new SeededRandom(overrides.seed ?? 42),
+    trigger: overrides.trigger as any,
+    move: overrides.move,
+    statChange: overrides.statChange as any,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Stat Abilities", () => {
+  // ---- Triage ----
+
+  describe("Triage", () => {
+    it("given a healing move, when Triage is active, then returns +3 priority bonus", () => {
+      // Source: Showdown data/abilities.ts -- triage: onModifyPriority +3
+      // Source: Bulbapedia "Triage" -- "+3 priority to healing moves"
+      const bonus = getTriagePriorityBonus("triage", "drain-punch", null);
+      expect(bonus).toBe(3);
+    });
+
+    it("given a drain-type effect, when Triage is active, then returns +3 priority bonus", () => {
+      // Source: Showdown data/abilities.ts -- triage: move.flags.heal
+      const bonus = getTriagePriorityBonus("triage", "some-drain-move", "drain");
+      expect(bonus).toBe(3);
+    });
+
+    it("given a non-healing move, when Triage is active, then returns 0", () => {
+      const bonus = getTriagePriorityBonus("triage", "thunderbolt", null);
+      expect(bonus).toBe(0);
+    });
+
+    it("given a different ability, when checking Triage bonus, then returns 0", () => {
+      const bonus = getTriagePriorityBonus("intimidate", "drain-punch", null);
+      expect(bonus).toBe(0);
+    });
+
+    it("given the dispatcher, when Triage user uses healing move, then returns activated:true", () => {
+      const ctx = makeCtx({
+        ability: "triage",
+        trigger: "on-priority-check",
+        move: makeMove({ id: "drain-punch" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+  });
+
+  // ---- Gale Wings ----
+
+  describe("Gale Wings", () => {
+    it("given full HP and a Flying move, when Gale Wings is active, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- galeWings: requires full HP
+      // Source: Bulbapedia "Gale Wings" Gen 7+ -- "only at full HP"
+      expect(isGaleWingsActive("gale-wings", "flying", 200, 200)).toBe(true);
+    });
+
+    it("given less than full HP and a Flying move, when Gale Wings is active, then returns false", () => {
+      // Source: Showdown data/abilities.ts -- galeWings: requires pokemon.hp === pokemon.maxhp
+      expect(isGaleWingsActive("gale-wings", "flying", 199, 200)).toBe(false);
+    });
+
+    it("given full HP and a non-Flying move, when Gale Wings is active, then returns false", () => {
+      expect(isGaleWingsActive("gale-wings", "fire", 200, 200)).toBe(false);
+    });
+
+    it("given a different ability, when checking Gale Wings, then returns false", () => {
+      expect(isGaleWingsActive("intimidate", "flying", 200, 200)).toBe(false);
+    });
+
+    it("given the dispatcher, when Gale Wings user at full HP uses Flying move, then returns activated:true", () => {
+      const ctx = makeCtx({
+        ability: "gale-wings",
+        trigger: "on-priority-check",
+        currentHp: 200,
+        maxHp: 200,
+        move: makeMove({ type: "flying" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+
+    it("given the dispatcher, when Gale Wings user below full HP uses Flying move, then returns activated:false", () => {
+      const ctx = makeCtx({
+        ability: "gale-wings",
+        trigger: "on-priority-check",
+        currentHp: 150,
+        maxHp: 200,
+        move: makeMove({ type: "flying" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(false);
+    });
+  });
+
+  // ---- Prankster ----
+
+  describe("Prankster", () => {
+    it("given a status move, when isPranksterEligible is checked, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- Prankster checks move.category === 'Status'
+      expect(isPranksterEligible("status")).toBe(true);
+    });
+
+    it("given a physical move, when isPranksterEligible is checked, then returns false", () => {
+      expect(isPranksterEligible("physical")).toBe(false);
+    });
+
+    it("given Prankster and a status move targeting Dark type, when checking block, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- prankster: Dark targets block
+      // Source: Bulbapedia "Prankster" Gen 7+ -- "status moves fail against Dark-type targets"
+      expect(isPranksterBlockedByDarkType("prankster", "status", ["dark"])).toBe(true);
+    });
+
+    it("given Prankster and a status move targeting non-Dark type, when checking block, then returns false", () => {
+      expect(isPranksterBlockedByDarkType("prankster", "status", ["fire"])).toBe(false);
+    });
+
+    it("given Prankster and a physical move targeting Dark type, when checking block, then returns false", () => {
+      expect(isPranksterBlockedByDarkType("prankster", "physical", ["dark"])).toBe(false);
+    });
+
+    it("given the dispatcher, when Prankster user uses status move, then returns activated:true", () => {
+      const ctx = makeCtx({
+        ability: "prankster",
+        trigger: "on-priority-check",
+        move: makeMove({ category: "status" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+  });
+
+  // ---- Intrepid Sword (NEW Gen 8) ----
+
+  describe("Intrepid Sword", () => {
+    it("given first turn on field (turnsOnField === 0), when checking trigger, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- intrepidsword: onStart (no once flag in Gen 8)
+      // Source: Bulbapedia "Intrepid Sword" -- triggers on entry
+      expect(isIntrepidSwordTrigger("intrepid-sword", 0)).toBe(true);
+    });
+
+    it("given already been on field (turnsOnField > 0), when checking trigger, then returns false", () => {
+      // The ability triggers on switch-in, not mid-battle
+      expect(isIntrepidSwordTrigger("intrepid-sword", 1)).toBe(false);
+    });
+
+    it("given a different ability, when checking Intrepid Sword trigger, then returns false", () => {
+      expect(isIntrepidSwordTrigger("intimidate", 0)).toBe(false);
+    });
+
+    it("given the dispatcher on switch-in, when Intrepid Sword activates, then effect is +1 Attack", () => {
+      // Source: Showdown data/abilities.ts -- intrepidsword: onStart, boost atk: 1
+      // Source: Bulbapedia "Intrepid Sword" -- "raises Attack by one stage upon entering battle"
+      const ctx = makeCtx({
+        ability: "intrepid-sword",
+        trigger: "on-switch-in",
+        turnsOnField: 0,
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.effects).toEqual([
+        { effectType: "stat-change", target: "self", stat: "attack", stages: 1 },
+      ]);
+    });
+
+    it("given multiple switch-ins in Gen 8, when Intrepid Sword re-enters, then triggers again", () => {
+      // Source: Showdown data/mods/gen8/abilities.ts -- no once-per-battle flag
+      // In Gen 8, Intrepid Sword triggers every switch-in, not once per battle
+      const ctx1 = makeCtx({
+        ability: "intrepid-sword",
+        trigger: "on-switch-in",
+        turnsOnField: 0,
+      });
+      const result1 = handleGen8StatAbility(ctx1);
+      expect(result1.activated).toBe(true);
+
+      // Simulate second switch-in (turnsOnField resets to 0)
+      const ctx2 = makeCtx({
+        ability: "intrepid-sword",
+        trigger: "on-switch-in",
+        turnsOnField: 0,
+      });
+      const result2 = handleGen8StatAbility(ctx2);
+      expect(result2.activated).toBe(true);
+    });
+  });
+
+  // ---- Dauntless Shield (NEW Gen 8) ----
+
+  describe("Dauntless Shield", () => {
+    it("given first turn on field, when checking trigger, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- dauntlessshield: onStart
+      // Source: Bulbapedia "Dauntless Shield" -- triggers on entry
+      expect(isDauntlessShieldTrigger("dauntless-shield", 0)).toBe(true);
+    });
+
+    it("given already been on field, when checking trigger, then returns false", () => {
+      expect(isDauntlessShieldTrigger("dauntless-shield", 1)).toBe(false);
+    });
+
+    it("given the dispatcher on switch-in, when Dauntless Shield activates, then effect is +1 Defense", () => {
+      // Source: Showdown data/abilities.ts -- dauntlessshield: onStart, boost def: 1
+      // Source: Bulbapedia "Dauntless Shield" -- "raises Defense by one stage upon entering battle"
+      const ctx = makeCtx({
+        ability: "dauntless-shield",
+        trigger: "on-switch-in",
+        turnsOnField: 0,
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.effects).toEqual([
+        { effectType: "stat-change", target: "self", stat: "defense", stages: 1 },
+      ]);
+    });
+
+    it("given multiple switch-ins in Gen 8, when Dauntless Shield re-enters, then triggers again", () => {
+      // Source: Gen 8 has no once-per-battle limit for Dauntless Shield
+      const ctx = makeCtx({
+        ability: "dauntless-shield",
+        trigger: "on-switch-in",
+        turnsOnField: 0,
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.effects[0]).toEqual({
+        effectType: "stat-change",
+        target: "self",
+        stat: "defense",
+        stages: 1,
+      });
+    });
+  });
+
+  // ---- Cotton Down (NEW Gen 8) ----
+
+  describe("Cotton Down", () => {
+    it("given Cotton Down, when checking trigger, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- cottondown: onDamagingHit
+      // Source: Bulbapedia "Cotton Down" -- "when hit by an attack"
+      expect(isCottonDownTrigger("cotton-down")).toBe(true);
+    });
+
+    it("given a different ability, when checking Cotton Down trigger, then returns false", () => {
+      expect(isCottonDownTrigger("intimidate")).toBe(false);
+    });
+
+    it("given the dispatcher, when Cotton Down holder is hit by physical move, then lowers opponent Speed by 1", () => {
+      // Source: Showdown data/abilities.ts -- cottondown: lowers all adjacent Speed
+      // Source: Bulbapedia "Cotton Down" -- "lowering the Speed stat of all other Pokemon"
+      const ctx = makeCtx({
+        ability: "cotton-down",
+        trigger: "on-damage-taken",
+        move: makeMove({ category: "physical" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.effects).toEqual([
+        { effectType: "stat-change", target: "opponent", stat: "speed", stages: -1 },
+      ]);
+    });
+
+    it("given the dispatcher, when Cotton Down holder is hit by special move, then also triggers", () => {
+      const ctx = makeCtx({
+        ability: "cotton-down",
+        trigger: "on-damage-taken",
+        move: makeMove({ category: "special" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+    });
+
+    it("given the dispatcher, when Cotton Down holder is hit by status move, then does not trigger", () => {
+      // Status moves do not deal damage, so Cotton Down does not trigger
+      const ctx = makeCtx({
+        ability: "cotton-down",
+        trigger: "on-damage-taken",
+        move: makeMove({ category: "status" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(false);
+    });
+  });
+
+  // ---- Steam Engine (NEW Gen 8) ----
+
+  describe("Steam Engine", () => {
+    it("given a Fire move, when checking Steam Engine trigger, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- steamengine: Fire or Water type
+      // Source: Bulbapedia "Steam Engine" -- "Fire- or Water-type move"
+      expect(isSteamEngineTrigger("steam-engine", "fire")).toBe(true);
+    });
+
+    it("given a Water move, when checking Steam Engine trigger, then returns true", () => {
+      expect(isSteamEngineTrigger("steam-engine", "water")).toBe(true);
+    });
+
+    it("given a Normal move, when checking Steam Engine trigger, then returns false", () => {
+      expect(isSteamEngineTrigger("steam-engine", "normal")).toBe(false);
+    });
+
+    it("given a different ability, when checking Steam Engine trigger, then returns false", () => {
+      expect(isSteamEngineTrigger("intimidate", "fire")).toBe(false);
+    });
+
+    it("given the dispatcher, when Steam Engine holder is hit by Fire move, then raises Speed by 6", () => {
+      // Source: Showdown data/abilities.ts -- steamengine: onDamagingHit, boost spe: 6
+      // Source: Bulbapedia "Steam Engine" -- "raises Speed by 6 stages"
+      const ctx = makeCtx({
+        ability: "steam-engine",
+        trigger: "on-damage-taken",
+        move: makeMove({ type: "fire" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.effects).toEqual([
+        { effectType: "stat-change", target: "self", stat: "speed", stages: 6 },
+      ]);
+    });
+
+    it("given the dispatcher, when Steam Engine holder is hit by Water move, then raises Speed by 6", () => {
+      const ctx = makeCtx({
+        ability: "steam-engine",
+        trigger: "on-damage-taken",
+        move: makeMove({ type: "water" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.effects).toEqual([
+        { effectType: "stat-change", target: "self", stat: "speed", stages: 6 },
+      ]);
+    });
+
+    it("given the dispatcher, when Steam Engine holder is hit by Electric move, then does not trigger", () => {
+      const ctx = makeCtx({
+        ability: "steam-engine",
+        trigger: "on-damage-taken",
+        move: makeMove({ type: "electric" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(false);
+    });
+  });
+
+  // ---- Quick Draw (NEW Gen 8) ----
+
+  describe("Quick Draw", () => {
+    it("given rng value < 0.3, when checking Quick Draw trigger, then returns true (30% chance)", () => {
+      // Source: Showdown data/abilities.ts -- quickdraw: onFractionalPriority, 30% chance
+      // Source: Bulbapedia "Quick Draw" -- "30% chance of acting first"
+      expect(isQuickDrawTrigger("quick-draw", 0.0)).toBe(true);
+      expect(isQuickDrawTrigger("quick-draw", 0.29)).toBe(true);
+    });
+
+    it("given rng value >= 0.3, when checking Quick Draw trigger, then returns false", () => {
+      expect(isQuickDrawTrigger("quick-draw", 0.3)).toBe(false);
+      expect(isQuickDrawTrigger("quick-draw", 0.5)).toBe(false);
+      expect(isQuickDrawTrigger("quick-draw", 0.99)).toBe(false);
+    });
+
+    it("given a different ability, when checking Quick Draw trigger, then returns false", () => {
+      expect(isQuickDrawTrigger("intimidate", 0.0)).toBe(false);
+    });
+
+    it("given the dispatcher with seeded rng, when Quick Draw user checks priority, then outcome is deterministic", () => {
+      // SeededRandom(42) produces a deterministic sequence.
+      // We test that the dispatcher returns a consistent result for the same seed.
+      // Source: Showdown data/abilities.ts -- quickdraw: 30% chance
+      const ctx = makeCtx({
+        ability: "quick-draw",
+        trigger: "on-priority-check",
+        move: makeMove({}),
+        seed: 42,
+      });
+      const result1 = handleGen8StatAbility(ctx);
+      // Run again with same seed to verify determinism
+      const ctx2 = makeCtx({
+        ability: "quick-draw",
+        trigger: "on-priority-check",
+        move: makeMove({}),
+        seed: 42,
+      });
+      const result2 = handleGen8StatAbility(ctx2);
+      expect(result1.activated).toBe(result2.activated);
+    });
+
+    it("given Quick Draw, when testing across many seeds, then approximately 30% activate", () => {
+      // Source: Showdown data/abilities.ts -- quickdraw: 30% chance
+      // Statistical test: with 1000 trials, ~300 should activate (allow +/- 50 for variance)
+      let activations = 0;
+      for (let seed = 0; seed < 1000; seed++) {
+        const ctx = makeCtx({
+          ability: "quick-draw",
+          trigger: "on-priority-check",
+          move: makeMove({}),
+          seed,
+        });
+        const result = handleGen8StatAbility(ctx);
+        if (result.activated) activations++;
+      }
+      // Expect approximately 30% (300 +/- 50)
+      expect(activations).toBeGreaterThan(250);
+      expect(activations).toBeLessThan(350);
+    });
+  });
+
+  // ---- Carried-forward abilities: Weak Armor, Stamina, Rattled ----
+
+  describe("Weak Armor (carried from Gen 7)", () => {
+    it("given a physical hit, when Weak Armor triggers, then -1 Def and +2 Speed", () => {
+      // Source: Showdown data/abilities.ts -- Weak Armor Gen 7+: spe +2
+      // Source: Bulbapedia "Weak Armor" -- "+2 Speed from Gen VII onwards"
+      const ctx = makeCtx({
+        ability: "weak-armor",
+        trigger: "on-damage-taken",
+        move: makeMove({ category: "physical" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.effects).toEqual([
+        { effectType: "stat-change", target: "self", stat: "defense", stages: -1 },
+        { effectType: "stat-change", target: "self", stat: "speed", stages: 2 },
+      ]);
+    });
+
+    it("given a special hit, when Weak Armor is checked, then does not trigger", () => {
+      const ctx = makeCtx({
+        ability: "weak-armor",
+        trigger: "on-damage-taken",
+        move: makeMove({ category: "special" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(false);
+    });
+  });
+
+  describe("Stamina (carried from Gen 7)", () => {
+    it("given any damaging move, when Stamina triggers, then +1 Defense", () => {
+      // Source: Showdown data/abilities.ts -- Stamina onDamagingHit
+      const ctx = makeCtx({
+        ability: "stamina",
+        trigger: "on-damage-taken",
+        move: makeMove({ category: "physical" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.effects).toEqual([
+        { effectType: "stat-change", target: "self", stat: "defense", stages: 1 },
+      ]);
+    });
+  });
+
+  // ---- Protean / Libero (Libero new in Gen 8) ----
+
+  describe("Protean / Libero", () => {
+    it("given Protean and a move type not matching current type, when used before move, then changes type", () => {
+      // Source: Showdown data/abilities.ts -- protean: onPrepareHit
+      const ctx = makeCtx({
+        ability: "protean",
+        trigger: "on-before-move",
+        types: ["normal"],
+        move: makeMove({ type: "fire" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.effects).toEqual([
+        { effectType: "type-change", target: "self", types: ["fire"] },
+      ]);
+    });
+
+    it("given Libero and a move type not matching current type, when used before move, then changes type", () => {
+      // Source: Showdown data/abilities.ts -- libero: same as protean
+      // Source: Bulbapedia "Libero" -- "same effect as Protean, introduced in Gen 8"
+      const ctx = makeCtx({
+        ability: "libero",
+        trigger: "on-before-move",
+        types: ["fire"],
+        move: makeMove({ type: "electric" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(true);
+      expect(result.effects).toEqual([
+        { effectType: "type-change", target: "self", types: ["electric"] },
+      ]);
+    });
+
+    it("given Protean and the move type already matches, when used before move, then does not activate", () => {
+      const ctx = makeCtx({
+        ability: "protean",
+        trigger: "on-before-move",
+        types: ["fire"],
+        move: makeMove({ type: "fire" }),
+      });
+      const result = handleGen8StatAbility(ctx);
+      expect(result.activated).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `Gen8AbilitiesDamage.ts` with damage-modifying ability handlers (Gorilla Tactics, Transistor, Dragon's Maw, Punk Rock, Ice Scales, Steelworker) plus all Gen 7 carry-forward abilities
- Add `Gen8AbilitiesStat.ts` with stat/priority ability handlers (Intrepid Sword, Dauntless Shield, Cotton Down, Steam Engine, Quick Draw, Libero) plus Gen 7 carry-forwards
- Gen 8 Moody excludes accuracy/evasion (5-stat pool vs Gen 7's 7-stat pool)
- Intrepid Sword/Dauntless Shield trigger every switch-in (Gen 8 pre-nerf, no once-per-battle limit)
- 111 new tests across 2 test files with full source provenance comments

## New Gen 8 Abilities
| Ability | Type | Effect |
|---------|------|--------|
| Gorilla Tactics | Damage | 1.5x physical Attack (6144/4096) |
| Transistor | Damage | 1.5x Electric moves (Gen 8: 1.5x, Gen 9: nerfed) |
| Dragon's Maw | Damage | 1.5x Dragon moves |
| Punk Rock | Damage | 1.3x outgoing sound / 0.5x incoming sound |
| Ice Scales | Damage | 0.5x incoming special damage |
| Steelworker | Damage | 1.5x Steel moves |
| Intrepid Sword | Stat | +1 Attack every switch-in |
| Dauntless Shield | Stat | +1 Defense every switch-in |
| Cotton Down | Stat | -1 Speed to foes when hit |
| Steam Engine | Stat | +6 Speed when hit by Fire/Water |
| Quick Draw | Stat | 30% chance to move first |
| Libero | Stat | Type change (same as Protean) |

## Test plan
- [x] All 62 damage ability tests pass
- [x] All 49 stat ability tests pass
- [x] Full gen8 test suite passes (269 tests)
- [x] Typecheck passes
- [x] Biome lint/format passes

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>