### PR TITLE
docs: enforce comment-reply requirement and bug validation protocol

### DIFF
--- a/.claude/rules/pr-comment-handling.md
+++ b/.claude/rules/pr-comment-handling.md
@@ -33,8 +33,34 @@ If blocked, run `/babysit-pr <number>` — it handles all of this automatically.
 
 Nitpicks do not require code changes, but they do require a reply. Ignoring them entirely is not acceptable.
 
+## Bug Validation Protocol (REQUIRED before acting on any bug report)
+
+Before fixing a reviewer-reported bug, **always validate it exists in the current code**:
+
+```bash
+grep -n "functionName\|relevant-symbol" packages/genN/src/TheFile.ts
+```
+
+Reviewer tools (CodeRabbit, Qodo) analyze the first commit of the PR. If a later fix commit already corrected the issue, the comment is stale — do NOT re-fix. Instead:
+1. Confirm the fix exists in the current code (grep, read the file)
+2. Reply citing the commit that fixed it
+3. Resolve the thread
+
+If the bug IS real in the current code:
+1. Fix it in a new commit
+2. Reply citing the fix commit
+3. If the fix is out of scope for the PR, file a GitHub issue (`gh issue create`) and reply with the issue number
+
+## Out-of-Scope Bugs
+
+Never ignore a real bug just because it's outside the current PR's scope. Either:
+- Fix it in the current PR (if small and related) and reply confirming fix
+- File a GitHub issue and reply: "Valid bug. Filed as #N for follow-up — out of scope for this PR."
+
 ## Never
 
 - Merge a PR without reading review comments
 - Use `gh pr merge` directly — use `/babysit-pr` instead
 - Leave CodeRabbit/Qodo threads with zero replies regardless of whether you agree or disagree
+- Assume a reviewer-reported bug is real without checking the current code — AI reviewers can analyze stale commits
+- File a GitHub issue for a bug that is already fixed in the current code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,8 @@ Effort is session-wide (no per-agent control). Default: `high` (set in `~/.claud
 - **Always use `/babysit-pr <number>` after creating a PR** — mandatory. This is the ONLY sanctioned way to monitor, address comments, and merge. Do NOT run `gh pr merge` directly — the comment gate hook will block it if review threads haven't been acknowledged.
 - **`/babysit-pr` auto-merges by default** and self-polls until complete — no `/loop` wrapper needed. Use `--no-merge` to require confirmation before merging.
 - **Comment gate enforced by hook**: `enforce-comment-gate.sh` blocks `gh pr merge` if any unresolved review thread has zero replies. Every thread (CodeRabbit, Qodo, human) needs at minimum a reply before merge. See `.claude/rules/pr-comment-handling.md`.
+- **HARD RULE — No comment may be ignored**: Every inline review comment must get a reply. Options: (1) fix the code and reply citing the commit, (2) reply explaining why the report is incorrect citing source authority, (3) reply that it's a real bug out of scope and file a GitHub issue with the issue number. There is no fourth option. A comment without a reply is a blocker — you cannot proceed to merge.
+- **Validate bugs before acting**: AI reviewers (CodeRabbit, Qodo) analyze the first commit. If a later fix already addressed the issue, grep/read the current code to confirm, then reply citing the fix commit. Never re-implement a fix that is already in the code, and never file a GitHub issue for a bug that no longer exists.
 - **Act autonomously.** When handling a PR, agents should:
   - Push fixes for reviewer feedback without asking permission
   - Fix CI/lint/test failures independently


### PR DESCRIPTION
## Summary

- Every inline PR review comment must now receive a reply (added to CLAUDE.md as a HARD RULE)
- Added Bug Validation Protocol to `.claude/rules/pr-comment-handling.md` — agents must grep/read current code to confirm a reported bug still exists before acting (AI reviewers analyze the first commit, not the latest)
- Added Out-of-Scope Bug guidance — file a GitHub issue and reply with the issue number rather than ignoring

## Motivation

PR #728 babysitting revealed that 4 Qodo bug comments (Shed Tail, Population Bomb, Rage Fist, Last Respects) had no replies despite all 4 bugs being already fixed in later commits. The comment gate blocked merge unnecessarily, and agents need explicit rules to prevent this pattern.

## Test plan
- [ ] Docs-only change — no code to test
- [ ] Verify CLAUDE.md and rules file render correctly

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal PR review workflow documentation and bug validation protocols.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal development process documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->