### PR TITLE
feat(gen8): Wave 8 -- Dynamax/Gigantamax gimmick

### DIFF
--- a/.changeset/gen8-wave8-dynamax.md
+++ b/.changeset/gen8-wave8-dynamax.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/gen8": minor
+---
+
+feat(gen8): Wave 8 -- Dynamax/Gigantamax gimmick (Max Moves, G-Max moves, HP scaling, 3-turn duration)

--- a/packages/gen8/src/Gen8Dynamax.ts
+++ b/packages/gen8/src/Gen8Dynamax.ts
@@ -1,0 +1,307 @@
+/**
+ * Gen 8 Dynamax/Gigantamax gimmick implementation.
+ *
+ * Implements the BattleGimmick interface for Dynamax:
+ *   - HP scaling based on Dynamax Level (0-10)
+ *   - 3-turn duration
+ *   - Move conversion to Max Moves / G-Max Moves
+ *   - Species immunity (Zacian, Zamazenta, Eternatus)
+ *
+ * Source: Showdown data/conditions.ts lines 771-802 -- Dynamax HP scaling and reversion
+ * Source: Showdown sim/battle-actions.ts -- Max Move conversion
+ * Source: Bulbapedia "Dynamax" -- mechanics overview
+ */
+
+import type {
+  ActivePokemon,
+  BattleEvent,
+  BattleGimmick,
+  BattleSide,
+  BattleState,
+} from "@pokemon-lib-ts/battle";
+import type { MoveData } from "@pokemon-lib-ts/core";
+
+import { getGMaxMove, isGigantamaxEligible } from "./Gen8GMaxMoves.js";
+import { getMaxMoveName, getMaxMovePower, isMaxGuard } from "./Gen8MaxMoves.js";
+
+/**
+ * Number of turns Dynamax lasts before reverting.
+ *
+ * Source: Showdown data/conditions.ts line 766 -- duration: 3
+ * Source: Bulbapedia "Dynamax" -- "Dynamax lasts for three turns"
+ */
+export const DYNAMAX_TURNS = 3;
+
+/**
+ * Species that cannot Dynamax.
+ *
+ * Source: Showdown data/conditions.ts -- canDynamax species filter
+ * Source: Bulbapedia "Dynamax" -- Zacian, Zamazenta, and Eternatus cannot Dynamax
+ */
+export const DYNAMAX_IMMUNE_SPECIES: readonly string[] = ["zacian", "zamazenta", "eternatus"];
+
+/**
+ * Species IDs of Dynamax-immune Pokemon for numeric lookup.
+ *
+ * Source: Bulbapedia -- Zacian (#888), Zamazenta (#889), Eternatus (#890)
+ */
+const DYNAMAX_IMMUNE_SPECIES_IDS: readonly number[] = [888, 889, 890];
+
+/**
+ * Calculates the max HP of a Dynamaxed Pokemon.
+ *
+ * Formula: floor(baseMaxHp * (1.5 + dynamaxLevel * 0.05))
+ *   - dynamaxLevel 0: 1.5x HP
+ *   - dynamaxLevel 10: 2.0x HP
+ *
+ * Source: Showdown data/conditions.ts lines 771-774 -- HP scaling on Dynamax activation
+ *
+ * @param baseMaxHp - The Pokemon's max HP before Dynamax
+ * @param dynamaxLevel - Dynamax Level (0-10)
+ * @returns The Dynamaxed max HP
+ */
+export function getDynamaxMaxHp(baseMaxHp: number, dynamaxLevel: number): number {
+  const ratio = 1.5 + dynamaxLevel * 0.05;
+  return Math.floor(baseMaxHp * ratio);
+}
+
+/**
+ * Calculates the current HP of a Dynamaxed Pokemon.
+ *
+ * The current HP is scaled proportionally using the same multiplier as max HP.
+ *
+ * Source: Showdown data/conditions.ts lines 771-774 -- HP scaling on Dynamax activation
+ *
+ * @param currentHp - The Pokemon's current HP before Dynamax
+ * @param dynamaxLevel - Dynamax Level (0-10)
+ * @returns The Dynamaxed current HP
+ */
+export function getDynamaxCurrentHp(currentHp: number, dynamaxLevel: number): number {
+  const ratio = 1.5 + dynamaxLevel * 0.05;
+  return Math.floor(currentHp * ratio);
+}
+
+/**
+ * Calculates the restored HP when a Pokemon reverts from Dynamax.
+ *
+ * Uses proportional HP restoration: undynamaxedHp = round(currentHp * baseMaxHp / maxHp)
+ *
+ * Source: Showdown data/conditions.ts lines 801-802 -- HP restoration on Dynamax end
+ *
+ * @param currentHp - Current HP while Dynamaxed
+ * @param maxHp - Max HP while Dynamaxed
+ * @param baseMaxHp - Original max HP before Dynamax
+ * @returns The HP after reverting from Dynamax
+ */
+export function getUndynamaxedHp(currentHp: number, maxHp: number, baseMaxHp: number): number {
+  if (maxHp === 0) return 0;
+  return Math.round((currentHp * baseMaxHp) / maxHp);
+}
+
+/**
+ * Checks whether a species is immune to Dynamax by species name (lowercase).
+ */
+function isSpeciesImmuneByName(speciesName: string): boolean {
+  return DYNAMAX_IMMUNE_SPECIES.includes(speciesName.toLowerCase());
+}
+
+/**
+ * Checks whether a species is immune to Dynamax by species ID.
+ */
+function isSpeciesImmuneById(speciesId: number): boolean {
+  return DYNAMAX_IMMUNE_SPECIES_IDS.includes(speciesId);
+}
+
+/**
+ * Gen 8 Dynamax gimmick.
+ *
+ * Implements the BattleGimmick interface for Dynamax/Gigantamax. When activated,
+ * the Pokemon's HP is scaled based on its Dynamax Level, all moves become Max Moves
+ * (or G-Max Moves if the species has a Gigantamax form), and the effect lasts 3 turns.
+ *
+ * Restrictions:
+ *   - One Dynamax per trainer per battle (tracked via BattleSide.gimmickUsed)
+ *   - Zacian, Zamazenta, and Eternatus cannot Dynamax
+ *   - Already-dynamaxed Pokemon cannot Dynamax again
+ *
+ * Source: Showdown data/conditions.ts -- Dynamax condition
+ * Source: Bulbapedia "Dynamax" -- mechanics overview
+ */
+export class Gen8Dynamax implements BattleGimmick {
+  readonly name = "Dynamax";
+  readonly generations = [8] as const;
+
+  /**
+   * Returns true if Dynamax can be used for the given Pokemon on this turn.
+   *
+   * Conditions (all must be true):
+   *   - The side has not yet used its gimmick this battle
+   *   - The Pokemon is not already Dynamaxed
+   *   - The Pokemon's species is not immune to Dynamax
+   *   - The species has `canDynamax !== false` (defaults to true)
+   *
+   * Source: Showdown data/conditions.ts -- canDynamax checks
+   * Source: Bulbapedia "Dynamax" -- restrictions
+   */
+  canUse(pokemon: ActivePokemon, side: BattleSide, _state: BattleState): boolean {
+    if (side.gimmickUsed) return false;
+    if (pokemon.isDynamaxed) return false;
+
+    // Check species immunity by ID
+    if (isSpeciesImmuneById(pokemon.pokemon.speciesId)) return false;
+
+    // Check species immunity by name if species data is available via transformedSpecies
+    const speciesData = pokemon.transformedSpecies;
+    if (speciesData && isSpeciesImmuneByName(speciesData.name)) return false;
+
+    // Check canDynamax flag on species data (defaults to true if absent)
+    if (speciesData && speciesData.canDynamax === false) return false;
+
+    return true;
+  }
+
+  /**
+   * Activates Dynamax for the given Pokemon.
+   *
+   * Mutations applied:
+   *   - pokemon.isDynamaxed = true
+   *   - pokemon.dynamaxTurnsLeft = 3
+   *   - pokemon.pokemon.currentHp scaled by Dynamax Level
+   *   - pokemon.pokemon.calculatedStats.hp scaled by Dynamax Level
+   *   - side.gimmickUsed = true
+   *
+   * Returns a DynamaxEvent identifying the side and Pokemon.
+   *
+   * Source: Showdown data/conditions.ts lines 771-774 -- HP scaling
+   * Source: Bulbapedia "Dynamax" -- activation mechanics
+   */
+  activate(pokemon: ActivePokemon, side: BattleSide, _state: BattleState): BattleEvent[] {
+    const dynamaxLevel = pokemon.pokemon.dynamaxLevel ?? 10;
+
+    // Scale HP
+    // Source: Showdown data/conditions.ts lines 771-774
+    if (pokemon.pokemon.calculatedStats) {
+      const baseMaxHp = pokemon.pokemon.calculatedStats.hp;
+      const newMaxHp = getDynamaxMaxHp(baseMaxHp, dynamaxLevel);
+      const newCurrentHp = getDynamaxCurrentHp(pokemon.pokemon.currentHp, dynamaxLevel);
+
+      // Store the base max HP for later restoration
+      // MutableStatBlock cast is required because StatBlock is readonly
+      const stats = pokemon.pokemon.calculatedStats as { hp: number };
+      stats.hp = newMaxHp;
+      pokemon.pokemon.currentHp = newCurrentHp;
+    }
+
+    // Set Dynamax state
+    pokemon.isDynamaxed = true;
+    pokemon.dynamaxTurnsLeft = DYNAMAX_TURNS;
+    side.gimmickUsed = true;
+
+    const event: BattleEvent = {
+      type: "dynamax",
+      side: side.index,
+      pokemon: pokemon.pokemon.uid,
+    };
+
+    return [event];
+  }
+
+  /**
+   * Reverts Dynamax when the 3-turn duration expires.
+   *
+   * Mutations applied:
+   *   - pokemon.isDynamaxed = false
+   *   - pokemon.dynamaxTurnsLeft = 0
+   *   - pokemon.pokemon.currentHp proportionally restored
+   *   - pokemon.pokemon.calculatedStats.hp restored to base
+   *
+   * Source: Showdown data/conditions.ts lines 801-802 -- HP restoration
+   * Source: Bulbapedia "Dynamax" -- reversion mechanics
+   */
+  revert(pokemon: ActivePokemon, _state: BattleState): BattleEvent[] {
+    if (!pokemon.isDynamaxed) return [];
+
+    const dynamaxLevel = pokemon.pokemon.dynamaxLevel ?? 10;
+
+    // Restore HP proportionally
+    // Source: Showdown data/conditions.ts lines 801-802
+    if (pokemon.pokemon.calculatedStats) {
+      const currentMaxHp = pokemon.pokemon.calculatedStats.hp;
+      const ratio = 1.5 + dynamaxLevel * 0.05;
+      const baseMaxHp = Math.round(currentMaxHp / ratio);
+      const restoredHp = getUndynamaxedHp(pokemon.pokemon.currentHp, currentMaxHp, baseMaxHp);
+
+      const stats = pokemon.pokemon.calculatedStats as { hp: number };
+      stats.hp = baseMaxHp;
+      pokemon.pokemon.currentHp = Math.min(restoredHp, baseMaxHp);
+    }
+
+    // Clear Dynamax state
+    pokemon.isDynamaxed = false;
+    pokemon.dynamaxTurnsLeft = 0;
+
+    const event: BattleEvent = {
+      type: "dynamax-end",
+      side: 0, // Side index is not available in revert; the engine sets the correct side
+      pokemon: pokemon.pokemon.uid,
+    };
+
+    return [event];
+  }
+
+  /**
+   * Converts a move to its Max Move equivalent when the Pokemon is Dynamaxed.
+   *
+   * - Status moves become Max Guard (BP 0, blocks all moves including other Max Moves)
+   * - Damage moves become the appropriate Max Move for their type with converted base power
+   * - If the Pokemon has a Gigantamax form and the move type matches, use the G-Max Move instead
+   *
+   * Source: Showdown sim/battle-actions.ts -- Max Move conversion
+   * Source: Bulbapedia "Max Move" -- move conversion rules
+   */
+  modifyMove(move: MoveData, pokemon: ActivePokemon): MoveData {
+    if (!pokemon.isDynamaxed) return move;
+
+    // Status moves become Max Guard
+    // Source: Showdown sim/battle-actions.ts -- status moves become Max Guard
+    if (isMaxGuard(move)) {
+      return {
+        ...move,
+        id: "max-guard",
+        displayName: "Max Guard",
+        power: null,
+        accuracy: null,
+        priority: 4,
+        effect: { type: "protect", variant: "standard" },
+      };
+    }
+
+    // Check for G-Max move eligibility
+    const speciesData = pokemon.transformedSpecies;
+    if (speciesData && isGigantamaxEligible(speciesData)) {
+      const gmaxMove = getGMaxMove(speciesData.name);
+      if (gmaxMove && gmaxMove.moveType === move.type) {
+        const basePower = gmaxMove.basePower ?? getMaxMovePower(move.power ?? 0, move.type);
+        return {
+          ...move,
+          id: `gmax-${speciesData.name.toLowerCase()}`,
+          displayName: gmaxMove.species,
+          power: basePower,
+          accuracy: null, // Max Moves never miss
+        };
+      }
+    }
+
+    // Standard Max Move conversion
+    const maxMoveName = getMaxMoveName(move.type, false);
+    const maxMovePower = getMaxMovePower(move.power ?? 0, move.type);
+
+    return {
+      ...move,
+      id: `max-${move.type}`,
+      displayName: maxMoveName,
+      power: maxMovePower,
+      accuracy: null, // Max Moves never miss
+    };
+  }
+}

