### PR TITLE
feat(gen8): Wave 5B -- switch/contact/field ability handlers

### DIFF
--- a/.changeset/gen8-wave5b-abilities.md
+++ b/.changeset/gen8-wave5b-abilities.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/gen8": minor
+---
+
+Wave 5B: Gen 8 switch/contact ability handlers (Screen Cleaner, Mirror Armor, Neutralizing Gas, Pastel Veil, Wandering Spirit, Perish Body, Gulp Missile, Ice Face, Hunger Switch, Libero)

--- a/packages/gen8/src/Gen8Abilities.ts
+++ b/packages/gen8/src/Gen8Abilities.ts
@@ -1,0 +1,119 @@
+import type { AbilityContext, AbilityResult } from "@pokemon-lib-ts/battle";
+import type { AbilityTrigger } from "@pokemon-lib-ts/core";
+import { handleGen8SwitchAbility, shouldMirrorArmorReflect } from "./Gen8AbilitiesSwitch.js";
+
+/**
+ * Gen 8 master ability dispatcher.
+ *
+ * Central router that delegates to the appropriate ability handler module
+ * based on the trigger type and ability ID.
+ *
+ * Module responsibilities:
+ *   - Gen8AbilitiesSwitch: switch-in/out, contact, passive, status, before-move, turn-end
+ *   - Future: Gen8AbilitiesDamage (damage-calc modifiers)
+ *   - Future: Gen8AbilitiesStat (stat-change triggers like Defiant, Competitive, etc.)
+ *
+ * Source: Showdown data/abilities.ts
+ */
+
+const NO_ACTIVATION: AbilityResult = { activated: false, effects: [], messages: [] };
+
+// ---------------------------------------------------------------------------
+// Switch-in abilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a switch-in ability trigger.
+ *
+ * Routes to Gen8AbilitiesSwitch for weather, Intimidate, Screen Cleaner,
+ * Neutralizing Gas, Intrepid Sword, Dauntless Shield, etc.
+ */
+export function handleGen8SwitchInAbility(
+  abilityId: string,
+  trigger: AbilityTrigger,
+  context: AbilityContext,
+): AbilityResult {
+  if (trigger !== "on-switch-in") return NO_ACTIVATION;
+  return handleGen8SwitchAbility(trigger, context);
+}
+
+// ---------------------------------------------------------------------------
+// Contact abilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a contact-triggered ability.
+ *
+ * Routes to Gen8AbilitiesSwitch for Static, Flame Body, Rough Skin,
+ * Wandering Spirit, Perish Body, Gulp Missile, Ice Face, etc.
+ */
+export function handleGen8ContactAbility(
+  abilityId: string,
+  trigger: AbilityTrigger,
+  context: AbilityContext,
+): AbilityResult {
+  if (trigger !== "on-contact") return NO_ACTIVATION;
+  return handleGen8SwitchAbility(trigger, context);
+}
+
+// ---------------------------------------------------------------------------
+// Field/passive abilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a field-wide or passive ability trigger.
+ *
+ * Routes to the appropriate handler based on trigger type:
+ *   - on-switch-out: Regenerator, Natural Cure
+ *   - on-status-inflicted: Synchronize
+ *   - on-before-move: Libero, Protean
+ *   - on-turn-end: Hunger Switch
+ *   - on-stat-change: Mirror Armor
+ */
+export function handleGen8FieldAbility(
+  abilityId: string,
+  trigger: AbilityTrigger,
+  context: AbilityContext,
+): AbilityResult {
+  // Mirror Armor: special handling for stat-change trigger
+  if (trigger === "on-stat-change" && abilityId === "mirror-armor") {
+    return handleMirrorArmorStatChange(context);
+  }
+
+  // Route everything else through the switch handler
+  return handleGen8SwitchAbility(trigger, context);
+}
+
+// ---------------------------------------------------------------------------
+// Mirror Armor stat-change handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle Mirror Armor reflecting stat drops.
+ *
+ * When a stat is lowered by an opponent, Mirror Armor reflects the drop
+ * back to the source instead of applying it to the holder.
+ *
+ * Source: Showdown data/abilities.ts -- Mirror Armor onTryBoost
+ * Source: Bulbapedia "Mirror Armor" -- "Bounces back stat-lowering effects"
+ */
+function handleMirrorArmorStatChange(ctx: AbilityContext): AbilityResult {
+  if (!ctx.statChange) return NO_ACTIVATION;
+
+  const { stat, stages, source } = ctx.statChange;
+  if (!shouldMirrorArmorReflect("mirror-armor", stages, source)) {
+    return NO_ACTIVATION;
+  }
+
+  // HP cannot be stage-changed; Mirror Armor only reflects non-HP stats
+  if (stat === "hp") return NO_ACTIVATION;
+
+  const name = ctx.pokemon.pokemon.nickname ?? String(ctx.pokemon.pokemon.speciesId);
+
+  // Reflect the stat drop back to the opponent
+  return {
+    activated: true,
+    effects: [{ effectType: "stat-change", target: "opponent", stat, stages }],
+    messages: [`${name}'s Mirror Armor reflected the stat drop!`],
+  };
+}