--- a/packages/gen8/src/Gen8GMaxMoves.ts
+++ b/packages/gen8/src/Gen8GMaxMoves.ts
@@ -1,0 +1,276 @@
+/**
+ * Gen 8 G-Max Move data -- species associations, types, and effects.
+ *
+ * Source: Showdown data/moves.ts lines 6955-7760 -- all gmaxXxx entries
+ * Source: Bulbapedia "Gigantamax" -- species-specific G-Max Moves
+ */
+
+import type { PokemonType } from "@pokemon-lib-ts/core";
+
+/**
+ * Describes the unique effect of a G-Max Move.
+ *
+ * Source: Showdown data/moves.ts -- individual G-Max move effect implementations
+ */
+export type GMaxMoveEffectType =
+  | { type: "status-random"; statuses: readonly string[] }
+  | { type: "residual"; duration: number; damage: string; immunity: readonly string[] }
+  | { type: "trap"; trapType: string }
+  | { type: "crit-boost"; layers: number }
+  | { type: "infatuate-foes" }
+  | { type: "pp-deduct"; amount: number }
+  | { type: "ignore-ability" }
+  | { type: "heal-allies"; fraction: string }
+  | { type: "stat-change"; stat: string; stages: number; target: string }
+  | { type: "confuse-foes" }
+  | { type: "pseudo-weather"; condition: string }
+  | { type: "status"; status: string }
+  | { type: "torment-foes" }
+  | { type: "bypass-protect" }
+  | { type: "restore-berries"; chance: number }
+  | { type: "side-condition"; condition: string }
+  | { type: "yawn"; chance: number }
+  | { type: "hazard"; hazard: string }
+  | { type: "cure-allies" }
+  | { type: "trap-foes" };
+
+/**
+ * Data for a single G-Max Move.
+ */
+export interface GMaxMoveData {
+  /** The species name that has access to this G-Max Move */
+  readonly species: string;
+  /** The type of the G-Max Move */
+  readonly moveType: PokemonType;
+  /** The unique effect of this G-Max Move */
+  readonly effect: GMaxMoveEffectType;
+  /** Override base power (for the trio starters: Rillaboom, Cinderace, Inteleon) */
+  readonly basePower?: number;
+}
+
+/**
+ * Complete G-Max Move table.
+ *
+ * Source: Showdown data/moves.ts lines 6955-7760 (all gmaxXxx entries)
+ * Source: Bulbapedia "Gigantamax" -- species list and effects
+ */
+export const GMAX_MOVES: Readonly<Record<string, GMaxMoveData>> = {
+  "gmax-befuddle": {
+    species: "Butterfree",
+    moveType: "bug",
+    effect: { type: "status-random", statuses: ["slp", "par", "psn"] },
+  },
+  "gmax-cannonade": {
+    species: "Blastoise",
+    moveType: "water",
+    effect: { type: "residual", duration: 4, damage: "1/6", immunity: ["water"] },
+  },
+  "gmax-centiferno": {
+    species: "Centiskorch",
+    moveType: "fire",
+    effect: { type: "trap", trapType: "fire-spin" },
+  },
+  "gmax-chi-strike": {
+    species: "Machamp",
+    moveType: "fighting",
+    effect: { type: "crit-boost", layers: 1 },
+  },
+  "gmax-cuddle": {
+    species: "Eevee",
+    moveType: "normal",
+    effect: { type: "infatuate-foes" },
+  },
+  "gmax-depletion": {
+    species: "Duraludon",
+    moveType: "dragon",
+    effect: { type: "pp-deduct", amount: 2 },
+  },
+  "gmax-drum-solo": {
+    species: "Rillaboom",
+    moveType: "grass",
+    effect: { type: "ignore-ability" },
+    basePower: 160,
+  },
+  "gmax-finale": {
+    species: "Alcremie",
+    moveType: "fairy",
+    effect: { type: "heal-allies", fraction: "1/6" },
+  },
+  "gmax-fireball": {
+    species: "Cinderace",
+    moveType: "fire",
+    effect: { type: "ignore-ability" },
+    basePower: 160,
+  },
+  "gmax-foam-burst": {
+    species: "Kingler",
+    moveType: "water",
+    effect: { type: "stat-change", stat: "spe", stages: -2, target: "foes" },
+  },
+  "gmax-gold-rush": {
+    species: "Meowth",
+    moveType: "normal",
+    effect: { type: "confuse-foes" },
+  },
+  "gmax-gravitas": {
+    species: "Orbeetle",
+    moveType: "psychic",
+    effect: { type: "pseudo-weather", condition: "gravity" },
+  },
+  "gmax-hydrosnipe": {
+    species: "Inteleon",
+    moveType: "water",
+    effect: { type: "ignore-ability" },
+    basePower: 160,
+  },
+  "gmax-malodor": {
+    species: "Garbodor",
+    moveType: "poison",
+    effect: { type: "status", status: "psn" },
+  },
+  "gmax-meltdown": {
+    species: "Melmetal",
+    moveType: "steel",
+    effect: { type: "torment-foes" },
+  },
+  "gmax-one-blow": {
+    species: "Urshifu",
+    moveType: "dark",
+    effect: { type: "bypass-protect" },
+  },
+  "gmax-rapid-flow": {
+    species: "Urshifu-Rapid-Strike",
+    moveType: "water",
+    effect: { type: "bypass-protect" },
+  },
+  "gmax-replenish": {
+    species: "Snorlax",
+    moveType: "normal",
+    effect: { type: "restore-berries", chance: 0.5 },
+  },
+  "gmax-resonance": {
+    species: "Lapras",
+    moveType: "ice",
+    effect: { type: "side-condition", condition: "aurora-veil" },
+  },
+  "gmax-sandblast": {
+    species: "Sandaconda",
+    moveType: "ground",
+    effect: { type: "trap", trapType: "sand-tomb" },
+  },
+  "gmax-smite": {
+    species: "Hatterene",
+    moveType: "fairy",
+    effect: { type: "confuse-foes" },
+  },
+  "gmax-snooze": {
+    species: "Grimmsnarl",
+    moveType: "dark",
+    effect: { type: "yawn", chance: 0.5 },
+  },
+  "gmax-steelsurge": {
+    species: "Copperajah",
+    moveType: "steel",
+    effect: { type: "hazard", hazard: "gmax-steelsurge" },
+  },
+  "gmax-stonesurge": {
+    species: "Drednaw",
+    moveType: "water",
+    effect: { type: "hazard", hazard: "stealth-rock" },
+  },
+  "gmax-stun-shock": {
+    species: "Toxtricity",
+    moveType: "electric",
+    effect: { type: "status-random", statuses: ["par", "psn"] },
+  },
+  "gmax-sweetness": {
+    species: "Appletun",
+    moveType: "grass",
+    effect: { type: "cure-allies" },
+  },
+  "gmax-tartness": {
+    species: "Flapple",
+    moveType: "grass",
+    effect: { type: "stat-change", stat: "eva", stages: -1, target: "foes" },
+  },
+  "gmax-terror": {
+    species: "Gengar",
+    moveType: "ghost",
+    effect: { type: "trap-foes" },
+  },
+  "gmax-vine-lash": {
+    species: "Venusaur",
+    moveType: "grass",
+    effect: { type: "residual", duration: 4, damage: "1/6", immunity: ["grass"] },
+  },
+  "gmax-volcalith": {
+    species: "Coalossal",
+    moveType: "rock",
+    effect: { type: "residual", duration: 4, damage: "1/6", immunity: ["rock"] },
+  },
+  "gmax-volt-crash": {
+    species: "Pikachu",
+    moveType: "electric",
+    effect: { type: "status", status: "par" },
+  },
+  "gmax-wildfire": {
+    species: "Charizard",
+    moveType: "fire",
+    effect: { type: "residual", duration: 4, damage: "1/6", immunity: ["fire"] },
+  },
+};
+
+/**
+ * Index of species name (lowercase) to G-Max move ID for fast lookup.
+ */
+const SPECIES_TO_GMAX: Readonly<Record<string, string>> = Object.fromEntries(
+  Object.entries(GMAX_MOVES).map(([id, data]) => [data.species.toLowerCase(), id]),
+);
+
+/**
+ * Returns the G-Max move data for a given species, or null if the species
+ * does not have a G-Max form.
+ *
+ * Accepts species name (string, case-insensitive) or species ID (number, currently
+ * not mapped -- returns null for numeric IDs as species-to-ID mapping is data-dependent).
+ *
+ * Source: Showdown data/moves.ts -- G-Max move entries per species
+ *
+ * @param speciesId - Species name or numeric ID
+ * @returns GMaxMoveData if found, null otherwise
+ */
+export function getGMaxMove(speciesId: number | string): GMaxMoveData | null {
+  if (typeof speciesId === "number") {
+    // Numeric IDs require a data lookup not available here;
+    // callers should resolve the species name first.
+    return null;
+  }
+  const key = speciesId.toLowerCase();
+  const gmaxId = SPECIES_TO_GMAX[key];
+  if (!gmaxId) return null;
+  return GMAX_MOVES[gmaxId] ?? null;
+}
+
+/**
+ * Returns true if the given species data has a Gigantamax form.
+ *
+ * Source: Game mechanic -- only certain species can Gigantamax
+ *
+ * @param species - Object with an optional `gigantamaxForm` property
+ * @returns true if the species has Gigantamax data
+ */
+export function isGigantamaxEligible(species: { gigantamaxForm?: unknown }): boolean {
+  return species.gigantamaxForm != null;
+}
+
+/**
+ * Returns G-Max move data by move ID (e.g., "gmax-wildfire"), or null if not found.
+ *
+ * Source: Showdown data/moves.ts -- G-Max move entries
+ *
+ * @param gmaxMoveId - The G-Max move ID
+ * @returns GMaxMoveData if found, null otherwise
+ */
+export function getGMaxMoveEffect(gmaxMoveId: string): GMaxMoveData | null {
+  return GMAX_MOVES[gmaxMoveId] ?? null;
+}