--- a/packages/gen8/src/Gen8AbilitiesSwitch.ts
+++ b/packages/gen8/src/Gen8AbilitiesSwitch.ts
@@ -1,0 +1,1218 @@
+import type { AbilityContext, AbilityEffect, AbilityResult } from "@pokemon-lib-ts/battle";
+import type { AbilityTrigger, PokemonType, ScreenType } from "@pokemon-lib-ts/core";
+
+/**
+ * Gen 8 switch-in, switch-out, contact, and passive ability handlers.
+ *
+ * Carries forward all Gen 7 switch/contact abilities plus Gen 8 additions:
+ *   - Screen Cleaner: removes Reflect/Light Screen/Aurora Veil from both sides
+ *   - Mirror Armor: reflects stat drops back to attacker
+ *   - Neutralizing Gas: suppresses all abilities on the field
+ *   - Pastel Veil: prevents poison/toxic on holder and allies
+ *   - Wandering Spirit: swaps abilities on contact
+ *   - Perish Body: both sides get Perish Song on contact
+ *   - Gulp Missile: Cramorant form-change and retaliation
+ *   - Ice Face: Eiscue blocks first physical hit, reforms in hail
+ *   - Hunger Switch: Morpeko toggles form each turn
+ *   - Libero: type change before attacking (same as Protean pre-nerf)
+ *   - Intrepid Sword / Dauntless Shield: stat boosts on every switch-in
+ *
+ * Source: Showdown data/abilities.ts
+ * Source: Showdown data/mods/gen8/abilities.ts
+ * Source: Bulbapedia -- individual ability articles
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getName(ctx: AbilityContext): string {
+  return ctx.pokemon.pokemon.nickname ?? String(ctx.pokemon.pokemon.speciesId);
+}
+
+function getOpponentName(ctx: AbilityContext): string {
+  if (!ctx.opponent) return "the opposing Pokemon";
+  return ctx.opponent.pokemon.nickname ?? String(ctx.opponent.pokemon.speciesId);
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Abilities that cannot be copied by Trace in Gen 8.
+ *
+ * Gen 8 adds: Hunger Switch, Gulp Missile, Ice Face, Power Spot,
+ * Neutralizing Gas, Intrepid Sword, Dauntless Shield.
+ *
+ * Source: Showdown data/abilities.ts -- trace.onUpdate
+ * Source: Bulbapedia "Trace" Gen 8 -- cannot copy these abilities
+ */
+export const TRACE_UNCOPYABLE_ABILITIES = new Set([
+  "trace",
+  "multitype",
+  "forecast",
+  "illusion",
+  "flower-gift",
+  "imposter",
+  "zen-mode",
+  "stance-change",
+  "power-construct",
+  "schooling",
+  "comatose",
+  "shields-down",
+  "disguise",
+  "rks-system",
+  "battle-bond",
+  "receiver",
+  "power-of-alchemy",
+  // Gen 8 additions
+  "hunger-switch",
+  "gulp-missile",
+  "ice-face",
+  "neutralizing-gas",
+  "intrepid-sword",
+  "dauntless-shield",
+]);
+
+/**
+ * Abilities that cannot be overwritten by Mummy or suppressed by Gastro Acid.
+ *
+ * Gen 8 adds: Gulp Missile, Ice Face, Neutralizing Gas.
+ *
+ * Source: Showdown data/abilities.ts -- cantsuppress
+ */
+export const UNSUPPRESSABLE_ABILITIES = new Set([
+  "multitype",
+  "stance-change",
+  "schooling",
+  "comatose",
+  "shields-down",
+  "disguise",
+  "rks-system",
+  "battle-bond",
+  "power-construct",
+  // Gen 8 additions
+  "gulp-missile",
+  "ice-face",
+  "neutralizing-gas",
+]);
+
+/**
+ * Abilities immune to Neutralizing Gas suppression.
+ *
+ * Source: Showdown data/abilities.ts -- Neutralizing Gas onStart
+ * Source: Bulbapedia "Neutralizing Gas" -- does not suppress itself,
+ *   Comatose, or any ability in the unsuppressable set
+ */
+export const NEUTRALIZING_GAS_IMMUNE_ABILITIES = new Set([
+  "neutralizing-gas",
+  "comatose",
+  "multitype",
+  "stance-change",
+  "schooling",
+  "shields-down",
+  "disguise",
+  "rks-system",
+  "battle-bond",
+  "power-construct",
+  "gulp-missile",
+  "ice-face",
+]);
+
+/**
+ * Mold Breaker ability variants.
+ *
+ * Source: Showdown data/abilities.ts -- moldbreaker/teravolt/turboblaze
+ */
+export const MOLD_BREAKER_ALIASES = new Set(["mold-breaker", "teravolt", "turboblaze"]);
+
+/**
+ * Weather duration extension by weather rocks: 5 turns base, 8 with rock.
+ *
+ * Source: Bulbapedia -- individual rock item pages
+ * Source: Showdown data/items.ts -- damprock/heatrock/smoothrock/icyrock
+ */
+const WEATHER_ROCK_MAP: Readonly<Record<string, { weather: string; turns: number }>> = {
+  "damp-rock": { weather: "rain", turns: 8 },
+  "heat-rock": { weather: "sun", turns: 8 },
+  "smooth-rock": { weather: "sand", turns: 8 },
+  "icy-rock": { weather: "hail", turns: 8 },
+};
+
+const BASE_WEATHER_TURNS = 5;
+
+/**
+ * Screen types that Screen Cleaner removes from both sides.
+ *
+ * Source: Showdown data/abilities.ts -- Screen Cleaner onStart
+ */
+export const SCREEN_CLEANER_SCREENS: readonly ScreenType[] = [
+  "reflect",
+  "light-screen",
+  "aurora-veil",
+];
+
+// ---------------------------------------------------------------------------
+// Inactive sentinel
+// ---------------------------------------------------------------------------
+
+const NO_EFFECT: AbilityResult = { activated: false, effects: [], messages: [] };
+
+// ---------------------------------------------------------------------------
+// Main dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatch a Gen 8 switch-in/switch-out/contact/passive ability trigger.
+ *
+ * @param trigger - The ability trigger type
+ * @param context - The ability context
+ */
+export function handleGen8SwitchAbility(
+  trigger: AbilityTrigger,
+  context: AbilityContext,
+): AbilityResult {
+  switch (trigger) {
+    case "on-switch-in":
+      return handleSwitchIn(context);
+    case "on-switch-out":
+      return handleSwitchOut(context);
+    case "on-contact":
+      return handleOnContact(context);
+    case "on-status-inflicted":
+      return handleOnStatusInflicted(context);
+    case "on-before-move":
+      return handleBeforeMove(context);
+    case "on-turn-end":
+      return handleTurnEnd(context);
+    default:
+      return NO_EFFECT;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// on-switch-in
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-switch-in" abilities for Gen 8.
+ *
+ * Source: Showdown data/abilities.ts -- onStart handlers
+ */
+function handleSwitchIn(ctx: AbilityContext): AbilityResult {
+  const abilityId = ctx.pokemon.ability;
+  const name = getName(ctx);
+
+  switch (abilityId) {
+    case "intimidate": {
+      // Source: Showdown data/abilities.ts -- Intimidate lowers opponent's Attack by 1 stage
+      // Blocked by Substitute
+      if (!ctx.opponent) return NO_EFFECT;
+      if (ctx.opponent.substituteHp > 0) return NO_EFFECT;
+      const oppName = getOpponentName(ctx);
+      const effect: AbilityEffect = {
+        effectType: "stat-change",
+        target: "opponent",
+        stat: "attack",
+        stages: -1,
+      };
+      return {
+        activated: true,
+        effects: [effect],
+        messages: [`${name}'s Intimidate cut ${oppName}'s Attack!`],
+      };
+    }
+
+    case "pressure": {
+      // Source: Showdown data/abilities.ts -- Pressure onStart message
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name} is exerting its Pressure!`],
+      };
+    }
+
+    case "drizzle": {
+      // Source: Showdown data/abilities.ts -- Drizzle sets rain, 5 turns (8 with Damp Rock)
+      const turns = getWeatherTurns(ctx.pokemon.pokemon.heldItem, "rain");
+      return {
+        activated: true,
+        effects: [
+          { effectType: "weather-set", target: "field", weather: "rain", weatherTurns: turns },
+        ],
+        messages: [`${name}'s Drizzle made it rain!`],
+      };
+    }
+
+    case "drought": {
+      // Source: Showdown data/abilities.ts -- Drought sets sun, 5 turns (8 with Heat Rock)
+      const turns = getWeatherTurns(ctx.pokemon.pokemon.heldItem, "sun");
+      return {
+        activated: true,
+        effects: [
+          { effectType: "weather-set", target: "field", weather: "sun", weatherTurns: turns },
+        ],
+        messages: [`${name}'s Drought intensified the sun's rays!`],
+      };
+    }
+
+    case "sand-stream": {
+      // Source: Showdown data/abilities.ts -- Sand Stream sets sand, 5 turns (8 with Smooth Rock)
+      const turns = getWeatherTurns(ctx.pokemon.pokemon.heldItem, "sand");
+      return {
+        activated: true,
+        effects: [
+          { effectType: "weather-set", target: "field", weather: "sand", weatherTurns: turns },
+        ],
+        messages: [`${name}'s Sand Stream whipped up a sandstorm!`],
+      };
+    }
+
+    case "snow-warning": {
+      // Source: Showdown data/abilities.ts -- Snow Warning sets hail, 5 turns (8 with Icy Rock)
+      const turns = getWeatherTurns(ctx.pokemon.pokemon.heldItem, "hail");
+      return {
+        activated: true,
+        effects: [
+          { effectType: "weather-set", target: "field", weather: "hail", weatherTurns: turns },
+        ],
+        messages: [`${name}'s Snow Warning made it hail!`],
+      };
+    }
+
+    case "download": {
+      // Source: Showdown data/abilities.ts -- Download: compare foe Def vs SpDef
+      if (!ctx.opponent) return NO_EFFECT;
+      const foeStats = ctx.opponent.pokemon.calculatedStats;
+      if (!foeStats) return NO_EFFECT;
+
+      const raisesAtk = foeStats.defense < foeStats.spDefense;
+      const stat = raisesAtk ? ("attack" as const) : ("spAttack" as const);
+      const statName = raisesAtk ? "Attack" : "Sp. Atk";
+      return {
+        activated: true,
+        effects: [{ effectType: "stat-change", target: "self", stat, stages: 1 }],
+        messages: [`${name}'s Download raised its ${statName}!`],
+      };
+    }
+
+    case "trace": {
+      // Source: Showdown data/abilities.ts -- Trace: copies opponent's ability
+      if (!ctx.opponent) return NO_EFFECT;
+      const opponentAbility = ctx.opponent.ability;
+      if (!opponentAbility || TRACE_UNCOPYABLE_ABILITIES.has(opponentAbility)) return NO_EFFECT;
+      const oppName = getOpponentName(ctx);
+      return {
+        activated: true,
+        effects: [{ effectType: "ability-change", target: "self", newAbility: opponentAbility }],
+        messages: [`${name} traced ${oppName}'s ${opponentAbility}!`],
+      };
+    }
+
+    case "mold-breaker": {
+      // Source: Showdown data/abilities.ts -- Mold Breaker onStart announcement
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name} breaks the mold!`],
+      };
+    }
+
+    case "teravolt": {
+      // Source: Showdown data/abilities.ts -- Teravolt onStart announcement
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name} is radiating a bursting aura!`],
+      };
+    }
+
+    case "turboblaze": {
+      // Source: Showdown data/abilities.ts -- Turboblaze onStart announcement
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name} is radiating a blazing aura!`],
+      };
+    }
+
+    case "imposter": {
+      // Source: Showdown data/abilities.ts -- Imposter: transforms into opponent on switch-in
+      if (!ctx.opponent) return NO_EFFECT;
+      const oppName = getOpponentName(ctx);
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name} transformed into ${oppName}!`],
+      };
+    }
+
+    case "illusion": {
+      // Source: Showdown data/abilities.ts -- Illusion: sets volatile on switch-in
+      return {
+        activated: true,
+        effects: [{ effectType: "volatile-inflict", target: "self", volatile: "illusion" }],
+        messages: [],
+      };
+    }
+
+    case "stance-change": {
+      // Source: Showdown data/abilities.ts -- Stance Change (Aegislash)
+      // Switch-in always resets to Shield Forme
+      if (ctx.pokemon.pokemon.speciesId !== 681) return NO_EFFECT;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [],
+      };
+    }
+
+    case "screen-cleaner": {
+      // Source: Showdown data/abilities.ts -- Screen Cleaner onStart
+      // Removes Reflect, Light Screen, AND Aurora Veil from BOTH sides
+      // Source: specs/reference/gen8-ground-truth.md -- Screen Cleaner: both sides + Aurora Veil
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "field" }],
+        messages: [`${name}'s Screen Cleaner removed all screens!`],
+      };
+    }
+
+    case "neutralizing-gas": {
+      // Source: Showdown data/abilities.ts -- Neutralizing Gas onStart
+      // Suppresses all abilities on the field except unsuppressable ones
+      // Source: Bulbapedia "Neutralizing Gas" -- nullifies all abilities while on field
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "field" }],
+        messages: [`${name}'s Neutralizing Gas filled the area!`],
+      };
+    }
+
+    case "intrepid-sword": {
+      // Source: Showdown data/mods/gen8/abilities.ts -- Intrepid Sword onStart
+      // Gen 8: raises Attack by 1 stage on EVERY switch-in (no once-per-battle limit)
+      // Source: specs/reference/gen8-ground-truth.md -- Intrepid Sword: every switch-in
+      return {
+        activated: true,
+        effects: [{ effectType: "stat-change", target: "self", stat: "attack", stages: 1 }],
+        messages: [`${name}'s Intrepid Sword raised its Attack!`],
+      };
+    }
+
+    case "dauntless-shield": {
+      // Source: Showdown data/mods/gen8/abilities.ts -- Dauntless Shield onStart
+      // Gen 8: raises Defense by 1 stage on EVERY switch-in (no once-per-battle limit)
+      // Source: specs/reference/gen8-ground-truth.md -- Dauntless Shield: every switch-in
+      return {
+        activated: true,
+        effects: [{ effectType: "stat-change", target: "self", stat: "defense", stages: 1 }],
+        messages: [`${name}'s Dauntless Shield raised its Defense!`],
+      };
+    }
+
+    // Receiver / Power of Alchemy: copies fallen ally's ability (Doubles only)
+    // In singles, never triggers.
+    // Source: Showdown data/abilities.ts -- receiver/powerofalchemy: onAllyFaint
+    case "receiver":
+    case "power-of-alchemy": {
+      return NO_EFFECT;
+    }
+
+    default:
+      return NO_EFFECT;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// on-switch-out
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-switch-out" abilities for Gen 8.
+ *
+ * Source: Showdown data/abilities.ts -- onSwitchOut handlers
+ */
+function handleSwitchOut(ctx: AbilityContext): AbilityResult {
+  const abilityId = ctx.pokemon.ability;
+  const name = getName(ctx);
+
+  switch (abilityId) {
+    case "regenerator": {
+      // Source: Showdown data/abilities.ts -- Regenerator: heals 1/3 max HP on switch-out
+      const maxHp = ctx.pokemon.pokemon.calculatedStats?.hp ?? ctx.pokemon.pokemon.currentHp;
+      const healAmount = Math.max(1, Math.floor(maxHp / 3));
+      return {
+        activated: true,
+        effects: [{ effectType: "heal", target: "self", value: healAmount }],
+        messages: [`${name}'s Regenerator restored its HP!`],
+      };
+    }
+
+    case "natural-cure": {
+      // Source: Showdown data/abilities.ts -- Natural Cure: cures status on switch-out
+      if (!ctx.pokemon.pokemon.status) return NO_EFFECT;
+      return {
+        activated: true,
+        effects: [{ effectType: "status-cure", target: "self" }],
+        messages: [`${name}'s Natural Cure cured its status!`],
+      };
+    }
+
+    default:
+      return NO_EFFECT;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// on-contact
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-contact" abilities for Gen 8.
+ *
+ * For DEFENDER-side abilities (Static, Flame Body, Wandering Spirit, Perish Body, etc.):
+ *   - ctx.pokemon = the defender (whose ability fires)
+ *   - ctx.opponent = the attacker who made contact
+ *
+ * For ATTACKER-side abilities (Poison Touch):
+ *   - ctx.pokemon = the attacker (whose ability fires)
+ *   - ctx.opponent = the defender that was hit
+ *
+ * Source: Showdown data/abilities.ts -- onDamagingHit / onSourceDamagingHit handlers
+ */
+function handleOnContact(ctx: AbilityContext): AbilityResult {
+  const abilityId = ctx.pokemon.ability;
+  const other = ctx.opponent;
+  if (!other) return NO_EFFECT;
+
+  const name = getName(ctx);
+
+  switch (abilityId) {
+    case "static": {
+      // Source: Showdown data/abilities.ts -- Static: 30% paralysis on contact
+      if (other.pokemon.status) return NO_EFFECT;
+      if (ctx.rng.next() >= 0.3) return NO_EFFECT;
+      return {
+        activated: true,
+        effects: [{ effectType: "status-inflict", target: "opponent", status: "paralysis" }],
+        messages: [`${name}'s Static paralyzed the attacker!`],
+      };
+    }
+
+    case "flame-body": {
+      // Source: Showdown data/abilities.ts -- Flame Body: 30% burn on contact
+      if (other.pokemon.status) return NO_EFFECT;
+      if (ctx.rng.next() >= 0.3) return NO_EFFECT;
+      return {
+        activated: true,
+        effects: [{ effectType: "status-inflict", target: "opponent", status: "burn" }],
+        messages: [`${name}'s Flame Body burned the attacker!`],
+      };
+    }
+
+    case "poison-point": {
+      // Source: Showdown data/abilities.ts -- Poison Point: 30% poison on contact
+      if (other.pokemon.status) return NO_EFFECT;
+      if (ctx.rng.next() >= 0.3) return NO_EFFECT;
+      return {
+        activated: true,
+        effects: [{ effectType: "status-inflict", target: "opponent", status: "poison" }],
+        messages: [`${name}'s Poison Point poisoned the attacker!`],
+      };
+    }
+
+    case "rough-skin":
+    case "iron-barbs": {
+      // Source: Showdown data/abilities.ts -- Rough Skin / Iron Barbs: 1/8 attacker HP on contact
+      const otherMaxHp = other.pokemon.calculatedStats?.hp ?? other.pokemon.currentHp;
+      const chipDamage = Math.max(1, Math.floor(otherMaxHp / 8));
+      const abilityName = abilityId === "rough-skin" ? "Rough Skin" : "Iron Barbs";
+      return {
+        activated: true,
+        effects: [{ effectType: "chip-damage", target: "opponent", value: chipDamage }],
+        messages: [`${name}'s ${abilityName} hurt the attacker!`],
+      };
+    }
+
+    case "effect-spore": {
+      // Source: Showdown data/abilities.ts -- Effect Spore: single random(100) roll
+      // 0-9 = sleep, 10-19 = paralysis, 20-29 = poison, 30-99 = nothing
+      if (other.pokemon.status) return NO_EFFECT;
+      if (other.types.includes("grass")) return NO_EFFECT;
+      if (other.ability === "overcoat") return NO_EFFECT;
+      const roll = Math.floor(ctx.rng.next() * 100);
+      if (roll < 10) {
+        return {
+          activated: true,
+          effects: [{ effectType: "status-inflict", target: "opponent", status: "sleep" }],
+          messages: [`${name}'s Effect Spore put the attacker to sleep!`],
+        };
+      }
+      if (roll < 20) {
+        return {
+          activated: true,
+          effects: [{ effectType: "status-inflict", target: "opponent", status: "paralysis" }],
+          messages: [`${name}'s Effect Spore paralyzed the attacker!`],
+        };
+      }
+      if (roll < 30) {
+        return {
+          activated: true,
+          effects: [{ effectType: "status-inflict", target: "opponent", status: "poison" }],
+          messages: [`${name}'s Effect Spore poisoned the attacker!`],
+        };
+      }
+      return NO_EFFECT;
+    }
+
+    case "cute-charm": {
+      // Source: Showdown data/abilities.ts -- Cute Charm: 30% infatuation on contact
+      if (ctx.rng.next() >= 0.3) return NO_EFFECT;
+      const defenderGender = ctx.pokemon.pokemon.gender;
+      const attackerGender = other.pokemon.gender;
+      if (
+        !defenderGender ||
+        !attackerGender ||
+        defenderGender === "genderless" ||
+        attackerGender === "genderless" ||
+        defenderGender === attackerGender
+      ) {
+        return NO_EFFECT;
+      }
+      return {
+        activated: true,
+        effects: [{ effectType: "volatile-inflict", target: "opponent", volatile: "infatuation" }],
+        messages: [`${name}'s Cute Charm infatuated the attacker!`],
+      };
+    }
+
+    case "aftermath": {
+      // Source: Showdown data/abilities.ts -- Aftermath: 1/4 attacker HP if holder fainted
+      if (ctx.pokemon.pokemon.currentHp > 0) return NO_EFFECT;
+      const otherMaxHp = other.pokemon.calculatedStats?.hp ?? other.pokemon.currentHp;
+      const chipDamage = Math.max(1, Math.floor(otherMaxHp / 4));
+      return {
+        activated: true,
+        effects: [{ effectType: "chip-damage", target: "opponent", value: chipDamage }],
+        messages: [`${name}'s Aftermath hurt the attacker!`],
+      };
+    }
+
+    case "mummy": {
+      // Source: Showdown data/abilities.ts -- Mummy: contact changes attacker's ability to Mummy
+      const otherAbility = other.ability;
+      if (!otherAbility || otherAbility === "mummy" || UNSUPPRESSABLE_ABILITIES.has(otherAbility)) {
+        return NO_EFFECT;
+      }
+      const oppName = getOpponentName(ctx);
+      return {
+        activated: true,
+        effects: [{ effectType: "ability-change", target: "opponent", newAbility: "mummy" }],
+        messages: [`${oppName}'s ability became Mummy!`],
+      };
+    }
+
+    case "gooey":
+    case "tangling-hair": {
+      // Source: Showdown data/abilities.ts -- Gooey / Tangling Hair: -1 Speed to contact attacker
+      const abilityName = abilityId === "gooey" ? "Gooey" : "Tangling Hair";
+      return {
+        activated: true,
+        effects: [{ effectType: "stat-change", target: "opponent", stat: "speed", stages: -1 }],
+        messages: [`${name}'s ${abilityName} lowered the attacker's Speed!`],
+      };
+    }
+
+    case "poison-touch": {
+      // Source: Showdown data/abilities.ts -- Poison Touch: 30% poison on own contact moves
+      if (other.pokemon.status) return NO_EFFECT;
+      if (ctx.rng.next() >= 0.3) return NO_EFFECT;
+      return {
+        activated: true,
+        effects: [{ effectType: "status-inflict", target: "opponent", status: "poison" }],
+        messages: [`${name}'s Poison Touch poisoned the target!`],
+      };
+    }
+
+    case "pickpocket": {
+      // Source: Showdown data/abilities.ts -- Pickpocket: steals attacker's item on contact
+      if (ctx.pokemon.pokemon.heldItem) return NO_EFFECT;
+      if (!other.pokemon.heldItem) return NO_EFFECT;
+      const oppName = getOpponentName(ctx);
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name}'s Pickpocket stole ${oppName}'s ${other.pokemon.heldItem}!`],
+      };
+    }
+
+    case "wandering-spirit": {
+      // Source: Showdown data/abilities.ts -- Wandering Spirit: swap abilities on contact
+      // Doesn't work on unsuppressable abilities
+      // Source: Bulbapedia "Wandering Spirit" -- swaps abilities with the attacker on contact
+      const otherAbility = other.ability;
+      if (!otherAbility || UNSUPPRESSABLE_ABILITIES.has(otherAbility)) {
+        return NO_EFFECT;
+      }
+      const oppName = getOpponentName(ctx);
+      return {
+        activated: true,
+        effects: [
+          { effectType: "ability-change", target: "self", newAbility: otherAbility },
+          { effectType: "ability-change", target: "opponent", newAbility: "wandering-spirit" },
+        ],
+        messages: [`${name} and ${oppName} swapped Abilities!`],
+      };
+    }
+
+    case "perish-body": {
+      // Source: Showdown data/abilities.ts -- Perish Body: both get Perish Song on contact
+      // Source: Bulbapedia "Perish Body" -- both Pokemon get 3-turn Perish Song countdown
+      return {
+        activated: true,
+        effects: [
+          { effectType: "volatile-inflict", target: "self", volatile: "perish-song" },
+          { effectType: "volatile-inflict", target: "opponent", volatile: "perish-song" },
+        ],
+        messages: [`${name}'s Perish Body activated!`, `Both Pokemon will faint in 3 turns!`],
+      };
+    }
+
+    case "gulp-missile": {
+      // Source: Showdown data/abilities.ts -- Gulp Missile: Cramorant spits projectile when hit
+      // Gulping Form (Arrokuda) = 1/4 max HP damage + -1 Defense
+      // Gorging Form (Pikachu) = 1/4 max HP damage + paralysis
+      // Only triggers if Cramorant is in Gulping or Gorging form
+      return handleGulpMissileOnHit(ctx);
+    }
+
+    case "ice-face": {
+      // Source: Showdown data/abilities.ts -- Ice Face: blocks first physical hit
+      // Only blocks physical moves; special moves go through
+      // Source: Bulbapedia "Ice Face" -- "The Pokemon takes no damage from physical moves once."
+      return handleIceFaceOnHit(ctx);
+    }
+
+    default:
+      return NO_EFFECT;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// on-status-inflicted
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-status-inflicted" abilities for Gen 8.
+ *
+ * Source: Showdown data/abilities.ts -- onAfterSetStatus / onSetStatus handlers
+ */
+function handleOnStatusInflicted(ctx: AbilityContext): AbilityResult {
+  const abilityId = ctx.pokemon.ability;
+  const name = getName(ctx);
+
+  switch (abilityId) {
+    case "synchronize": {
+      // Source: Showdown data/abilities.ts -- Synchronize: passes burn/paralysis/poison
+      if (!ctx.opponent) return NO_EFFECT;
+      const status = ctx.pokemon.pokemon.status;
+      if (!status) return NO_EFFECT;
+      if (status !== "burn" && status !== "paralysis" && status !== "poison") return NO_EFFECT;
+      if (ctx.opponent.pokemon.status) return NO_EFFECT;
+      return {
+        activated: true,
+        effects: [{ effectType: "status-inflict", target: "opponent", status }],
+        messages: [`${name}'s Synchronize spread ${status}!`],
+      };
+    }
+
+    default:
+      return NO_EFFECT;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// on-before-move
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-before-move" abilities for Gen 8.
+ *
+ * Source: Showdown data/abilities.ts -- onPrepareHit / onModifyType handlers
+ */
+function handleBeforeMove(ctx: AbilityContext): AbilityResult {
+  const abilityId = ctx.pokemon.ability;
+
+  switch (abilityId) {
+    case "libero":
+    case "protean": {
+      // Source: Showdown data/abilities.ts -- Libero/Protean: changes type before attacking
+      // Gen 8: activates on every move use (no once-per-switchin limit)
+      // Source: specs/reference/gen8-ground-truth.md -- Libero/Protean: no once-per-switchin limit
+      if (!ctx.move) return NO_EFFECT;
+      const moveType = ctx.move.type as PokemonType;
+      if (!moveType) return NO_EFFECT;
+
+      // Don't change type if already that monotype
+      if (ctx.pokemon.types.length === 1 && ctx.pokemon.types[0] === moveType) {
+        return NO_EFFECT;
+      }
+
+      const name = getName(ctx);
+      const abilityName = abilityId === "libero" ? "Libero" : "Protean";
+      return {
+        activated: true,
+        effects: [{ effectType: "type-change", target: "self", types: [moveType] }],
+        messages: [`${name}'s ${abilityName} changed its type to ${moveType}!`],
+      };
+    }
+
+    default:
+      return NO_EFFECT;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// on-turn-end
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle "on-turn-end" abilities for Gen 8.
+ *
+ * Source: Showdown data/abilities.ts -- onResidual handlers
+ */
+function handleTurnEnd(ctx: AbilityContext): AbilityResult {
+  const abilityId = ctx.pokemon.ability;
+  const name = getName(ctx);
+
+  switch (abilityId) {
+    case "hunger-switch": {
+      // Source: Showdown data/abilities.ts -- Hunger Switch: Morpeko toggles form each turn
+      // Changes between Full Belly Mode and Hangry Mode
+      // Source: Bulbapedia "Hunger Switch" -- Morpeko (species 877) only
+      if (ctx.pokemon.pokemon.speciesId !== 877) return NO_EFFECT;
+      return {
+        activated: true,
+        effects: [{ effectType: "none", target: "self" }],
+        messages: [`${name} transformed!`],
+      };
+    }
+
+    default:
+      return NO_EFFECT;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gulp Missile sub-handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle Gulp Missile when Cramorant is hit while in Gulping or Gorging form.
+ *
+ * Cramorant species ID: 845
+ * Gulping Form (Arrokuda): 25% damage to attacker + Defense -1
+ * Gorging Form (Pikachu): 25% damage to attacker + paralysis
+ *
+ * Source: Showdown data/abilities.ts -- Gulp Missile onDamagingHit
+ * Source: Bulbapedia "Gulp Missile"
+ */
+function handleGulpMissileOnHit(ctx: AbilityContext): AbilityResult {
+  if (!ctx.opponent) return NO_EFFECT;
+  // Only for Cramorant (species 845)
+  if (ctx.pokemon.pokemon.speciesId !== 845) return NO_EFFECT;
+
+  const name = getName(ctx);
+  const otherMaxHp = ctx.opponent.pokemon.calculatedStats?.hp ?? ctx.opponent.pokemon.currentHp;
+  const chipDamage = Math.max(1, Math.floor(otherMaxHp / 4));
+
+  // Determine form from volatile status data
+  // The engine should set a "gulp-missile-gulping" or "gulp-missile-gorging" volatile
+  const isGulping = ctx.pokemon.volatileStatuses.has("gulp-missile-gulping" as never);
+  const isGorging = ctx.pokemon.volatileStatuses.has("gulp-missile-gorging" as never);
+
+  if (!isGulping && !isGorging) return NO_EFFECT;
+
+  const effects: AbilityEffect[] = [
+    { effectType: "chip-damage", target: "opponent", value: chipDamage },
+  ];
+
+  if (isGulping) {
+    // Arrokuda form: Defense -1
+    effects.push({ effectType: "stat-change", target: "opponent", stat: "defense", stages: -1 });
+  } else {
+    // Pikachu form: paralysis
+    if (!ctx.opponent.pokemon.status) {
+      effects.push({ effectType: "status-inflict", target: "opponent", status: "paralysis" });
+    }
+  }
+
+  return {
+    activated: true,
+    effects,
+    messages: [`${name} spat out its catch!`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Ice Face sub-handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle Ice Face when Eiscue is hit by a physical move while in Ice Face form.
+ *
+ * Eiscue species ID: 875
+ * Blocks the first physical hit and changes to Noice Face form.
+ * Reforms to Ice Face form in hail (handled separately).
+ *
+ * Source: Showdown data/abilities.ts -- Ice Face onDamage
+ * Source: Bulbapedia "Ice Face"
+ */
+function handleIceFaceOnHit(ctx: AbilityContext): AbilityResult {
+  // Only for Eiscue (species 875)
+  if (ctx.pokemon.pokemon.speciesId !== 875) return NO_EFFECT;
+
+  // Only blocks physical moves
+  if (!ctx.move || ctx.move.category !== "physical") return NO_EFFECT;
+
+  // Check if Ice Face is active (not broken)
+  if (ctx.pokemon.volatileStatuses.has("ice-face-broken" as never)) return NO_EFFECT;
+
+  const name = getName(ctx);
+  return {
+    activated: true,
+    effects: [
+      { effectType: "damage-reduction", target: "self" },
+      { effectType: "volatile-inflict", target: "self", volatile: "ice-face-broken" as never },
+    ],
+    messages: [`${name}'s Ice Face absorbed the damage!`],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Passive ability checks (exported for direct use)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if an ability is a Mold Breaker variant.
+ *
+ * Source: Showdown data/abilities.ts -- moldbreaker/teravolt/turboblaze
+ */
+export function isMoldBreakerAbility(abilityId: string): boolean {
+  return MOLD_BREAKER_ALIASES.has(abilityId);
+}
+
+/**
+ * Check if Magic Guard blocks indirect damage for a Pokemon.
+ *
+ * Source: Showdown data/abilities.ts -- magicguard: onDamage (not 'moveDamage')
+ * Source: Bulbapedia "Magic Guard" -- "Prevents all damage except from direct attacks."
+ */
+export function hasMagicGuard(abilityId: string): boolean {
+  return abilityId === "magic-guard";
+}
+
+/**
+ * Check if Overcoat blocks weather damage and powder moves.
+ *
+ * Source: Showdown data/abilities.ts -- overcoat: onImmunity('powder'), onImmunity('sandstorm'/'hail')
+ * Source: Bulbapedia "Overcoat" Gen 6+ -- blocks weather damage AND powder moves
+ */
+export function hasOvercoat(abilityId: string): boolean {
+  return abilityId === "overcoat";
+}
+
+/**
+ * Check if Soundproof blocks a move by its sound-based flag.
+ *
+ * Source: Showdown data/abilities.ts -- soundproof: move.flags['sound']
+ * Source: Bulbapedia "Soundproof" -- "Gives immunity to sound-based moves."
+ */
+export function isSoundproofBlocked(
+  abilityId: string,
+  moveFlags: Record<string, boolean>,
+): boolean {
+  if (abilityId !== "soundproof") return false;
+  return !!moveFlags.sound;
+}
+
+/**
+ * Check if Bulletproof blocks a move by its ball/bomb flag.
+ *
+ * Source: Showdown data/abilities.ts -- bulletproof: move.flags['bullet']
+ * Source: Bulbapedia "Bulletproof" -- "Protects from ball and bomb moves."
+ */
+export function isBulletproofBlocked(
+  abilityId: string,
+  moveFlags: Record<string, boolean>,
+): boolean {
+  if (abilityId !== "bulletproof") return false;
+  return !!moveFlags.bullet;
+}
+
+/**
+ * Check if Damp prevents Self-Destruct/Explosion/Aftermath/Mind Blown.
+ *
+ * Source: Showdown data/abilities.ts -- damp: prevents Explosion, Self-Destruct, Aftermath, Mind Blown
+ * Source: Bulbapedia "Damp" -- "Prevents the use of self-destructing moves."
+ */
+export function isDampBlocked(abilityId: string, moveId: string): boolean {
+  if (abilityId !== "damp") return false;
+  return moveId === "self-destruct" || moveId === "explosion" || moveId === "mind-blown";
+}
+
+/**
+ * Check if Shed Skin cures status at end of turn (33% chance).
+ *
+ * Source: Showdown data/abilities.ts -- shedskin: onResidualOrder, 1/3 chance
+ * Source: Bulbapedia "Shed Skin" -- "Has a 1/3 chance of curing status at end of turn."
+ */
+export function rollShedSkin(abilityId: string, hasStatus: boolean, rngRoll: number): boolean {
+  if (abilityId !== "shed-skin") return false;
+  if (!hasStatus) return false;
+  return rngRoll < 1 / 3;
+}
+
+/**
+ * Check if Harvest restores a consumed berry at end of turn.
+ * 50% chance normally, 100% in sun.
+ *
+ * Source: Showdown data/abilities.ts -- harvest: onResidualOrder
+ * Source: Bulbapedia "Harvest" -- "50% (100% in sun) chance to restore consumed berry"
+ */
+export function rollHarvest(
+  abilityId: string,
+  hasBerry: boolean,
+  weatherType: string | null,
+  rngRoll: number,
+): boolean {
+  if (abilityId !== "harvest") return false;
+  if (!hasBerry) return false;
+  if (weatherType === "sun") return true;
+  return rngRoll < 0.5;
+}
+
+/**
+ * Get the weather duration considering weather rock items.
+ *
+ * Source: Showdown data/items.ts -- damprock/heatrock/smoothrock/icyrock
+ * Source: Bulbapedia -- each rock extends weather to 8 turns
+ */
+function getWeatherTurns(heldItem: string | null, weatherType: string): number {
+  if (!heldItem) return BASE_WEATHER_TURNS;
+  const rock = WEATHER_ROCK_MAP[heldItem];
+  if (rock && rock.weather === weatherType) return rock.turns;
+  return BASE_WEATHER_TURNS;
+}
+
+/**
+ * Exported version for testing.
+ */
+export function getWeatherDuration(heldItem: string | null, weatherType: string): number {
+  return getWeatherTurns(heldItem, weatherType);
+}
+
+// ---------------------------------------------------------------------------
+// New Gen 8 ability checks (exported for direct use)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if Screen Cleaner should remove screens on switch-in.
+ *
+ * Source: Showdown data/abilities.ts -- Screen Cleaner onStart
+ * Source: specs/reference/gen8-ground-truth.md -- removes from BOTH sides
+ */
+export function isScreenCleaner(abilityId: string): boolean {
+  return abilityId === "screen-cleaner";
+}
+
+/**
+ * Get the list of screen types that Screen Cleaner removes.
+ *
+ * Source: Showdown data/abilities.ts -- Screen Cleaner onStart: Reflect, Light Screen, Aurora Veil
+ */
+export function getScreenCleanerTargets(): readonly ScreenType[] {
+  return SCREEN_CLEANER_SCREENS;
+}
+
+/**
+ * Check if Mirror Armor should reflect a stat drop.
+ * Only reflects stat drops caused by an opponent's move or ability.
+ *
+ * Source: Showdown data/abilities.ts -- Mirror Armor onTryBoost
+ * Source: Bulbapedia "Mirror Armor" -- "Bounces back only stat-lowering effects"
+ *
+ * @param abilityId - The ability ID of the defender
+ * @param stages - The signed stage delta (negative = drop)
+ * @param source - Whether the stat change is from self or opponent
+ * @returns true if the stat drop should be reflected back to the source
+ */
+export function shouldMirrorArmorReflect(
+  abilityId: string,
+  stages: number,
+  source: "self" | "opponent",
+): boolean {
+  if (abilityId !== "mirror-armor") return false;
+  // Only reflects drops (negative stages) from the opponent
+  if (stages >= 0) return false;
+  if (source !== "opponent") return false;
+  return true;
+}
+
+/**
+ * Check if Neutralizing Gas is active on the field.
+ * Returns true if any active Pokemon on either side has Neutralizing Gas.
+ *
+ * Source: Showdown data/abilities.ts -- Neutralizing Gas: while on field, suppresses abilities
+ * Source: Bulbapedia "Neutralizing Gas" -- affects all Pokemon on the field
+ *
+ * @param sideAbilities - Array of ability IDs of all active Pokemon on the field (both sides)
+ */
+export function isNeutralizingGasActive(sideAbilities: readonly string[]): boolean {
+  return sideAbilities.some((a) => a === "neutralizing-gas");
+}
+
+/**
+ * Check if an ability is immune to Neutralizing Gas suppression.
+ *
+ * Source: Showdown data/abilities.ts -- Neutralizing Gas exceptions
+ */
+export function isNeutralizingGasImmune(abilityId: string): boolean {
+  return NEUTRALIZING_GAS_IMMUNE_ABILITIES.has(abilityId);
+}
+
+/**
+ * Check if Pastel Veil blocks a poison/toxic status condition.
+ * Blocks for the holder AND allies.
+ *
+ * Source: Showdown data/abilities.ts -- Pastel Veil onAllySetStatus
+ * Source: Bulbapedia "Pastel Veil" -- prevents poisoning for holder and allies
+ *
+ * @param activeSideAbilities - Abilities of all active Pokemon on the same side
+ * @param status - The status being inflicted
+ * @returns true if Pastel Veil blocks the status
+ */
+export function isPastelVeilBlocking(
+  activeSideAbilities: readonly string[],
+  status: string,
+): boolean {
+  if (status !== "poison" && status !== "bad-poison") return false;
+  return activeSideAbilities.some((a) => a === "pastel-veil");
+}
+
+/**
+ * Check if Wandering Spirit should swap abilities on contact.
+ *
+ * Source: Showdown data/abilities.ts -- Wandering Spirit onDamagingHit
+ * Source: Bulbapedia "Wandering Spirit" -- swaps on contact
+ */
+export function shouldWanderingSpiritSwap(
+  abilityId: string,
+  trigger: AbilityTrigger,
+  contactMade: boolean,
+): boolean {
+  if (abilityId !== "wandering-spirit") return false;
+  if (trigger !== "on-contact") return false;
+  return contactMade;
+}
+
+/**
+ * Check if Perish Body should trigger on contact.
+ *
+ * Source: Showdown data/abilities.ts -- Perish Body onDamagingHit
+ * Source: Bulbapedia "Perish Body" -- triggers on contact
+ */
+export function shouldPerishBodyTrigger(
+  abilityId: string,
+  trigger: AbilityTrigger,
+  contactMade: boolean,
+): boolean {
+  if (abilityId !== "perish-body") return false;
+  if (trigger !== "on-contact") return false;
+  return contactMade;
+}
+
+/**
+ * Check if a Pokemon is Cramorant with Gulp Missile.
+ *
+ * Source: Showdown data/abilities.ts -- Gulp Missile: species check
+ */
+export function isCramorantWithGulpMissile(speciesId: number, abilityId: string): boolean {
+  return speciesId === 845 && abilityId === "gulp-missile";
+}
+
+/**
+ * Get the effect when Gulp Missile triggers (Cramorant spits projectile).
+ *
+ * @param form - "gulping" (Arrokuda) or "gorging" (Pikachu)
+ * @param attackerMaxHp - Attacker's max HP for damage calculation
+ * @returns Object with damage amount and secondary effect
+ *
+ * Source: Showdown data/abilities.ts -- Gulp Missile secondary effects
+ * Source: Bulbapedia "Gulp Missile" -- 1/4 max HP damage
+ */
+export function getGulpMissileResult(
+  form: "gulping" | "gorging",
+  attackerMaxHp: number,
+): { damage: number; secondaryEffect: "defense-drop" | "paralysis" } {
+  const damage = Math.max(1, Math.floor(attackerMaxHp / 4));
+  return {
+    damage,
+    secondaryEffect: form === "gulping" ? "defense-drop" : "paralysis",
+  };
+}
+
+/**
+ * Check if Eiscue's Ice Face is currently active (not broken).
+ *
+ * Source: Showdown data/abilities.ts -- Ice Face onDamage
+ * Source: Bulbapedia "Ice Face" -- active when in Ice Face form
+ *
+ * @param speciesId - Pokemon species ID (875 = Eiscue)
+ * @param abilityId - The ability ID
+ * @param hasIceFaceBroken - Whether the ice-face-broken volatile is set
+ */
+export function isIceFaceActive(
+  speciesId: number,
+  abilityId: string,
+  hasIceFaceBroken: boolean,
+): boolean {
+  if (speciesId !== 875) return false;
+  if (abilityId !== "ice-face") return false;
+  return !hasIceFaceBroken;
+}
+
+/**
+ * Check if Eiscue's Ice Face should reform in hail.
+ *
+ * Source: Showdown data/abilities.ts -- Ice Face: reforms in Hail
+ * Source: Bulbapedia "Ice Face" -- "If Hail is active, it will reform."
+ */
+export function shouldIceFaceReform(abilityId: string, weather: string | null): boolean {
+  if (abilityId !== "ice-face") return false;
+  return weather === "hail";
+}
+
+/**
+ * Check if Hunger Switch should toggle Morpeko's form.
+ *
+ * Source: Showdown data/abilities.ts -- Hunger Switch onResidual
+ * Source: Bulbapedia "Hunger Switch" -- Morpeko (species 877) toggles each turn
+ */
+export function shouldHungerSwitchToggle(abilityId: string, speciesId: number): boolean {
+  if (abilityId !== "hunger-switch") return false;
+  return speciesId === 877;
+}
+
+/**
+ * Check if Libero/Protean should change the user's type.
+ * In Gen 8, both activate on every move use (no once-per-switchin limit).
+ *
+ * Source: Showdown data/mods/gen8/ -- no once-per-switchin check for Protean/Libero
+ * Source: specs/reference/gen8-ground-truth.md -- Libero/Protean pre-nerf
+ */
+export function isLiberoActive(abilityId: string): boolean {
+  return abilityId === "libero" || abilityId === "protean";
+}

--- a/packages/gen8/src/Gen8Ruleset.ts
+++ b/packages/gen8/src/Gen8Ruleset.ts
@@ -1,4 +1,6 @@
 import type {
+  AbilityContext,
+  AbilityResult,
   ActivePokemon,
   BattleGimmick,
   BattleGimmickType,
@@ -11,6 +13,7 @@ import type {
 } from "@pokemon-lib-ts/battle";
 import { BaseRuleset } from "@pokemon-lib-ts/battle";
 import type {
+  AbilityTrigger,
   DataManager,
   EntryHazardType,
   PokemonType,
@@ -19,6 +22,7 @@ import type {
   TypeChart,
 } from "@pokemon-lib-ts/core";
 import { createGen8DataManager } from "./data/index.js";
+import { handleGen8SwitchAbility, shouldMirrorArmorReflect } from "./Gen8AbilitiesSwitch.js";
 import { GEN8_CRIT_MULTIPLIER, GEN8_CRIT_RATE_TABLE } from "./Gen8CritCalc.js";
 import { calculateGen8Damage } from "./Gen8DamageCalc.js";
 import { applyGen8TerrainEffects, checkGen8TerrainStatusImmunity } from "./Gen8Terrain.js";
@@ -210,6 +214,61 @@ export class Gen8Ruleset extends BaseRuleset {
     // Z-Moves removed in Gen 8
     // Dynamax: implemented in Wave 8
     return null;
+  }
+
+  // --- Abilities ---
+
+  /**
+   * Gen 8 ability dispatch.
+   *
+   * Routes triggers to the appropriate Gen 8 ability handler module.
+   * Covers all Gen 7 carryforward abilities plus new Gen 8 abilities:
+   *   - on-switch-in: Intimidate, weather, Screen Cleaner, Neutralizing Gas,
+   *     Intrepid Sword, Dauntless Shield, etc.
+   *   - on-switch-out: Regenerator, Natural Cure
+   *   - on-contact: Static, Flame Body, Wandering Spirit, Perish Body,
+   *     Gulp Missile, Ice Face, Mummy, etc.
+   *   - on-status-inflicted: Synchronize
+   *   - on-before-move: Libero, Protean
+   *   - on-stat-change: Mirror Armor
+   *   - on-turn-end: Hunger Switch
+   *
+   * Source: Showdown data/abilities.ts -- Gen 8 ability handlers
+   */
+  override applyAbility(trigger: AbilityTrigger, context: AbilityContext): AbilityResult {
+    const noActivation: AbilityResult = { activated: false, effects: [], messages: [] };
+
+    // Mirror Armor: special handling for stat-change trigger
+    if (trigger === "on-stat-change" && context.pokemon.ability === "mirror-armor") {
+      if (context.statChange) {
+        const { stat, stages, source } = context.statChange;
+        // HP cannot be stage-changed; Mirror Armor only reflects non-HP stats
+        if (stat !== "hp" && shouldMirrorArmorReflect("mirror-armor", stages, source)) {
+          const name =
+            context.pokemon.pokemon.nickname ?? String(context.pokemon.pokemon.speciesId);
+          return {
+            activated: true,
+            effects: [{ effectType: "stat-change", target: "opponent", stat, stages }],
+            messages: [`${name}'s Mirror Armor reflected the stat drop!`],
+          };
+        }
+      }
+      return noActivation;
+    }
+
+    // Route all other triggers through the switch handler
+    switch (trigger) {
+      case "on-switch-in":
+      case "on-switch-out":
+      case "on-contact":
+      case "on-status-inflicted":
+      case "on-before-move":
+      case "on-turn-end":
+        return handleGen8SwitchAbility(trigger, context);
+
+      default:
+        return noActivation;
+    }
   }
 
   // --- Experience ---

--- a/packages/gen8/src/index.ts
+++ b/packages/gen8/src/index.ts
@@ -2,6 +2,11 @@
 
 export { createGen8DataManager } from "./data/index.js";
 export {
+  handleGen8ContactAbility,
+  handleGen8FieldAbility,
+  handleGen8SwitchInAbility,
+} from "./Gen8Abilities.js";
+export {
   getAteAbilityOverride,
   getDragonsMawMultiplier,
   getFurCoatMultiplier,
@@ -38,6 +43,37 @@ export {
   isQuickDrawTrigger,
   isSteamEngineTrigger,
 } from "./Gen8AbilitiesStat.js";
+export {
+  getGulpMissileResult,
+  getScreenCleanerTargets,
+  getWeatherDuration,
+  handleGen8SwitchAbility,
+  hasMagicGuard,
+  hasOvercoat,
+  isBulletproofBlocked,
+  isCramorantWithGulpMissile,
+  isDampBlocked,
+  isIceFaceActive,
+  isLiberoActive,
+  isMoldBreakerAbility,
+  isNeutralizingGasActive,
+  isNeutralizingGasImmune,
+  isPastelVeilBlocking,
+  isScreenCleaner,
+  isSoundproofBlocked,
+  MOLD_BREAKER_ALIASES,
+  NEUTRALIZING_GAS_IMMUNE_ABILITIES,
+  rollHarvest,
+  rollShedSkin,
+  SCREEN_CLEANER_SCREENS,
+  shouldHungerSwitchToggle,
+  shouldIceFaceReform,
+  shouldMirrorArmorReflect,
+  shouldPerishBodyTrigger,
+  shouldWanderingSpiritSwap,
+  TRACE_UNCOPYABLE_ABILITIES,
+  UNSUPPRESSABLE_ABILITIES,
+} from "./Gen8AbilitiesSwitch.js";
 export { GEN8_CRIT_MULTIPLIER, GEN8_CRIT_RATE_TABLE } from "./Gen8CritCalc.js";
 export {
   calculateGen8Damage,

--- a/packages/gen8/tests/abilities-switch.test.ts
+++ b/packages/gen8/tests/abilities-switch.test.ts
@@ -1,0 +1,1089 @@
+import type { AbilityContext, BattleSide, BattleState } from "@pokemon-lib-ts/battle";
+import type { MoveData, PokemonInstance, PokemonType } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import {
+  getGulpMissileResult,
+  getScreenCleanerTargets,
+  getWeatherDuration,
+  handleGen8SwitchAbility,
+  hasMagicGuard,
+  hasOvercoat,
+  isBulletproofBlocked,
+  isCramorantWithGulpMissile,
+  isDampBlocked,
+  isIceFaceActive,
+  isLiberoActive,
+  isMoldBreakerAbility,
+  isNeutralizingGasActive,
+  isNeutralizingGasImmune,
+  isPastelVeilBlocking,
+  isScreenCleaner,
+  isSoundproofBlocked,
+  MOLD_BREAKER_ALIASES,
+  NEUTRALIZING_GAS_IMMUNE_ABILITIES,
+  rollHarvest,
+  rollShedSkin,
+  SCREEN_CLEANER_SCREENS,
+  shouldHungerSwitchToggle,
+  shouldIceFaceReform,
+  shouldMirrorArmorReflect,
+  shouldPerishBodyTrigger,
+  shouldWanderingSpiritSwap,
+  TRACE_UNCOPYABLE_ABILITIES,
+  UNSUPPRESSABLE_ABILITIES,
+} from "../src/Gen8AbilitiesSwitch";
+
+/**
+ * Gen 8 switch-in, switch-out, contact, and passive ability tests.
+ *
+ * Tests carry-forward abilities from Gen 7 and Gen 8 additions:
+ *   - Magic Guard, Overcoat, Soundproof, Bulletproof, Damp (passive checks)
+ *   - Shed Skin, Harvest (end-of-turn RNG checks)
+ *   - Screen Cleaner (new Gen 8): removes all screens from both sides
+ *   - Mirror Armor (new Gen 8): reflects stat drops back to attacker
+ *   - Neutralizing Gas (new Gen 8): suppresses all abilities on the field
+ *   - Pastel Veil (new Gen 8): prevents poison for holder and allies
+ *   - Wandering Spirit (new Gen 8): swaps abilities on contact
+ *   - Perish Body (new Gen 8): both get Perish Song on contact
+ *   - Libero/Protean (Gen 8 behavior): type change on every move use
+ *   - Ice Face (new Gen 8): blocks first physical hit, reforms in hail
+ *   - Intrepid Sword / Dauntless Shield (Gen 8): every switch-in boost
+ *
+ * Source: Showdown data/abilities.ts
+ * Source: Showdown data/mods/gen8/abilities.ts
+ * Source: Bulbapedia -- individual ability articles
+ */
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makePokemonInstance(overrides: {
+  speciesId?: number;
+  nickname?: string | null;
+  ability?: string;
+  heldItem?: string | null;
+  currentHp?: number;
+  maxHp?: number;
+  status?: string | null;
+  gender?: "male" | "female" | "genderless";
+}): PokemonInstance {
+  const maxHp = overrides.maxHp ?? 200;
+  return {
+    uid: `test-${Math.random()}`,
+    speciesId: overrides.speciesId ?? 1,
+    nickname: overrides.nickname ?? null,
+    level: 50,
+    experience: 0,
+    nature: "hardy",
+    ivs: { hp: 31, attack: 31, defense: 31, spAttack: 31, spDefense: 31, speed: 31 },
+    evs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+    currentHp: overrides.currentHp ?? maxHp,
+    moves: [],
+    ability: overrides.ability ?? "",
+    abilitySlot: "normal1" as const,
+    heldItem: overrides.heldItem ?? null,
+    status: (overrides.status as PokemonInstance["status"]) ?? null,
+    friendship: 0,
+    gender: overrides.gender ?? "male",
+    isShiny: false,
+    metLocation: "",
+    metLevel: 1,
+    originalTrainer: "",
+    originalTrainerId: 0,
+    pokeball: "pokeball",
+    calculatedStats: {
+      hp: maxHp,
+      attack: 100,
+      defense: 100,
+      spAttack: 100,
+      spDefense: 100,
+      speed: 100,
+    },
+  } as PokemonInstance;
+}
+
+function makeActivePokemon(overrides: {
+  ability?: string;
+  types?: PokemonType[];
+  nickname?: string | null;
+  currentHp?: number;
+  maxHp?: number;
+  speciesId?: number;
+  status?: string | null;
+  heldItem?: string | null;
+  gender?: "male" | "female" | "genderless";
+  substituteHp?: number;
+  volatiles?: Map<string, { turnsLeft: number; data?: Record<string, unknown> }>;
+}) {
+  return {
+    pokemon: makePokemonInstance({
+      ability: overrides.ability,
+      nickname: overrides.nickname,
+      currentHp: overrides.currentHp,
+      maxHp: overrides.maxHp,
+      speciesId: overrides.speciesId,
+      status: overrides.status,
+      heldItem: overrides.heldItem,
+      gender: overrides.gender,
+    }),
+    teamSlot: 0,
+    statStages: {
+      attack: 0,
+      defense: 0,
+      spAttack: 0,
+      spDefense: 0,
+      speed: 0,
+      accuracy: 0,
+      evasion: 0,
+    },
+    volatileStatuses: overrides.volatiles ?? new Map(),
+    types: overrides.types ?? ["normal"],
+    ability: overrides.ability ?? "",
+    suppressedAbility: null,
+    lastMoveUsed: null,
+    lastDamageTaken: 0,
+    lastDamageType: null,
+    lastDamageCategory: null,
+    turnsOnField: 0,
+    movedThisTurn: false,
+    consecutiveProtects: 0,
+    substituteHp: overrides.substituteHp ?? 0,
+    itemKnockedOff: false,
+    transformed: false,
+    transformedSpecies: null,
+    isMega: false,
+    isDynamaxed: false,
+    dynamaxTurnsLeft: 0,
+    isTerastallized: false,
+    teraType: null,
+    forcedMove: null,
+  };
+}
+
+function makeSide(index: 0 | 1): BattleSide {
+  return {
+    index,
+    trainer: null,
+    team: [],
+    active: [],
+    hazards: [],
+    screens: [],
+    tailwind: { active: false, turnsLeft: 0 },
+    luckyChant: { active: false, turnsLeft: 0 },
+    wish: null,
+    futureAttack: null,
+    faintCount: 0,
+    gimmickUsed: false,
+  };
+}
+
+function makeBattleState(): BattleState {
+  return {
+    phase: "turn-end",
+    generation: 8,
+    format: "singles",
+    turnNumber: 1,
+    sides: [makeSide(0), makeSide(1)],
+    weather: null,
+    terrain: null,
+    trickRoom: { active: false, turnsLeft: 0 },
+    magicRoom: { active: false, turnsLeft: 0 },
+    wonderRoom: { active: false, turnsLeft: 0 },
+    gravity: { active: false, turnsLeft: 0 },
+    turnHistory: [],
+    rng: {
+      next: () => 0,
+      int: () => 1,
+      chance: () => false,
+      pick: <T>(arr: readonly T[]) => arr[0] as T,
+      shuffle: <T>(arr: T[]) => arr,
+      getState: () => 0,
+      setState: () => {},
+    },
+    ended: false,
+    winner: null,
+  } as unknown as BattleState;
+}
+
+function makeMove(
+  type: PokemonType,
+  opts: {
+    id?: string;
+    category?: "physical" | "special" | "status";
+    flags?: Record<string, boolean>;
+  } = {},
+): MoveData {
+  return {
+    id: opts.id ?? "test-move",
+    displayName: "Test Move",
+    type,
+    category: opts.category ?? "physical",
+    power: opts.category === "status" ? 0 : 80,
+    accuracy: 100,
+    pp: 10,
+    maxPp: 10,
+    priority: 0,
+    target: "single",
+    generation: 8,
+    flags: opts.flags ?? { contact: true },
+    effectChance: null,
+    secondaryEffects: [],
+  } as unknown as MoveData;
+}
+
+function makeContext(opts: {
+  ability: string;
+  trigger: string;
+  types?: PokemonType[];
+  opponent?: ReturnType<typeof makeActivePokemon>;
+  move?: MoveData;
+  nickname?: string;
+  heldItem?: string | null;
+  speciesId?: number;
+  status?: string | null;
+  currentHp?: number;
+  maxHp?: number;
+  rng?: { next: () => number };
+  substituteHp?: number;
+  volatiles?: Map<string, { turnsLeft: number; data?: Record<string, unknown> }>;
+  gender?: "male" | "female" | "genderless";
+  statChange?: { stat: string; stages: number; source: "self" | "opponent" };
+}): AbilityContext {
+  const state = makeBattleState();
+  if (opts.rng) {
+    (state as any).rng = { ...state.rng, ...opts.rng };
+  }
+  const pokemon = makeActivePokemon({
+    ability: opts.ability,
+    types: opts.types,
+    nickname: opts.nickname,
+    heldItem: opts.heldItem,
+    speciesId: opts.speciesId,
+    status: opts.status,
+    currentHp: opts.currentHp,
+    maxHp: opts.maxHp,
+    substituteHp: opts.substituteHp,
+    volatiles: opts.volatiles,
+    gender: opts.gender,
+  });
+
+  return {
+    pokemon,
+    opponent: opts.opponent,
+    state,
+    rng: (opts.rng ?? state.rng) as any,
+    trigger: opts.trigger as any,
+    move: opts.move,
+    statChange: opts.statChange as any,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Carry-forward passive ability checks
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Passive Ability Checks (carry-forward)", () => {
+  describe("hasMagicGuard", () => {
+    it("given magic-guard, when checking, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- magicguard blocks indirect damage
+      expect(hasMagicGuard("magic-guard")).toBe(true);
+    });
+
+    it("given other ability, when checking, then returns false", () => {
+      // Source: Showdown data/abilities.ts -- only magic-guard triggers this
+      expect(hasMagicGuard("levitate")).toBe(false);
+    });
+  });
+
+  describe("hasOvercoat", () => {
+    it("given overcoat, when checking, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- overcoat blocks weather + powder
+      expect(hasOvercoat("overcoat")).toBe(true);
+    });
+
+    it("given other ability, when checking, then returns false", () => {
+      expect(hasOvercoat("sturdy")).toBe(false);
+    });
+  });
+
+  describe("isBulletproofBlocked", () => {
+    it("given bulletproof ability and bullet flag move, when checking, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- bulletproof: move.flags['bullet']
+      expect(isBulletproofBlocked("bulletproof", { bullet: true })).toBe(true);
+    });
+
+    it("given bulletproof ability and non-bullet move, when checking, then returns false", () => {
+      expect(isBulletproofBlocked("bulletproof", { contact: true })).toBe(false);
+    });
+
+    it("given non-bulletproof ability and bullet flag move, when checking, then returns false", () => {
+      expect(isBulletproofBlocked("sturdy", { bullet: true })).toBe(false);
+    });
+  });
+
+  describe("isDampBlocked", () => {
+    it("given damp ability and explosion, when checking, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- damp prevents Explosion
+      expect(isDampBlocked("damp", "explosion")).toBe(true);
+    });
+
+    it("given damp ability and self-destruct, when checking, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- damp prevents Self-Destruct
+      expect(isDampBlocked("damp", "self-destruct")).toBe(true);
+    });
+
+    it("given damp ability and mind-blown, when checking, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- damp prevents Mind Blown (Gen 7+)
+      expect(isDampBlocked("damp", "mind-blown")).toBe(true);
+    });
+
+    it("given damp ability and normal move, when checking, then returns false", () => {
+      expect(isDampBlocked("damp", "tackle")).toBe(false);
+    });
+
+    it("given non-damp ability and explosion, when checking, then returns false", () => {
+      expect(isDampBlocked("sturdy", "explosion")).toBe(false);
+    });
+  });
+
+  describe("isSoundproofBlocked", () => {
+    it("given soundproof ability and sound flag move, when checking, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- soundproof: move.flags['sound']
+      expect(isSoundproofBlocked("soundproof", { sound: true })).toBe(true);
+    });
+
+    it("given soundproof ability and non-sound move, when checking, then returns false", () => {
+      expect(isSoundproofBlocked("soundproof", { contact: true })).toBe(false);
+    });
+
+    it("given non-soundproof ability and sound flag move, when checking, then returns false", () => {
+      expect(isSoundproofBlocked("sturdy", { sound: true })).toBe(false);
+    });
+  });
+
+  describe("isMoldBreakerAbility", () => {
+    it("given mold-breaker, when checking, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- moldbreaker
+      expect(isMoldBreakerAbility("mold-breaker")).toBe(true);
+    });
+
+    it("given teravolt, when checking, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- teravolt is mold breaker variant
+      expect(isMoldBreakerAbility("teravolt")).toBe(true);
+    });
+
+    it("given turboblaze, when checking, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- turboblaze is mold breaker variant
+      expect(isMoldBreakerAbility("turboblaze")).toBe(true);
+    });
+
+    it("given other ability, when checking, then returns false", () => {
+      expect(isMoldBreakerAbility("intimidate")).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: RNG-based passive abilities
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 RNG-based Passive Abilities (carry-forward)", () => {
+  describe("rollShedSkin", () => {
+    it("given shed-skin with status and low RNG roll, when rolling, then returns true (cures)", () => {
+      // Source: Showdown data/abilities.ts -- Shed Skin: 1/3 chance to cure
+      // 1/3 = 0.3333... so roll of 0.3 is below threshold
+      expect(rollShedSkin("shed-skin", true, 0.3)).toBe(true);
+    });
+
+    it("given shed-skin with status and high RNG roll, when rolling, then returns false (no cure)", () => {
+      // Source: Showdown data/abilities.ts -- Shed Skin: ~67% chance of failure
+      // Roll of 0.5 > 1/3 threshold
+      expect(rollShedSkin("shed-skin", true, 0.5)).toBe(false);
+    });
+
+    it("given shed-skin without status, when rolling, then returns false", () => {
+      // Source: Showdown data/abilities.ts -- Shed Skin only cures if status exists
+      expect(rollShedSkin("shed-skin", false, 0.1)).toBe(false);
+    });
+
+    it("given non-shed-skin ability with status, when rolling, then returns false", () => {
+      expect(rollShedSkin("sturdy", true, 0.1)).toBe(false);
+    });
+  });
+
+  describe("rollHarvest", () => {
+    it("given harvest with consumed berry and low RNG roll, when rolling, then returns true", () => {
+      // Source: Showdown data/abilities.ts -- Harvest: 50% normally
+      // Roll of 0.3 < 0.5 threshold
+      expect(rollHarvest("harvest", true, null, 0.3)).toBe(true);
+    });
+
+    it("given harvest with consumed berry and high RNG roll, when rolling, then returns false", () => {
+      // Source: Showdown data/abilities.ts -- Harvest: 50% normally
+      // Roll of 0.7 > 0.5 threshold
+      expect(rollHarvest("harvest", true, null, 0.7)).toBe(false);
+    });
+
+    it("given harvest with consumed berry in sun, when rolling, then always returns true", () => {
+      // Source: Showdown data/abilities.ts -- Harvest: 100% in sun
+      // Even a high RNG roll returns true in sun
+      expect(rollHarvest("harvest", true, "sun", 0.99)).toBe(true);
+    });
+
+    it("given harvest without consumed berry, when rolling, then returns false", () => {
+      // Source: Showdown data/abilities.ts -- Harvest: needs consumed berry
+      expect(rollHarvest("harvest", false, null, 0.1)).toBe(false);
+    });
+  });
+
+  describe("getWeatherDuration", () => {
+    it("given no held item, when getting duration, then returns 5 turns", () => {
+      // Source: Showdown data/abilities.ts -- base weather is 5 turns
+      expect(getWeatherDuration(null, "rain")).toBe(5);
+    });
+
+    it("given damp-rock for rain, when getting duration, then returns 8 turns", () => {
+      // Source: Showdown data/items.ts -- Damp Rock extends rain to 8 turns
+      expect(getWeatherDuration("damp-rock", "rain")).toBe(8);
+    });
+
+    it("given heat-rock for sun, when getting duration, then returns 8 turns", () => {
+      // Source: Showdown data/items.ts -- Heat Rock extends sun to 8 turns
+      expect(getWeatherDuration("heat-rock", "sun")).toBe(8);
+    });
+
+    it("given damp-rock for sun (wrong weather), when getting duration, then returns 5 turns", () => {
+      // Source: Showdown data/items.ts -- rock must match weather type
+      expect(getWeatherDuration("damp-rock", "sun")).toBe(5);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 New Abilities -- Screen Cleaner
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Screen Cleaner", () => {
+  it("given screen-cleaner ability, when switching in, then returns activated with field effect", () => {
+    // Source: Showdown data/abilities.ts -- Screen Cleaner onStart: removes screens both sides
+    // Source: specs/reference/gen8-ground-truth.md -- Screen Cleaner: both sides + Aurora Veil
+    const ctx = makeContext({
+      ability: "screen-cleaner",
+      trigger: "on-switch-in",
+      nickname: "MrRime",
+    });
+
+    const result = handleGen8SwitchAbility("on-switch-in", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.messages[0]).toContain("Screen Cleaner");
+  });
+
+  it("given isScreenCleaner, when checking screen-cleaner ability, then returns true", () => {
+    // Source: Showdown data/abilities.ts -- Screen Cleaner ability ID
+    expect(isScreenCleaner("screen-cleaner")).toBe(true);
+  });
+
+  it("given isScreenCleaner, when checking other ability, then returns false", () => {
+    expect(isScreenCleaner("intimidate")).toBe(false);
+  });
+
+  it("given getScreenCleanerTargets, when called, then returns reflect, light-screen, and aurora-veil", () => {
+    // Source: Showdown data/abilities.ts -- Screen Cleaner removes all three screen types
+    const targets = getScreenCleanerTargets();
+    expect(targets).toContain("reflect");
+    expect(targets).toContain("light-screen");
+    expect(targets).toContain("aurora-veil");
+    expect(targets).toHaveLength(3);
+  });
+
+  it("given SCREEN_CLEANER_SCREENS constant, then includes aurora-veil (Gen 8 spec fix)", () => {
+    // Source: specs/battle/09-gen8.md -- Screen Cleaner was corrected to include Aurora Veil
+    // The v2.0 spec fix confirmed Aurora Veil is included
+    expect(SCREEN_CLEANER_SCREENS).toContain("aurora-veil");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 New Abilities -- Mirror Armor
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Mirror Armor", () => {
+  it("given mirror-armor and opponent stat drop, when checking, then reflects stat drop", () => {
+    // Source: Showdown data/abilities.ts -- Mirror Armor onTryBoost: reflects opponent-caused drops
+    // Source: Bulbapedia "Mirror Armor" -- reflects stat-lowering effects
+    expect(shouldMirrorArmorReflect("mirror-armor", -1, "opponent")).toBe(true);
+  });
+
+  it("given mirror-armor and opponent stat drop of -2, when checking, then reflects", () => {
+    // Source: Showdown data/abilities.ts -- Mirror Armor reflects any magnitude of drop
+    expect(shouldMirrorArmorReflect("mirror-armor", -2, "opponent")).toBe(true);
+  });
+
+  it("given mirror-armor and self-inflicted stat drop, when checking, then does not reflect", () => {
+    // Source: Showdown data/abilities.ts -- Mirror Armor only reflects opponent-caused drops
+    // Self-inflicted drops (e.g. Close Combat, Superpower) are not reflected
+    expect(shouldMirrorArmorReflect("mirror-armor", -1, "self")).toBe(false);
+  });
+
+  it("given mirror-armor and stat boost (positive stages), when checking, then does not reflect", () => {
+    // Source: Showdown data/abilities.ts -- Mirror Armor only reflects negative stat changes
+    expect(shouldMirrorArmorReflect("mirror-armor", 1, "opponent")).toBe(false);
+  });
+
+  it("given non-mirror-armor ability and opponent stat drop, when checking, then does not reflect", () => {
+    expect(shouldMirrorArmorReflect("intimidate", -1, "opponent")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 New Abilities -- Neutralizing Gas
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Neutralizing Gas", () => {
+  it("given neutralizing-gas on field, when checking isNeutralizingGasActive, then returns true", () => {
+    // Source: Showdown data/abilities.ts -- Neutralizing Gas suppresses all abilities on field
+    // Source: Bulbapedia "Neutralizing Gas" -- nullifies all abilities while on field
+    expect(isNeutralizingGasActive(["intimidate", "neutralizing-gas", "levitate"])).toBe(true);
+  });
+
+  it("given no neutralizing-gas on field, when checking isNeutralizingGasActive, then returns false", () => {
+    // Source: Showdown data/abilities.ts -- only active when Neutralizing Gas Pokemon is on field
+    expect(isNeutralizingGasActive(["intimidate", "levitate"])).toBe(false);
+  });
+
+  it("given neutralizing-gas ability, when checking immunity, then is immune to its own suppression", () => {
+    // Source: Showdown data/abilities.ts -- Neutralizing Gas cannot suppress itself
+    expect(isNeutralizingGasImmune("neutralizing-gas")).toBe(true);
+  });
+
+  it("given comatose ability, when checking immunity, then is immune to Neutralizing Gas", () => {
+    // Source: Showdown data/abilities.ts -- Comatose is in the unsuppressable set
+    expect(isNeutralizingGasImmune("comatose")).toBe(true);
+  });
+
+  it("given normal ability like intimidate, when checking immunity, then is NOT immune", () => {
+    // Source: Showdown data/abilities.ts -- most abilities are suppressed
+    expect(isNeutralizingGasImmune("intimidate")).toBe(false);
+  });
+
+  it("given neutralizing-gas user, when switching in, then announces Neutralizing Gas", () => {
+    // Source: Showdown data/abilities.ts -- Neutralizing Gas onStart message
+    const ctx = makeContext({
+      ability: "neutralizing-gas",
+      trigger: "on-switch-in",
+      nickname: "Weezing",
+    });
+
+    const result = handleGen8SwitchAbility("on-switch-in", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.messages[0]).toContain("Neutralizing Gas");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 New Abilities -- Pastel Veil
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Pastel Veil", () => {
+  it("given pastel-veil on side and poison status, when checking, then blocks poison", () => {
+    // Source: Showdown data/abilities.ts -- Pastel Veil onAllySetStatus: blocks poison
+    // Source: Bulbapedia "Pastel Veil" -- prevents poisoning for holder and allies
+    expect(isPastelVeilBlocking(["pastel-veil", "run-away"], "poison")).toBe(true);
+  });
+
+  it("given pastel-veil on side and bad-poison status, when checking, then blocks toxic", () => {
+    // Source: Showdown data/abilities.ts -- Pastel Veil blocks Toxic poison too
+    expect(isPastelVeilBlocking(["pastel-veil"], "bad-poison")).toBe(true);
+  });
+
+  it("given pastel-veil on ally (not self), when checking poison, then still blocks", () => {
+    // Source: Showdown data/abilities.ts -- Pastel Veil onAllySetStatus (covers allies too)
+    // Source: Bulbapedia "Pastel Veil" -- "prevents the Pokemon and its allies from being poisoned"
+    expect(isPastelVeilBlocking(["run-away", "pastel-veil"], "poison")).toBe(true);
+  });
+
+  it("given pastel-veil on side and burn status, when checking, then does NOT block burn", () => {
+    // Source: Showdown data/abilities.ts -- Pastel Veil only blocks poison/toxic
+    expect(isPastelVeilBlocking(["pastel-veil"], "burn")).toBe(false);
+  });
+
+  it("given pastel-veil on side and paralysis status, when checking, then does NOT block paralysis", () => {
+    // Source: Showdown data/abilities.ts -- Pastel Veil only blocks poison/toxic
+    expect(isPastelVeilBlocking(["pastel-veil"], "paralysis")).toBe(false);
+  });
+
+  it("given no pastel-veil on side and poison status, when checking, then does not block", () => {
+    expect(isPastelVeilBlocking(["intimidate", "levitate"], "poison")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 New Abilities -- Wandering Spirit
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Wandering Spirit", () => {
+  it("given wandering-spirit and on-contact trigger with contact, when checking, then returns true", () => {
+    // Source: Showdown data/abilities.ts -- Wandering Spirit onDamagingHit: swaps on contact
+    // Source: Bulbapedia "Wandering Spirit" -- swaps abilities on contact
+    expect(shouldWanderingSpiritSwap("wandering-spirit", "on-contact", true)).toBe(true);
+  });
+
+  it("given wandering-spirit and on-contact trigger without contact, when checking, then returns false", () => {
+    // Source: Showdown data/abilities.ts -- requires contact flag
+    expect(shouldWanderingSpiritSwap("wandering-spirit", "on-contact", false)).toBe(false);
+  });
+
+  it("given wandering-spirit and non-contact trigger, when checking, then returns false", () => {
+    expect(shouldWanderingSpiritSwap("wandering-spirit", "on-switch-in", true)).toBe(false);
+  });
+
+  it("given non-wandering-spirit ability, when checking, then returns false", () => {
+    expect(shouldWanderingSpiritSwap("rough-skin", "on-contact", true)).toBe(false);
+  });
+
+  it("given wandering-spirit holder hit by contact, when triggered, then swaps both abilities", () => {
+    // Source: Showdown data/abilities.ts -- Wandering Spirit: swap abilities with attacker
+    const attacker = makeActivePokemon({ ability: "intimidate" });
+    const ctx = makeContext({
+      ability: "wandering-spirit",
+      trigger: "on-contact",
+      nickname: "Runerigus",
+      opponent: attacker,
+    });
+
+    const result = handleGen8SwitchAbility("on-contact", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toHaveLength(2);
+    expect(result.effects[0]).toEqual({
+      effectType: "ability-change",
+      target: "self",
+      newAbility: "intimidate",
+    });
+    expect(result.effects[1]).toEqual({
+      effectType: "ability-change",
+      target: "opponent",
+      newAbility: "wandering-spirit",
+    });
+  });
+
+  it("given wandering-spirit holder hit by unsuppressable ability attacker, when triggered, then does not swap", () => {
+    // Source: Showdown data/abilities.ts -- can't swap unsuppressable abilities
+    const attacker = makeActivePokemon({ ability: "multitype" });
+    const ctx = makeContext({
+      ability: "wandering-spirit",
+      trigger: "on-contact",
+      opponent: attacker,
+    });
+
+    const result = handleGen8SwitchAbility("on-contact", ctx);
+    expect(result.activated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 New Abilities -- Perish Body
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Perish Body", () => {
+  it("given perish-body and on-contact trigger with contact, when checking, then returns true", () => {
+    // Source: Showdown data/abilities.ts -- Perish Body onDamagingHit: triggers on contact
+    // Source: Bulbapedia "Perish Body" -- both get Perish Song on contact
+    expect(shouldPerishBodyTrigger("perish-body", "on-contact", true)).toBe(true);
+  });
+
+  it("given perish-body and on-contact trigger without contact, when checking, then returns false", () => {
+    expect(shouldPerishBodyTrigger("perish-body", "on-contact", false)).toBe(false);
+  });
+
+  it("given non-perish-body ability, when checking, then returns false", () => {
+    expect(shouldPerishBodyTrigger("rough-skin", "on-contact", true)).toBe(false);
+  });
+
+  it("given perish-body holder hit by contact move, when triggered, then both get perish-song volatile", () => {
+    // Source: Showdown data/abilities.ts -- Perish Body: both Pokemon get Perish Song
+    const attacker = makeActivePokemon({ ability: "intimidate" });
+    const ctx = makeContext({
+      ability: "perish-body",
+      trigger: "on-contact",
+      nickname: "Cursola",
+      opponent: attacker,
+    });
+
+    const result = handleGen8SwitchAbility("on-contact", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toHaveLength(2);
+    expect(result.effects[0]).toEqual({
+      effectType: "volatile-inflict",
+      target: "self",
+      volatile: "perish-song",
+    });
+    expect(result.effects[1]).toEqual({
+      effectType: "volatile-inflict",
+      target: "opponent",
+      volatile: "perish-song",
+    });
+    expect(result.messages).toContain("Both Pokemon will faint in 3 turns!");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 Libero / Protean
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Libero / Protean", () => {
+  it("given libero ability, when isLiberoActive, then returns true", () => {
+    // Source: Showdown data/abilities.ts -- Libero same as Protean
+    expect(isLiberoActive("libero")).toBe(true);
+  });
+
+  it("given protean ability, when isLiberoActive, then returns true", () => {
+    // Source: Showdown data/abilities.ts -- Protean type change before attacking
+    expect(isLiberoActive("protean")).toBe(true);
+  });
+
+  it("given other ability, when isLiberoActive, then returns false", () => {
+    expect(isLiberoActive("intimidate")).toBe(false);
+  });
+
+  it("given libero user using fire move, when on-before-move triggers, then changes type to fire", () => {
+    // Source: Showdown data/mods/gen8/ -- Libero: no once-per-switchin limit in Gen 8
+    // Source: specs/reference/gen8-ground-truth.md -- activates on every move use
+    const ctx = makeContext({
+      ability: "libero",
+      trigger: "on-before-move",
+      types: ["normal"],
+      nickname: "Cinderace",
+      move: makeMove("fire", { id: "pyro-ball" }),
+    });
+
+    const result = handleGen8SwitchAbility("on-before-move", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toHaveLength(1);
+    expect(result.effects[0]).toEqual({
+      effectType: "type-change",
+      target: "self",
+      types: ["fire"],
+    });
+    expect(result.messages[0]).toContain("Libero");
+    expect(result.messages[0]).toContain("fire");
+  });
+
+  it("given protean user using water move, when on-before-move triggers, then changes type to water", () => {
+    // Source: Showdown data/abilities.ts -- Protean: same behavior as Libero
+    const ctx = makeContext({
+      ability: "protean",
+      trigger: "on-before-move",
+      types: ["water"],
+      nickname: "Greninja",
+      move: makeMove("water", { id: "water-shuriken" }),
+    });
+
+    // Already water type -- should not activate
+    const result = handleGen8SwitchAbility("on-before-move", ctx);
+    expect(result.activated).toBe(false);
+  });
+
+  it("given libero user already matching type, when on-before-move triggers, then does NOT activate", () => {
+    // Source: Showdown data/abilities.ts -- Libero/Protean doesn't activate if already that monotype
+    const ctx = makeContext({
+      ability: "libero",
+      trigger: "on-before-move",
+      types: ["fire"],
+      move: makeMove("fire", { id: "pyro-ball" }),
+    });
+
+    const result = handleGen8SwitchAbility("on-before-move", ctx);
+    expect(result.activated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 Ice Face
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Ice Face", () => {
+  it("given Eiscue with ice-face, when isIceFaceActive with no broken volatile, then returns true", () => {
+    // Source: Showdown data/abilities.ts -- Ice Face: active in Ice Face form
+    // Eiscue species ID: 875
+    expect(isIceFaceActive(875, "ice-face", false)).toBe(true);
+  });
+
+  it("given Eiscue with ice-face, when isIceFaceActive with broken volatile, then returns false", () => {
+    // Source: Showdown data/abilities.ts -- Ice Face: once broken, stays Noice Face
+    expect(isIceFaceActive(875, "ice-face", true)).toBe(false);
+  });
+
+  it("given non-Eiscue with ice-face, when isIceFaceActive, then returns false", () => {
+    // Source: Showdown data/abilities.ts -- only works for Eiscue (species 875)
+    expect(isIceFaceActive(25, "ice-face", false)).toBe(false);
+  });
+
+  it("given Eiscue with different ability, when isIceFaceActive, then returns false", () => {
+    expect(isIceFaceActive(875, "sturdy", false)).toBe(false);
+  });
+
+  it("given ice-face in hail, when shouldIceFaceReform, then returns true", () => {
+    // Source: Showdown data/abilities.ts -- Ice Face reforms in Hail
+    // Source: Bulbapedia "Ice Face" -- "If Hail is active, it will reform."
+    expect(shouldIceFaceReform("ice-face", "hail")).toBe(true);
+  });
+
+  it("given ice-face in sun, when shouldIceFaceReform, then returns false", () => {
+    // Source: Showdown data/abilities.ts -- Ice Face only reforms in hail
+    expect(shouldIceFaceReform("ice-face", "sun")).toBe(false);
+  });
+
+  it("given ice-face with no weather, when shouldIceFaceReform, then returns false", () => {
+    expect(shouldIceFaceReform("ice-face", null)).toBe(false);
+  });
+
+  it("given Eiscue hit by physical move with Ice Face active, when on-contact triggers, then blocks damage", () => {
+    // Source: Showdown data/abilities.ts -- Ice Face onDamage: blocks physical hit
+    // Source: Bulbapedia "Ice Face" -- blocks first physical hit
+    const attacker = makeActivePokemon({ ability: "intimidate" });
+    const ctx = makeContext({
+      ability: "ice-face",
+      trigger: "on-contact",
+      speciesId: 875,
+      nickname: "Eiscue",
+      opponent: attacker,
+      move: makeMove("normal", { id: "tackle", category: "physical" }),
+    });
+
+    const result = handleGen8SwitchAbility("on-contact", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects.some((e) => e.effectType === "damage-reduction")).toBe(true);
+    expect(result.messages[0]).toContain("Ice Face");
+  });
+
+  it("given Eiscue hit by special move with Ice Face active, when on-contact triggers, then does NOT block", () => {
+    // Source: Showdown data/abilities.ts -- Ice Face only blocks physical moves
+    const attacker = makeActivePokemon({ ability: "intimidate" });
+    const ctx = makeContext({
+      ability: "ice-face",
+      trigger: "on-contact",
+      speciesId: 875,
+      nickname: "Eiscue",
+      opponent: attacker,
+      move: makeMove("fire", { id: "flamethrower", category: "special" }),
+    });
+
+    const result = handleGen8SwitchAbility("on-contact", ctx);
+    expect(result.activated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 Gulp Missile
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Gulp Missile", () => {
+  it("given Cramorant with gulp-missile, when isCramorantWithGulpMissile, then returns true", () => {
+    // Source: Showdown data/abilities.ts -- Gulp Missile: species 845 = Cramorant
+    expect(isCramorantWithGulpMissile(845, "gulp-missile")).toBe(true);
+  });
+
+  it("given non-Cramorant with gulp-missile, when isCramorantWithGulpMissile, then returns false", () => {
+    expect(isCramorantWithGulpMissile(25, "gulp-missile")).toBe(false);
+  });
+
+  it("given Cramorant without gulp-missile, when isCramorantWithGulpMissile, then returns false", () => {
+    expect(isCramorantWithGulpMissile(845, "keen-eye")).toBe(false);
+  });
+
+  it("given gulping form (Arrokuda), when getGulpMissileResult, then returns 1/4 HP damage and defense-drop", () => {
+    // Source: Showdown data/abilities.ts -- Gulp Missile gulping: 1/4 HP + -1 Defense
+    // Source: Bulbapedia "Gulp Missile" -- Arrokuda: damage + Defense drop
+    // With 200 max HP: floor(200/4) = 50 damage
+    const result = getGulpMissileResult("gulping", 200);
+    expect(result.damage).toBe(50);
+    expect(result.secondaryEffect).toBe("defense-drop");
+  });
+
+  it("given gorging form (Pikachu), when getGulpMissileResult, then returns 1/4 HP damage and paralysis", () => {
+    // Source: Showdown data/abilities.ts -- Gulp Missile gorging: 1/4 HP + paralysis
+    // Source: Bulbapedia "Gulp Missile" -- Pikachu: damage + paralysis
+    // With 160 max HP: floor(160/4) = 40 damage
+    const result = getGulpMissileResult("gorging", 160);
+    expect(result.damage).toBe(40);
+    expect(result.secondaryEffect).toBe("paralysis");
+  });
+
+  it("given gulping form with 1 HP attacker, when getGulpMissileResult, then minimum damage is 1", () => {
+    // Source: Showdown -- minimum damage is 1
+    // With 3 max HP: floor(3/4) = 0, but minimum is 1
+    const result = getGulpMissileResult("gulping", 3);
+    expect(result.damage).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 Hunger Switch
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Hunger Switch", () => {
+  it("given hunger-switch and Morpeko (877), when shouldHungerSwitchToggle, then returns true", () => {
+    // Source: Showdown data/abilities.ts -- Hunger Switch: Morpeko (species 877) only
+    // Source: Bulbapedia "Hunger Switch" -- toggles form each turn
+    expect(shouldHungerSwitchToggle("hunger-switch", 877)).toBe(true);
+  });
+
+  it("given hunger-switch and non-Morpeko, when shouldHungerSwitchToggle, then returns false", () => {
+    // Source: Showdown data/abilities.ts -- only applies to Morpeko
+    expect(shouldHungerSwitchToggle("hunger-switch", 25)).toBe(false);
+  });
+
+  it("given non-hunger-switch ability and Morpeko, when shouldHungerSwitchToggle, then returns false", () => {
+    expect(shouldHungerSwitchToggle("intimidate", 877)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Gen 8 Intrepid Sword / Dauntless Shield
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Intrepid Sword / Dauntless Shield", () => {
+  it("given intrepid-sword user, when switching in, then raises Attack by 1 stage", () => {
+    // Source: Showdown data/mods/gen8/abilities.ts -- Intrepid Sword onStart: +1 Atk
+    // Source: specs/reference/gen8-ground-truth.md -- every switch-in (Gen 8 pre-nerf)
+    const ctx = makeContext({
+      ability: "intrepid-sword",
+      trigger: "on-switch-in",
+      nickname: "Zacian",
+    });
+
+    const result = handleGen8SwitchAbility("on-switch-in", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toHaveLength(1);
+    expect(result.effects[0]).toEqual({
+      effectType: "stat-change",
+      target: "self",
+      stat: "attack",
+      stages: 1,
+    });
+    expect(result.messages[0]).toContain("Intrepid Sword");
+  });
+
+  it("given dauntless-shield user, when switching in, then raises Defense by 1 stage", () => {
+    // Source: Showdown data/mods/gen8/abilities.ts -- Dauntless Shield onStart: +1 Def
+    // Source: specs/reference/gen8-ground-truth.md -- every switch-in (Gen 8 pre-nerf)
+    const ctx = makeContext({
+      ability: "dauntless-shield",
+      trigger: "on-switch-in",
+      nickname: "Zamazenta",
+    });
+
+    const result = handleGen8SwitchAbility("on-switch-in", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toHaveLength(1);
+    expect(result.effects[0]).toEqual({
+      effectType: "stat-change",
+      target: "self",
+      stat: "defense",
+      stages: 1,
+    });
+    expect(result.messages[0]).toContain("Dauntless Shield");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Carry-forward switch-in abilities
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Switch-in Abilities (carry-forward)", () => {
+  it("given intimidate user, when switching in, then lowers opponent Attack by 1", () => {
+    // Source: Showdown data/abilities.ts -- Intimidate: -1 Atk to foe on switch-in
+    const opponent = makeActivePokemon({ ability: "inner-focus" });
+    const ctx = makeContext({
+      ability: "intimidate",
+      trigger: "on-switch-in",
+      nickname: "Gyarados",
+      opponent,
+    });
+
+    const result = handleGen8SwitchAbility("on-switch-in", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects[0]).toEqual({
+      effectType: "stat-change",
+      target: "opponent",
+      stat: "attack",
+      stages: -1,
+    });
+  });
+
+  it("given drizzle user, when switching in, then sets rain weather", () => {
+    // Source: Showdown data/abilities.ts -- Drizzle sets rain
+    const ctx = makeContext({
+      ability: "drizzle",
+      trigger: "on-switch-in",
+      nickname: "Pelipper",
+    });
+
+    const result = handleGen8SwitchAbility("on-switch-in", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects[0]).toEqual({
+      effectType: "weather-set",
+      target: "field",
+      weather: "rain",
+      weatherTurns: 5,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Constants
+// ---------------------------------------------------------------------------
+
+describe("Gen 8 Ability Constants", () => {
+  it("given TRACE_UNCOPYABLE_ABILITIES, then includes Gen 8 additions", () => {
+    // Source: Showdown data/abilities.ts -- trace Gen 8 ban list
+    expect(TRACE_UNCOPYABLE_ABILITIES.has("hunger-switch")).toBe(true);
+    expect(TRACE_UNCOPYABLE_ABILITIES.has("gulp-missile")).toBe(true);
+    expect(TRACE_UNCOPYABLE_ABILITIES.has("ice-face")).toBe(true);
+    expect(TRACE_UNCOPYABLE_ABILITIES.has("neutralizing-gas")).toBe(true);
+    expect(TRACE_UNCOPYABLE_ABILITIES.has("intrepid-sword")).toBe(true);
+    expect(TRACE_UNCOPYABLE_ABILITIES.has("dauntless-shield")).toBe(true);
+  });
+
+  it("given TRACE_UNCOPYABLE_ABILITIES, then still includes Gen 7 entries", () => {
+    // Source: Showdown data/abilities.ts -- trace ban list carry-forward
+    expect(TRACE_UNCOPYABLE_ABILITIES.has("trace")).toBe(true);
+    expect(TRACE_UNCOPYABLE_ABILITIES.has("multitype")).toBe(true);
+    expect(TRACE_UNCOPYABLE_ABILITIES.has("disguise")).toBe(true);
+    expect(TRACE_UNCOPYABLE_ABILITIES.has("battle-bond")).toBe(true);
+  });
+
+  it("given UNSUPPRESSABLE_ABILITIES, then includes Gen 8 additions", () => {
+    // Source: Showdown data/abilities.ts -- cantsuppress Gen 8 entries
+    expect(UNSUPPRESSABLE_ABILITIES.has("gulp-missile")).toBe(true);
+    expect(UNSUPPRESSABLE_ABILITIES.has("ice-face")).toBe(true);
+    expect(UNSUPPRESSABLE_ABILITIES.has("neutralizing-gas")).toBe(true);
+  });
+
+  it("given MOLD_BREAKER_ALIASES, then contains mold-breaker, teravolt, turboblaze", () => {
+    // Source: Showdown data/abilities.ts -- mold breaker variants
+    expect(MOLD_BREAKER_ALIASES.has("mold-breaker")).toBe(true);
+    expect(MOLD_BREAKER_ALIASES.has("teravolt")).toBe(true);
+    expect(MOLD_BREAKER_ALIASES.has("turboblaze")).toBe(true);
+    expect(MOLD_BREAKER_ALIASES.size).toBe(3);
+  });
+
+  it("given NEUTRALIZING_GAS_IMMUNE_ABILITIES, then includes neutralizing-gas and comatose", () => {
+    // Source: Showdown data/abilities.ts -- Neutralizing Gas immune set
+    expect(NEUTRALIZING_GAS_IMMUNE_ABILITIES.has("neutralizing-gas")).toBe(true);
+    expect(NEUTRALIZING_GAS_IMMUNE_ABILITIES.has("comatose")).toBe(true);
+    expect(NEUTRALIZING_GAS_IMMUNE_ABILITIES.has("multitype")).toBe(true);
+    expect(NEUTRALIZING_GAS_IMMUNE_ABILITIES.has("disguise")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `Gen8AbilitiesSwitch.ts` with all carry-forward abilities from Gen 7 plus 10 new Gen 8 abilities: Screen Cleaner, Mirror Armor, Neutralizing Gas, Pastel Veil, Wandering Spirit, Perish Body, Gulp Missile, Ice Face, Hunger Switch, Libero/Protean (pre-nerf)
- Implement `Gen8Abilities.ts` master dispatcher routing triggers to handlers
- Wire `applyAbility` override in `Gen8Ruleset.ts`
- Export all new functions and constants from `index.ts`
- 96 tests with Given/When/Then naming and source provenance comments

## New Gen 8 Abilities
| Ability | Trigger | Effect |
|---------|---------|--------|
| Screen Cleaner | on-switch-in | Removes Reflect, Light Screen, Aurora Veil from both sides |
| Mirror Armor | on-stat-change | Reflects opponent-caused stat drops back to attacker |
| Neutralizing Gas | on-switch-in | Suppresses all non-immune abilities on the field |
| Pastel Veil | passive | Prevents poison/toxic for holder and allies |
| Wandering Spirit | on-contact | Swaps abilities with the attacker |
| Perish Body | on-contact | Both Pokemon get Perish Song (3-turn faint) |
| Gulp Missile | on-contact | Cramorant spits projectile (25% HP + secondary) |
| Ice Face | on-contact | Eiscue blocks first physical hit; reforms in hail |
| Hunger Switch | on-turn-end | Morpeko toggles Full Belly / Hangry each turn |
| Libero | on-before-move | Type change before attacking (every use, no limit) |
| Intrepid Sword | on-switch-in | +1 Attack on every switch-in (Gen 8 pre-nerf) |
| Dauntless Shield | on-switch-in | +1 Defense on every switch-in (Gen 8 pre-nerf) |

## Test plan
- [x] Carry-forward passive checks (Magic Guard, Overcoat, Bulletproof, Damp, Soundproof, Mold Breaker)
- [x] RNG-based passives (Shed Skin 1/3, Harvest 50%/100% in sun)
- [x] Weather duration (5 base, 8 with rock)
- [x] Screen Cleaner removes all 3 screen types from both sides
- [x] Mirror Armor reflects opponent drops, ignores self-inflicted and boosts
- [x] Neutralizing Gas detection and immunity set
- [x] Pastel Veil blocks poison/toxic for holder and allies
- [x] Wandering Spirit swaps on contact, respects unsuppressable
- [x] Perish Body gives both sides perish-song volatile
- [x] Libero/Protean type change on every move (Gen 8 pre-nerf)
- [x] Ice Face blocks physical hits, reforms in hail
- [x] Gulp Missile damage (1/4 HP) and secondary effects
- [x] Hunger Switch Morpeko species check
- [x] Intrepid Sword/Dauntless Shield stat boosts
- [x] Constants (TRACE_UNCOPYABLE, UNSUPPRESSABLE, NEUTRALIZING_GAS_IMMUNE)

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)