--- a/packages/gen8/src/Gen8MaxMoves.ts
+++ b/packages/gen8/src/Gen8MaxMoves.ts
@@ -1,0 +1,241 @@
+/**
+ * Gen 8 Max Move system -- type-to-Max-Move name mapping, base power conversion,
+ * and secondary effect descriptors.
+ *
+ * Source: Showdown sim/battle-actions.ts lines 9-29 -- MAX_MOVES table
+ * Source: Showdown data/moves.ts -- maxMove.basePower values on individual moves
+ * Source: Bulbapedia "Max Move" -- secondary effects per type
+ */
+
+import type { BattleStat, PokemonType } from "@pokemon-lib-ts/core";
+
+/**
+ * Describes the secondary effect of a Max Move.
+ *
+ * - `stat-boost`: Raises or lowers a stat for the user's side or the opponent's side.
+ * - `weather`: Sets weather for 5 turns.
+ * - `terrain`: Sets terrain for 5 turns.
+ * - `protect`: Blocks all moves (Max Guard, from status moves).
+ *
+ * Source: Bulbapedia "Max Move" -- secondary effects per type
+ */
+export type MaxMoveEffect =
+  | {
+      type: "stat-boost";
+      stat: BattleStat;
+      stages: number;
+      target: "user-side" | "opponent" | "opponent-side";
+    }
+  | { type: "weather"; weather: string }
+  | { type: "terrain"; terrain: string }
+  | { type: "protect" };
+
+/**
+ * Mapping from Pokemon type to Max Move name.
+ *
+ * Source: Showdown sim/battle-actions.ts lines 9-29 -- MAX_MOVES table
+ */
+const MAX_MOVE_NAMES: Readonly<Record<PokemonType, string>> = {
+  normal: "Max Strike",
+  fire: "Max Flare",
+  water: "Max Geyser",
+  electric: "Max Lightning",
+  grass: "Max Overgrowth",
+  ice: "Max Hailstorm",
+  fighting: "Max Knuckle",
+  poison: "Max Ooze",
+  ground: "Max Quake",
+  flying: "Max Airstream",
+  psychic: "Max Mindstorm",
+  bug: "Max Flutterby",
+  rock: "Max Rockfall",
+  ghost: "Max Phantasm",
+  dragon: "Max Wyrmwind",
+  dark: "Max Darkness",
+  steel: "Max Steelspike",
+  fairy: "Max Starfall",
+};
+
+/**
+ * Secondary effects of each Max Move.
+ *
+ * Source: Bulbapedia "Max Move" -- secondary effects per type
+ * Source: Showdown data/moves.ts -- individual Max Move entries
+ */
+const MAX_MOVE_EFFECTS: Readonly<Record<string, MaxMoveEffect>> = {
+  "Max Strike": {
+    type: "stat-boost",
+    stat: "speed",
+    stages: -1,
+    target: "opponent-side",
+  },
+  "Max Flare": { type: "weather", weather: "sun" },
+  "Max Geyser": { type: "weather", weather: "rain" },
+  "Max Lightning": { type: "terrain", terrain: "electric" },
+  "Max Overgrowth": { type: "terrain", terrain: "grassy" },
+  "Max Hailstorm": { type: "weather", weather: "hail" },
+  "Max Knuckle": {
+    type: "stat-boost",
+    stat: "attack",
+    stages: 1,
+    target: "user-side",
+  },
+  "Max Ooze": {
+    type: "stat-boost",
+    stat: "spAttack",
+    stages: 1,
+    target: "user-side",
+  },
+  "Max Quake": {
+    type: "stat-boost",
+    stat: "spDefense",
+    stages: 1,
+    target: "user-side",
+  },
+  "Max Airstream": {
+    type: "stat-boost",
+    stat: "speed",
+    stages: 1,
+    target: "user-side",
+  },
+  "Max Mindstorm": { type: "terrain", terrain: "psychic" },
+  "Max Flutterby": {
+    type: "stat-boost",
+    stat: "spAttack",
+    stages: -1,
+    target: "opponent-side",
+  },
+  "Max Rockfall": { type: "weather", weather: "sandstorm" },
+  "Max Phantasm": {
+    type: "stat-boost",
+    stat: "defense",
+    stages: -1,
+    target: "opponent",
+  },
+  "Max Wyrmwind": {
+    type: "stat-boost",
+    stat: "attack",
+    stages: -1,
+    target: "opponent-side",
+  },
+  "Max Darkness": {
+    type: "stat-boost",
+    stat: "spDefense",
+    stages: -1,
+    target: "opponent-side",
+  },
+  "Max Steelspike": {
+    type: "stat-boost",
+    stat: "defense",
+    stages: 1,
+    target: "user-side",
+  },
+  "Max Starfall": { type: "terrain", terrain: "misty" },
+  "Max Guard": { type: "protect" },
+};
+
+/**
+ * Returns the Max Move name for a given type.
+ *
+ * Status moves always become Max Guard regardless of type.
+ *
+ * Source: Showdown sim/battle-actions.ts lines 9-29 -- MAX_MOVES table
+ *
+ * @param moveType - The type of the base move
+ * @param isStatus - Whether the move is a status move
+ * @returns The Max Move name
+ */
+export function getMaxMoveName(moveType: PokemonType, isStatus: boolean): string {
+  if (isStatus) return "Max Guard";
+  return MAX_MOVE_NAMES[moveType];
+}
+
+/**
+ * Converts a base move's power to its Max Move base power.
+ *
+ * Poison and Fighting type moves use a lower power table than all other types.
+ * Status moves always have 0 base power as Max Guard.
+ *
+ * Source: Showdown data/moves.ts -- maxMove.basePower values on individual moves
+ * Source: Bulbapedia "Max Move" -- base power conversion table
+ *
+ * @param basePower - The base move's power (0 for status moves)
+ * @param moveType - The type of the base move
+ * @returns The Max Move base power
+ */
+export function getMaxMovePower(basePower: number, moveType: PokemonType): number {
+  if (basePower === 0) return 0;
+
+  const isPoisonOrFighting = moveType === "poison" || moveType === "fighting";
+
+  if (isPoisonOrFighting) {
+    return getPoisonFightingMaxPower(basePower);
+  }
+  return getStandardMaxPower(basePower);
+}
+
+/**
+ * Poison/Fighting Max Move power table.
+ *
+ * Source: Showdown data/moves.ts -- maxMove.basePower for Poison/Fighting moves
+ */
+function getPoisonFightingMaxPower(basePower: number): number {
+  if (basePower <= 40) return 70;
+  if (basePower <= 50) return 75;
+  if (basePower <= 60) return 80;
+  if (basePower <= 70) return 85;
+  if (basePower <= 80) return 90;
+  if (basePower <= 90) return 95;
+  if (basePower <= 100) return 100;
+  if (basePower <= 110) return 105;
+  if (basePower <= 120) return 110;
+  if (basePower <= 130) return 115;
+  if (basePower <= 140) return 120;
+  if (basePower <= 150) return 125;
+  return 130;
+}
+
+/**
+ * Standard (non-Poison/non-Fighting) Max Move power table.
+ *
+ * Source: Showdown data/moves.ts -- maxMove.basePower for standard moves
+ */
+function getStandardMaxPower(basePower: number): number {
+  if (basePower <= 40) return 90;
+  if (basePower <= 50) return 100;
+  if (basePower <= 60) return 110;
+  if (basePower <= 70) return 115;
+  if (basePower <= 80) return 120;
+  if (basePower <= 90) return 125;
+  if (basePower <= 100) return 130;
+  if (basePower <= 110) return 135;
+  if (basePower <= 120) return 140;
+  if (basePower <= 130) return 145;
+  if (basePower <= 140) return 150;
+  // 145-150 and 155+ both cap at 150
+  return 150;
+}
+
+/**
+ * Returns the secondary effect descriptor for a Max Move, or null for unknown moves.
+ *
+ * Source: Bulbapedia "Max Move" -- secondary effects per type
+ *
+ * @param maxMoveName - The Max Move name (e.g., "Max Flare")
+ * @returns The secondary effect descriptor, or null if not found
+ */
+export function getMaxMoveSecondaryEffect(maxMoveName: string): MaxMoveEffect | null {
+  return MAX_MOVE_EFFECTS[maxMoveName] ?? null;
+}
+
+/**
+ * Returns true if the given move should become Max Guard (i.e., it is a status move).
+ *
+ * Source: Showdown sim/battle-actions.ts -- status moves become Max Guard
+ *
+ * @param move - Object with a `category` property
+ * @returns true if the move is a status move
+ */
+export function isMaxGuard(move: { category: string }): boolean {
+  return move.category === "status";
+}

--- a/packages/gen8/src/Gen8Ruleset.ts
+++ b/packages/gen8/src/Gen8Ruleset.ts
@@ -28,6 +28,7 @@ import { createGen8DataManager } from "./data/index.js";
 import { handleGen8SwitchAbility, shouldMirrorArmorReflect } from "./Gen8AbilitiesSwitch.js";
 import { GEN8_CRIT_MULTIPLIER, GEN8_CRIT_RATE_TABLE } from "./Gen8CritCalc.js";
 import { calculateGen8Damage } from "./Gen8DamageCalc.js";
+import { Gen8Dynamax } from "./Gen8Dynamax.js";
 import { applyGen8EntryHazards } from "./Gen8EntryHazards.js";
 import { applyGen8TerrainEffects, checkGen8TerrainStatusImmunity } from "./Gen8Terrain.js";
 import { GEN8_TYPE_CHART, GEN8_TYPES } from "./Gen8TypeChart.js";
@@ -255,10 +256,12 @@ export class Gen8Ruleset extends BaseRuleset {
    * Source: Showdown data/mods/gen8 -- no Mega Evolution or Z-Moves
    * Source: Bulbapedia -- Dynamax is the Gen 8 battle gimmick
    */
-  getBattleGimmick(_type: BattleGimmickType): BattleGimmick | null {
+  getBattleGimmick(type: BattleGimmickType): BattleGimmick | null {
     // Mega Evolution removed in Gen 8
     // Z-Moves removed in Gen 8
-    // Dynamax: implemented in Wave 8
+    // Source: Showdown data/mods/gen8 -- no Mega Evolution or Z-Moves
+    // Source: Bulbapedia -- Dynamax is the Gen 8 battle gimmick
+    if (type === "dynamax") return new Gen8Dynamax();
     return null;
   }
 

--- a/packages/gen8/src/index.ts
+++ b/packages/gen8/src/index.ts
@@ -82,6 +82,14 @@ export {
   TYPE_RESIST_BERRIES,
 } from "./Gen8DamageCalc.js";
 export {
+  DYNAMAX_IMMUNE_SPECIES,
+  DYNAMAX_TURNS,
+  Gen8Dynamax,
+  getDynamaxCurrentHp,
+  getDynamaxMaxHp,
+  getUndynamaxedHp,
+} from "./Gen8Dynamax.js";
+export {
   applyGen8EntryHazards,
   applyGen8GMaxSteelsurge,
   applyGen8SpikesHazard,
@@ -90,6 +98,21 @@ export {
   applyGen8ToxicSpikes,
   hasHeavyDutyBoots,
 } from "./Gen8EntryHazards.js";
+export {
+  GMAX_MOVES,
+  type GMaxMoveData,
+  type GMaxMoveEffectType,
+  getGMaxMove,
+  getGMaxMoveEffect,
+  isGigantamaxEligible,
+} from "./Gen8GMaxMoves.js";
+export {
+  getMaxMoveName,
+  getMaxMovePower,
+  getMaxMoveSecondaryEffect,
+  isMaxGuard,
+  type MaxMoveEffect,
+} from "./Gen8MaxMoves.js";
 export {
   AURORA_VEIL_DEFAULT_TURNS,
   AURORA_VEIL_LIGHT_CLAY_TURNS,

--- a/packages/gen8/tests/dynamax.test.ts
+++ b/packages/gen8/tests/dynamax.test.ts
@@ -1,0 +1,498 @@
+import type { ActivePokemon, BattleSide, BattleState } from "@pokemon-lib-ts/battle";
+import type { PokemonInstance } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  DYNAMAX_IMMUNE_SPECIES,
+  DYNAMAX_TURNS,
+  Gen8Dynamax,
+  getDynamaxCurrentHp,
+  getDynamaxMaxHp,
+  getUndynamaxedHp,
+} from "../src/Gen8Dynamax.js";
+
+// --- Test Helpers ---
+
+function createMockPokemon(overrides: Partial<PokemonInstance> = {}): PokemonInstance {
+  return {
+    uid: "test-pokemon-1",
+    speciesId: 25, // Pikachu
+    nickname: null,
+    level: 50,
+    experience: 0,
+    nature: "adamant",
+    ivs: { hp: 31, attack: 31, defense: 31, spAttack: 31, spDefense: 31, speed: 31 },
+    evs: { hp: 0, attack: 0, defense: 0, spAttack: 0, spDefense: 0, speed: 0 },
+    currentHp: 200,
+    moves: [],
+    ability: "static",
+    abilitySlot: "normal1",
+    heldItem: null,
+    status: null,
+    friendship: 70,
+    gender: "male",
+    isShiny: false,
+    metLocation: "test",
+    metLevel: 1,
+    originalTrainer: "Ash",
+    originalTrainerId: 12345,
+    pokeball: "poke-ball",
+    calculatedStats: { hp: 300, attack: 100, defense: 80, spAttack: 90, spDefense: 70, speed: 110 },
+    dynamaxLevel: 10,
+    ...overrides,
+  } as PokemonInstance;
+}
+
+function createMockActive(
+  pokemonOverrides: Partial<PokemonInstance> = {},
+  activeOverrides: Partial<ActivePokemon> = {},
+): ActivePokemon {
+  return {
+    pokemon: createMockPokemon(pokemonOverrides),
+    teamSlot: 0,
+    statStages: {
+      hp: 0,
+      attack: 0,
+      defense: 0,
+      spAttack: 0,
+      spDefense: 0,
+      speed: 0,
+      accuracy: 0,
+      evasion: 0,
+    },
+    volatileStatuses: new Map(),
+    types: ["electric"],
+    ability: "static",
+    suppressedAbility: null,
+    lastMoveUsed: null,
+    lastDamageTaken: 0,
+    lastDamageType: null,
+    lastDamageCategory: null,
+    turnsOnField: 0,
+    movedThisTurn: false,
+    consecutiveProtects: 0,
+    substituteHp: 0,
+    itemKnockedOff: false,
+    transformed: false,
+    transformedSpecies: null,
+    isMega: false,
+    isDynamaxed: false,
+    dynamaxTurnsLeft: 0,
+    isTerastallized: false,
+    teraType: null,
+    forcedMove: null,
+    ...activeOverrides,
+  } as ActivePokemon;
+}
+
+function createMockSide(overrides: Partial<BattleSide> = {}): BattleSide {
+  return {
+    index: 0,
+    trainer: null,
+    team: [],
+    active: [],
+    hazards: [],
+    screens: [],
+    tailwind: { active: false, turnsLeft: 0 },
+    luckyChant: { active: false, turnsLeft: 0 },
+    wish: null,
+    futureAttack: null,
+    faintCount: 0,
+    gimmickUsed: false,
+    ...overrides,
+  } as BattleSide;
+}
+
+function createMockState(): BattleState {
+  return {
+    sides: [createMockSide(), createMockSide({ index: 1 })],
+    weather: null,
+    terrain: null,
+    trickRoom: null,
+    turnNumber: 1,
+  } as unknown as BattleState;
+}
+
+// --- Tests ---
+
+describe("Gen8Dynamax", () => {
+  describe("Constants", () => {
+    it("given DYNAMAX_TURNS, when checking value, then equals 3", () => {
+      // Source: Showdown data/conditions.ts line 766 -- duration: 3
+      expect(DYNAMAX_TURNS).toBe(3);
+    });
+
+    it("given DYNAMAX_IMMUNE_SPECIES, when checking contents, then includes zacian, zamazenta, eternatus", () => {
+      // Source: Bulbapedia "Dynamax" -- these three species cannot Dynamax
+      expect(DYNAMAX_IMMUNE_SPECIES).toContain("zacian");
+      expect(DYNAMAX_IMMUNE_SPECIES).toContain("zamazenta");
+      expect(DYNAMAX_IMMUNE_SPECIES).toContain("eternatus");
+      expect(DYNAMAX_IMMUNE_SPECIES.length).toBe(3);
+    });
+  });
+
+  describe("getDynamaxMaxHp", () => {
+    it("given dynamaxLevel=0 and baseMaxHp=300, when calculating, then returns floor(300 * 1.5) = 450", () => {
+      // Source: Showdown data/conditions.ts line 771 -- ratio = 1.5 + (level * 0.05)
+      // dynamaxLevel=0: ratio = 1.5, floor(300 * 1.5) = 450
+      const result = getDynamaxMaxHp(300, 0);
+      expect(result).toBe(450);
+    });
+
+    it("given dynamaxLevel=10 and baseMaxHp=300, when calculating, then returns floor(300 * 2.0) = 600", () => {
+      // Source: Showdown data/conditions.ts line 771 -- dynamaxLevel 10: ratio = 2.0
+      // floor(300 * 2.0) = 600
+      const result = getDynamaxMaxHp(300, 10);
+      expect(result).toBe(600);
+    });
+
+    it("given dynamaxLevel=5 and baseMaxHp=300, when calculating, then returns floor(300 * 1.75) = 525", () => {
+      // Inline derivation: ratio = 1.5 + (5 * 0.05) = 1.75, floor(300 * 1.75) = 525
+      const result = getDynamaxMaxHp(300, 5);
+      expect(result).toBe(525);
+    });
+
+    it("given dynamaxLevel=10 and baseMaxHp=1 (Shedinja), when calculating, then returns floor(1 * 2.0) = 2", () => {
+      // Source: Showdown -- Shedinja can Dynamax; HP still scales
+      // floor(1 * 2.0) = 2
+      const result = getDynamaxMaxHp(1, 10);
+      expect(result).toBe(2);
+    });
+  });
+
+  describe("getDynamaxCurrentHp", () => {
+    it("given currentHp=200 and dynamaxLevel=0, when calculating, then returns floor(200 * 1.5) = 300", () => {
+      // Source: Showdown data/conditions.ts lines 771-774 -- same ratio applied to currentHp
+      const result = getDynamaxCurrentHp(200, 0);
+      expect(result).toBe(300);
+    });
+
+    it("given currentHp=200 and dynamaxLevel=10, when calculating, then returns floor(200 * 2.0) = 400", () => {
+      // Inline derivation: ratio = 2.0, floor(200 * 2.0) = 400
+      const result = getDynamaxCurrentHp(200, 10);
+      expect(result).toBe(400);
+    });
+
+    it("given currentHp=150 and dynamaxLevel=5, when calculating, then returns floor(150 * 1.75) = 262", () => {
+      // Inline derivation: ratio = 1.75, floor(150 * 1.75) = 262.5 -> 262
+      const result = getDynamaxCurrentHp(150, 5);
+      expect(result).toBe(262);
+    });
+  });
+
+  describe("getUndynamaxedHp", () => {
+    it("given currentHp=225, maxHp=450, baseMaxHp=300, when reverting, then returns round(225*300/450) = 150", () => {
+      // Source: Showdown data/conditions.ts lines 801-802 -- proportional HP restoration
+      // round(225 * 300 / 450) = round(150) = 150
+      const result = getUndynamaxedHp(225, 450, 300);
+      expect(result).toBe(150);
+    });
+
+    it("given currentHp=600, maxHp=600, baseMaxHp=300, when reverting at full HP, then returns 300", () => {
+      // Inline derivation: round(600 * 300 / 600) = round(300) = 300
+      const result = getUndynamaxedHp(600, 600, 300);
+      expect(result).toBe(300);
+    });
+
+    it("given currentHp=0, maxHp=600, baseMaxHp=300, when reverting at 0 HP, then returns 0", () => {
+      // Inline derivation: round(0 * 300 / 600) = 0
+      const result = getUndynamaxedHp(0, 600, 300);
+      expect(result).toBe(0);
+    });
+
+    it("given currentHp=301, maxHp=600, baseMaxHp=300, when reverting with odd ratio, then rounds correctly", () => {
+      // Inline derivation: round(301 * 300 / 600) = round(150.5) = 151 (round rounds up at .5)
+      const result = getUndynamaxedHp(301, 600, 300);
+      expect(result).toBe(151);
+    });
+
+    it("given maxHp=0 (edge case), when reverting, then returns 0 without division by zero", () => {
+      const result = getUndynamaxedHp(100, 0, 300);
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("Gen8Dynamax.canUse", () => {
+    it("given pokemon not dynamaxed and side has not used gimmick, when checking canUse, then returns true", () => {
+      // Source: Showdown data/conditions.ts -- basic Dynamax eligibility
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive();
+      const side = createMockSide();
+      const state = createMockState();
+
+      expect(dynamax.canUse(pokemon, side, state)).toBe(true);
+    });
+
+    it("given pokemon already isDynamaxed, when checking canUse, then returns false", () => {
+      // Source: Showdown -- cannot Dynamax if already Dynamaxed
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive({}, { isDynamaxed: true });
+      const side = createMockSide();
+      const state = createMockState();
+
+      expect(dynamax.canUse(pokemon, side, state)).toBe(false);
+    });
+
+    it("given side.gimmickUsed is true, when checking canUse, then returns false", () => {
+      // Source: Showdown -- one gimmick per side per battle
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive();
+      const side = createMockSide({ gimmickUsed: true });
+      const state = createMockState();
+
+      expect(dynamax.canUse(pokemon, side, state)).toBe(false);
+    });
+
+    it("given Zacian (speciesId 888), when checking canUse, then returns false", () => {
+      // Source: Bulbapedia "Dynamax" -- Zacian (#888) cannot Dynamax
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive({ speciesId: 888 });
+      const side = createMockSide();
+      const state = createMockState();
+
+      expect(dynamax.canUse(pokemon, side, state)).toBe(false);
+    });
+
+    it("given Zamazenta (speciesId 889), when checking canUse, then returns false", () => {
+      // Source: Bulbapedia "Dynamax" -- Zamazenta (#889) cannot Dynamax
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive({ speciesId: 889 });
+      const side = createMockSide();
+      const state = createMockState();
+
+      expect(dynamax.canUse(pokemon, side, state)).toBe(false);
+    });
+
+    it("given Eternatus (speciesId 890), when checking canUse, then returns false", () => {
+      // Source: Bulbapedia "Dynamax" -- Eternatus (#890) cannot Dynamax
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive({ speciesId: 890 });
+      const side = createMockSide();
+      const state = createMockState();
+
+      expect(dynamax.canUse(pokemon, side, state)).toBe(false);
+    });
+  });
+
+  describe("Gen8Dynamax.activate", () => {
+    it("given a normal pokemon with dynamaxLevel=10, when activating, then sets isDynamaxed=true and dynamaxTurnsLeft=3", () => {
+      // Source: Showdown data/conditions.ts -- Dynamax state on activation
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive();
+      const side = createMockSide();
+      const state = createMockState();
+
+      dynamax.activate(pokemon, side, state);
+
+      expect(pokemon.isDynamaxed).toBe(true);
+      expect(pokemon.dynamaxTurnsLeft).toBe(3);
+    });
+
+    it("given a pokemon with dynamaxLevel=10 and 300 max HP, when activating, then HP doubles to 600", () => {
+      // Source: Showdown data/conditions.ts line 771 -- dynamaxLevel 10: ratio = 2.0
+      // floor(300 * 2.0) = 600
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive({ currentHp: 300, dynamaxLevel: 10 });
+      const side = createMockSide();
+      const state = createMockState();
+
+      dynamax.activate(pokemon, side, state);
+
+      expect(pokemon.pokemon.calculatedStats!.hp).toBe(600);
+      expect(pokemon.pokemon.currentHp).toBe(600);
+    });
+
+    it("given a pokemon with dynamaxLevel=0 and 300 max HP/200 current HP, when activating, then scales HP by 1.5x", () => {
+      // Source: Showdown data/conditions.ts line 771 -- dynamaxLevel 0: ratio = 1.5
+      // maxHp: floor(300 * 1.5) = 450, currentHp: floor(200 * 1.5) = 300
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive({ currentHp: 200, dynamaxLevel: 0 });
+      const side = createMockSide();
+      const state = createMockState();
+
+      dynamax.activate(pokemon, side, state);
+
+      expect(pokemon.pokemon.calculatedStats!.hp).toBe(450);
+      expect(pokemon.pokemon.currentHp).toBe(300);
+    });
+
+    it("given activation, when checking side state, then side.gimmickUsed is true", () => {
+      // Source: Showdown -- gimmickUsed set on activation
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive();
+      const side = createMockSide();
+      const state = createMockState();
+
+      dynamax.activate(pokemon, side, state);
+
+      expect(side.gimmickUsed).toBe(true);
+    });
+
+    it("given activation, when checking events, then returns DynamaxEvent with correct data", () => {
+      // Source: BattleEvent interface -- dynamax event
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive();
+      const side = createMockSide();
+      const state = createMockState();
+
+      const events = dynamax.activate(pokemon, side, state);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: "dynamax",
+        side: 0,
+        pokemon: "test-pokemon-1",
+      });
+    });
+  });
+
+  describe("Gen8Dynamax.revert", () => {
+    it("given dynamaxed pokemon, when reverting, then sets isDynamaxed=false and dynamaxTurnsLeft=0", () => {
+      // Source: Showdown data/conditions.ts -- Dynamax end
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive({ dynamaxLevel: 10 });
+      const side = createMockSide();
+      const state = createMockState();
+
+      // First activate
+      dynamax.activate(pokemon, side, state);
+      expect(pokemon.isDynamaxed).toBe(true);
+
+      // Then revert
+      dynamax.revert(pokemon, state);
+      expect(pokemon.isDynamaxed).toBe(false);
+      expect(pokemon.dynamaxTurnsLeft).toBe(0);
+    });
+
+    it("given dynamaxed pokemon at full HP with dynamaxLevel=10, when reverting, then restores HP proportionally", () => {
+      // Source: Showdown data/conditions.ts lines 801-802
+      // Activate: maxHp 300 -> 600, currentHp 300 -> 600
+      // Revert: currentHp 600 * (300/600) = 300
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive({ currentHp: 300, dynamaxLevel: 10 });
+      const side = createMockSide();
+      const state = createMockState();
+
+      dynamax.activate(pokemon, side, state);
+      expect(pokemon.pokemon.calculatedStats!.hp).toBe(600);
+      expect(pokemon.pokemon.currentHp).toBe(600);
+
+      dynamax.revert(pokemon, state);
+      expect(pokemon.pokemon.calculatedStats!.hp).toBe(300);
+      expect(pokemon.pokemon.currentHp).toBe(300);
+    });
+
+    it("given dynamaxed pokemon that took damage, when reverting, then restores proportional HP", () => {
+      // Source: Showdown data/conditions.ts lines 801-802
+      // Activate: maxHp 300 -> 600, currentHp 300 -> 600
+      // Take 300 damage -> currentHp = 300 out of 600
+      // Revert: round(300 * 300 / 600) = round(150) = 150
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive({ currentHp: 300, dynamaxLevel: 10 });
+      const side = createMockSide();
+      const state = createMockState();
+
+      dynamax.activate(pokemon, side, state);
+      // Simulate damage
+      pokemon.pokemon.currentHp = 300;
+
+      dynamax.revert(pokemon, state);
+      expect(pokemon.pokemon.calculatedStats!.hp).toBe(300);
+      expect(pokemon.pokemon.currentHp).toBe(150);
+    });
+
+    it("given non-dynamaxed pokemon, when reverting, then returns empty events", () => {
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive();
+      const state = createMockState();
+
+      const events = dynamax.revert(pokemon, state);
+      expect(events).toHaveLength(0);
+    });
+
+    it("given revert, when checking events, then returns DynamaxEndEvent", () => {
+      // Source: BattleEvent interface -- dynamax-end event
+      const dynamax = new Gen8Dynamax();
+      const pokemon = createMockActive({ dynamaxLevel: 10 });
+      const side = createMockSide();
+      const state = createMockState();
+
+      dynamax.activate(pokemon, side, state);
+      const events = dynamax.revert(pokemon, state);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("dynamax-end");
+    });
+  });
+
+  describe("Gen8Dynamax.modifyMove", () => {
+    const dynamax = new Gen8Dynamax();
+
+    const baseMove = {
+      id: "flamethrower",
+      displayName: "Flamethrower",
+      type: "fire" as const,
+      category: "special" as const,
+      power: 90,
+      accuracy: 100,
+      pp: 15,
+      priority: 0,
+      target: "adjacent-foe" as const,
+      flags: {
+        contact: false,
+        sound: false,
+        bullet: false,
+        pulse: false,
+        punch: false,
+        bite: false,
+        wind: false,
+        slicing: false,
+        powder: false,
+        protect: true,
+        mirror: true,
+        snatch: false,
+        gravity: false,
+        defrost: false,
+        recharge: false,
+        charge: false,
+        bypassSubstitute: false,
+      },
+      effect: null,
+      description: "test",
+      generation: 1 as const,
+    };
+
+    it("given non-dynamaxed pokemon, when modifying move, then returns move unchanged", () => {
+      const pokemon = createMockActive();
+      const result = dynamax.modifyMove(baseMove, pokemon);
+      expect(result).toBe(baseMove); // Same reference
+    });
+
+    it("given dynamaxed pokemon with damage move, when modifying, then converts to Max Move with scaled power", () => {
+      // Source: Showdown sim/battle-actions.ts -- damage moves become Max Moves
+      // Fire + BP 90 -> Max Flare with BP 125 (standard table: 85-90 -> 125)
+      const pokemon = createMockActive({}, { isDynamaxed: true });
+      const result = dynamax.modifyMove(baseMove, pokemon);
+
+      expect(result.displayName).toBe("Max Flare");
+      expect(result.power).toBe(125);
+      expect(result.accuracy).toBeNull();
+    });
+
+    it("given dynamaxed pokemon with status move, when modifying, then converts to Max Guard", () => {
+      // Source: Showdown sim/battle-actions.ts -- status moves become Max Guard
+      const statusMove = {
+        ...baseMove,
+        id: "toxic",
+        displayName: "Toxic",
+        category: "status" as const,
+        power: null,
+      };
+      const pokemon = createMockActive({}, { isDynamaxed: true });
+      const result = dynamax.modifyMove(statusMove, pokemon);
+
+      expect(result.displayName).toBe("Max Guard");
+      expect(result.id).toBe("max-guard");
+    });
+  });
+});

--- a/packages/gen8/tests/gmax-moves.test.ts
+++ b/packages/gen8/tests/gmax-moves.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GMAX_MOVES,
+  getGMaxMove,
+  getGMaxMoveEffect,
+  isGigantamaxEligible,
+} from "../src/Gen8GMaxMoves.js";
+
+describe("Gen8GMaxMoves", () => {
+  describe("GMAX_MOVES table", () => {
+    it("given the GMAX_MOVES table, when counting entries, then has exactly 32 entries", () => {
+      // Source: Showdown data/moves.ts lines 6955-7760 -- 32 G-Max moves total
+      expect(Object.keys(GMAX_MOVES).length).toBe(32);
+    });
+
+    it("given GMAX_MOVES, when checking all entries, then each has species, moveType, and effect", () => {
+      // Source: Showdown data/moves.ts -- all G-Max entries have these fields
+      for (const [id, data] of Object.entries(GMAX_MOVES)) {
+        expect(data.species, `${id} missing species`).toBeTruthy();
+        expect(data.moveType, `${id} missing moveType`).toBeTruthy();
+        expect(data.effect, `${id} missing effect`).toBeTruthy();
+      }
+    });
+  });
+
+  describe("getGMaxMove", () => {
+    it("given Charizard species name, when looking up G-Max move, then returns G-Max Wildfire (Fire type)", () => {
+      // Source: Showdown data/moves.ts -- gmaxWildfire for Charizard
+      const result = getGMaxMove("Charizard");
+      expect(result).not.toBeNull();
+      expect(result!.species).toBe("Charizard");
+      expect(result!.moveType).toBe("fire");
+      expect(result!.effect.type).toBe("residual");
+    });
+
+    it("given Pikachu species name, when looking up G-Max move, then returns G-Max Volt Crash (Electric)", () => {
+      // Source: Showdown data/moves.ts -- gmaxVoltCrash for Pikachu
+      const result = getGMaxMove("Pikachu");
+      expect(result).not.toBeNull();
+      expect(result!.species).toBe("Pikachu");
+      expect(result!.moveType).toBe("electric");
+      expect(result!.effect.type).toBe("status");
+    });
+
+    it("given species name in lowercase, when looking up G-Max move, then finds it case-insensitively", () => {
+      // Source: Implementation -- species lookup is case-insensitive
+      const result = getGMaxMove("charizard");
+      expect(result).not.toBeNull();
+      expect(result!.species).toBe("Charizard");
+    });
+
+    it("given non-Gigantamax species name, when looking up G-Max move, then returns null", () => {
+      const result = getGMaxMove("Magikarp");
+      expect(result).toBeNull();
+    });
+
+    it("given numeric species ID, when looking up G-Max move, then returns null (requires name resolution)", () => {
+      // Numeric IDs require data lookup not available in this module
+      const result = getGMaxMove(6); // Charizard's ID
+      expect(result).toBeNull();
+    });
+
+    it("given Rillaboom species, when looking up G-Max move, then returns 160 base power override", () => {
+      // Source: Showdown data/moves.ts -- G-Max Drum Solo has basePower: 160
+      const result = getGMaxMove("Rillaboom");
+      expect(result).not.toBeNull();
+      expect(result!.basePower).toBe(160);
+      expect(result!.effect.type).toBe("ignore-ability");
+    });
+  });
+
+  describe("getGMaxMoveEffect", () => {
+    it("given gmax-steelsurge ID, when looking up effect, then returns Steel type with hazard effect", () => {
+      // Source: Showdown data/moves.ts -- gmaxSteelsurge sets Steel-type hazard
+      const result = getGMaxMoveEffect("gmax-steelsurge");
+      expect(result).not.toBeNull();
+      expect(result!.moveType).toBe("steel");
+      expect(result!.effect).toEqual({ type: "hazard", hazard: "gmax-steelsurge" });
+    });
+
+    it("given gmax-wildfire ID, when looking up effect, then returns residual damage with fire immunity", () => {
+      // Source: Showdown data/moves.ts -- gmaxWildfire: 1/6 residual, 4 turns, fire immune
+      const result = getGMaxMoveEffect("gmax-wildfire");
+      expect(result).not.toBeNull();
+      expect(result!.effect).toEqual({
+        type: "residual",
+        duration: 4,
+        damage: "1/6",
+        immunity: ["fire"],
+      });
+    });
+
+    it("given nonexistent move ID, when looking up effect, then returns null", () => {
+      const result = getGMaxMoveEffect("gmax-nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("given gmax-resonance ID, when looking up effect, then returns aurora-veil side condition", () => {
+      // Source: Showdown data/moves.ts -- gmaxResonance sets Aurora Veil
+      const result = getGMaxMoveEffect("gmax-resonance");
+      expect(result).not.toBeNull();
+      expect(result!.species).toBe("Lapras");
+      expect(result!.effect).toEqual({ type: "side-condition", condition: "aurora-veil" });
+    });
+  });
+
+  describe("isGigantamaxEligible", () => {
+    it("given species with gigantamaxForm data, when checking eligibility, then returns true", () => {
+      // Source: Game mechanic -- species with Gigantamax data can G-Max
+      const species = {
+        gigantamaxForm: {
+          gMaxMove: { type: "fire", name: "G-Max Wildfire", basePower: 160, effect: "residual" },
+        },
+      };
+      expect(isGigantamaxEligible(species)).toBe(true);
+    });
+
+    it("given species without gigantamaxForm data, when checking eligibility, then returns false", () => {
+      // Source: Game mechanic -- species without Gigantamax data cannot G-Max
+      const species = {};
+      expect(isGigantamaxEligible(species)).toBe(false);
+    });
+
+    it("given species with null gigantamaxForm, when checking eligibility, then returns false", () => {
+      const species = { gigantamaxForm: null };
+      expect(isGigantamaxEligible(species)).toBe(false);
+    });
+
+    it("given species with undefined gigantamaxForm, when checking eligibility, then returns false", () => {
+      const species = { gigantamaxForm: undefined };
+      expect(isGigantamaxEligible(species)).toBe(false);
+    });
+  });
+});

--- a/packages/gen8/tests/max-moves.test.ts
+++ b/packages/gen8/tests/max-moves.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getMaxMoveName,
+  getMaxMovePower,
+  getMaxMoveSecondaryEffect,
+  isMaxGuard,
+} from "../src/Gen8MaxMoves.js";
+
+describe("Gen8MaxMoves", () => {
+  describe("getMaxMoveName", () => {
+    it("given fire type damage move, when getting Max Move name, then returns Max Flare", () => {
+      // Source: Showdown sim/battle-actions.ts line 12 -- Fire -> Max Flare
+      const result = getMaxMoveName("fire", false);
+      expect(result).toBe("Max Flare");
+    });
+
+    it("given electric type damage move, when getting Max Move name, then returns Max Lightning", () => {
+      // Source: Showdown sim/battle-actions.ts line 14 -- Electric -> Max Lightning
+      const result = getMaxMoveName("electric", false);
+      expect(result).toBe("Max Lightning");
+    });
+
+    it("given normal type damage move, when getting Max Move name, then returns Max Strike", () => {
+      // Source: Showdown sim/battle-actions.ts line 9 -- Normal -> Max Strike
+      const result = getMaxMoveName("normal", false);
+      expect(result).toBe("Max Strike");
+    });
+
+    it("given flying type damage move, when getting Max Move name, then returns Max Airstream", () => {
+      // Source: Showdown sim/battle-actions.ts line 20 -- Flying -> Max Airstream
+      const result = getMaxMoveName("flying", false);
+      expect(result).toBe("Max Airstream");
+    });
+
+    it("given any type status move, when getting Max Move name, then returns Max Guard", () => {
+      // Source: Showdown sim/battle-actions.ts -- status moves always become Max Guard
+      expect(getMaxMoveName("fire", true)).toBe("Max Guard");
+      expect(getMaxMoveName("normal", true)).toBe("Max Guard");
+      expect(getMaxMoveName("psychic", true)).toBe("Max Guard");
+    });
+
+    it("given all 18 types, when getting Max Move name for damage moves, then returns unique names", () => {
+      // Source: Showdown sim/battle-actions.ts lines 9-29 -- one Max Move per type
+      const types = [
+        "normal",
+        "fire",
+        "water",
+        "electric",
+        "grass",
+        "ice",
+        "fighting",
+        "poison",
+        "ground",
+        "flying",
+        "psychic",
+        "bug",
+        "rock",
+        "ghost",
+        "dragon",
+        "dark",
+        "steel",
+        "fairy",
+      ] as const;
+      const names = types.map((t) => getMaxMoveName(t, false));
+      const uniqueNames = new Set(names);
+      expect(uniqueNames.size).toBe(18);
+    });
+  });
+
+  describe("getMaxMovePower", () => {
+    it("given Normal type move with BP 100, when converting to Max Move, then returns 130", () => {
+      // Source: Showdown data/moves.ts -- standard table: 95-100 -> 130
+      const result = getMaxMovePower(100, "normal");
+      expect(result).toBe(130);
+    });
+
+    it("given Fire type move with BP 90, when converting to Max Move, then returns 125", () => {
+      // Source: Showdown data/moves.ts -- standard table: 85-90 -> 125
+      const result = getMaxMovePower(90, "fire");
+      expect(result).toBe(125);
+    });
+
+    it("given Fighting type move with BP 100, when converting to Max Move, then returns 100", () => {
+      // Source: Showdown data/moves.ts -- Poison/Fighting table: 95-100 -> 100
+      const result = getMaxMovePower(100, "fighting");
+      expect(result).toBe(100);
+    });
+
+    it("given Poison type move with BP 100, when converting to Max Move, then returns 100", () => {
+      // Source: Showdown data/moves.ts -- Poison/Fighting table: 95-100 -> 100
+      const result = getMaxMovePower(100, "poison");
+      expect(result).toBe(100);
+    });
+
+    it("given status move (BP 0), when converting to Max Move, then returns 0", () => {
+      // Source: Showdown sim/battle-actions.ts -- status moves become Max Guard with BP 0
+      const result = getMaxMovePower(0, "ghost");
+      expect(result).toBe(0);
+    });
+
+    it("given very low BP (30) Normal type, when converting, then returns 90", () => {
+      // Source: Showdown data/moves.ts -- standard table: 0-40 -> 90
+      const result = getMaxMovePower(30, "normal");
+      expect(result).toBe(90);
+    });
+
+    it("given very low BP (30) Fighting type, when converting, then returns 70", () => {
+      // Source: Showdown data/moves.ts -- Poison/Fighting table: 0-40 -> 70
+      const result = getMaxMovePower(30, "fighting");
+      expect(result).toBe(70);
+    });
+
+    it("given very high BP (200) standard type, when converting, then caps at 150", () => {
+      // Source: Showdown data/moves.ts -- standard table caps at 150
+      const result = getMaxMovePower(200, "dragon");
+      expect(result).toBe(150);
+    });
+
+    it("given very high BP (200) Fighting type, when converting, then caps at 130", () => {
+      // Source: Showdown data/moves.ts -- Poison/Fighting table caps at 130
+      const result = getMaxMovePower(200, "fighting");
+      expect(result).toBe(130);
+    });
+
+    it("given BP 60 Water type, when converting, then returns 110", () => {
+      // Source: Showdown data/moves.ts -- standard table: 55-60 -> 110
+      const result = getMaxMovePower(60, "water");
+      expect(result).toBe(110);
+    });
+
+    it("given BP 120 Ice type, when converting, then returns 140", () => {
+      // Source: Showdown data/moves.ts -- standard table: 115-120 -> 140
+      const result = getMaxMovePower(120, "ice");
+      expect(result).toBe(140);
+    });
+  });
+
+  describe("getMaxMoveSecondaryEffect", () => {
+    it("given Max Airstream, when getting secondary effect, then returns +1 Speed user-side", () => {
+      // Source: Bulbapedia "Max Airstream" -- raises Speed by 1 for user's side
+      const effect = getMaxMoveSecondaryEffect("Max Airstream");
+      expect(effect).toEqual({
+        type: "stat-boost",
+        stat: "speed",
+        stages: 1,
+        target: "user-side",
+      });
+    });
+
+    it("given Max Flare, when getting secondary effect, then returns weather sun", () => {
+      // Source: Bulbapedia "Max Flare" -- sets harsh sun for 5 turns
+      const effect = getMaxMoveSecondaryEffect("Max Flare");
+      expect(effect).toEqual({ type: "weather", weather: "sun" });
+    });
+
+    it("given Max Lightning, when getting secondary effect, then returns terrain electric", () => {
+      // Source: Bulbapedia "Max Lightning" -- sets Electric Terrain for 5 turns
+      const effect = getMaxMoveSecondaryEffect("Max Lightning");
+      expect(effect).toEqual({ type: "terrain", terrain: "electric" });
+    });
+
+    it("given Max Guard, when getting secondary effect, then returns protect", () => {
+      // Source: Bulbapedia "Max Guard" -- blocks all moves
+      const effect = getMaxMoveSecondaryEffect("Max Guard");
+      expect(effect).toEqual({ type: "protect" });
+    });
+
+    it("given Max Darkness, when getting secondary effect, then returns -1 SpDef opponent-side", () => {
+      // Source: Bulbapedia "Max Darkness" -- lowers SpDef by 1 for opponent's side
+      const effect = getMaxMoveSecondaryEffect("Max Darkness");
+      expect(effect).toEqual({
+        type: "stat-boost",
+        stat: "spDefense",
+        stages: -1,
+        target: "opponent-side",
+      });
+    });
+
+    it("given Max Phantasm, when getting secondary effect, then returns -1 Def opponent", () => {
+      // Source: Bulbapedia "Max Phantasm" -- lowers Def by 1 for opponent
+      const effect = getMaxMoveSecondaryEffect("Max Phantasm");
+      expect(effect).toEqual({
+        type: "stat-boost",
+        stat: "defense",
+        stages: -1,
+        target: "opponent",
+      });
+    });
+
+    it("given unknown move name, when getting secondary effect, then returns null", () => {
+      const effect = getMaxMoveSecondaryEffect("Not A Real Move");
+      expect(effect).toBeNull();
+    });
+
+    it("given Max Starfall, when getting secondary effect, then returns terrain misty", () => {
+      // Source: Bulbapedia "Max Starfall" -- sets Misty Terrain
+      const effect = getMaxMoveSecondaryEffect("Max Starfall");
+      expect(effect).toEqual({ type: "terrain", terrain: "misty" });
+    });
+  });
+
+  describe("isMaxGuard", () => {
+    it("given status category move, when checking isMaxGuard, then returns true", () => {
+      // Source: Showdown sim/battle-actions.ts -- status moves become Max Guard
+      expect(isMaxGuard({ category: "status" })).toBe(true);
+    });
+
+    it("given physical category move, when checking isMaxGuard, then returns false", () => {
+      expect(isMaxGuard({ category: "physical" })).toBe(false);
+    });
+
+    it("given special category move, when checking isMaxGuard, then returns false", () => {
+      expect(isMaxGuard({ category: "special" })).toBe(false);
+    });
+  });
+});

--- a/packages/gen8/tests/ruleset.test.ts
+++ b/packages/gen8/tests/ruleset.test.ts
@@ -104,10 +104,13 @@ describe("Gen8Ruleset -- getBattleGimmick", () => {
     expect(ruleset.getBattleGimmick("zmove")).toBeNull();
   });
 
-  it("given getBattleGimmick('dynamax'), then returns null (stub until Wave 8)", () => {
-    // Dynamax will be implemented in Wave 8
-    // For now, returns null as a placeholder
-    expect(ruleset.getBattleGimmick("dynamax")).toBeNull();
+  it("given getBattleGimmick('dynamax'), then returns Gen8Dynamax gimmick", () => {
+    // Source: Bulbapedia -- Dynamax is the Gen 8 battle gimmick
+    // Source: Showdown data/conditions.ts -- Dynamax condition
+    const gimmick = ruleset.getBattleGimmick("dynamax");
+    expect(gimmick).not.toBeNull();
+    expect(gimmick!.name).toBe("Dynamax");
+    expect(gimmick!.generations).toEqual([8]);
   });
 
   it("given getBattleGimmick('tera'), then returns null (Tera is Gen 9 only)", () => {


### PR DESCRIPTION
## Summary

- Implements the Gen 8 Dynamax/Gigantamax battle gimmick via the `BattleGimmick` interface
- `Gen8MaxMoves.ts`: Type-to-Max-Move name table (all 18 types), base power conversion (standard + Poison/Fighting tables), secondary effect descriptors (stat boosts, weather, terrain, protect)
- `Gen8GMaxMoves.ts`: All 32 G-Max moves with species associations, types, and unique effects (residual damage, hazards, status infliction, ability ignore, etc.)
- `Gen8Dynamax.ts`: Full `BattleGimmick` implementation -- HP scaling by Dynamax Level (0-10, 1.5x-2.0x), 3-turn duration, species immunity (Zacian/Zamazenta/Eternatus), move conversion to Max/G-Max Moves, proportional HP restoration on revert
- `Gen8Ruleset.ts`: `getBattleGimmick("dynamax")` now returns `Gen8Dynamax` instead of null
- 77 new tests covering HP formulas, power conversion tables, canUse conditions, activate/revert state mutations, move modification, and G-Max move lookups

## Test plan

- [x] `getDynamaxMaxHp` returns correct values for dynamaxLevel 0, 5, and 10
- [x] `getDynamaxCurrentHp` scales current HP proportionally
- [x] `getUndynamaxedHp` restores HP proportionally on revert (including edge cases)
- [x] `getMaxMovePower` uses standard table for non-Fighting/Poison types
- [x] `getMaxMovePower` uses Poison/Fighting table for those types
- [x] All 18 Max Move names are correct and unique
- [x] Max Move secondary effects match Showdown/Bulbapedia
- [x] GMAX_MOVES table has exactly 32 entries
- [x] `canUse` blocks immune species (888, 889, 890), already-dynamaxed, and gimmick-used
- [x] `activate` sets isDynamaxed, dynamaxTurnsLeft=3, scales HP, sets gimmickUsed
- [x] `revert` clears state and restores HP proportionally
- [x] `modifyMove` converts damage moves to Max Moves and status moves to Max Guard
- [x] All 555 existing gen8 tests still pass

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented Wave 8 Dynamax gimmick with complete battle mechanics: damage moves transform into Max Moves with scaled power and modified accuracy, eligible species can use species-specific G-Max moves, Pokémon HP scales during Dynamax activation, and the effect lasts 3 turns. Certain species are immune to Dynamaxing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->