### PR TITLE
refactor(battle): extract Struggle MoveData to module constant

### DIFF
--- a/.changeset/struggle-move-data.md
+++ b/.changeset/struggle-move-data.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/battle": patch
+---
+
+Extract inline Struggle MoveData to named module constant

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -29,6 +29,47 @@ import {
 const SLEEP_USABLE_MOVES: ReadonlySet<string> = new Set(["sleep-talk", "snore"]);
 
 /**
+ * Struggle move data used when a Pokemon has no usable moves.
+ * Extracted as a module constant to avoid reconstructing the object every turn.
+ * Source: pokered — Struggle is a Normal/Physical move with 50 power, 100% accuracy,
+ * and contact flag. Generation field is set to 1 (earliest gen) since the engine
+ * passes this to the ruleset which handles gen-specific Struggle behavior.
+ */
+const STRUGGLE_MOVE_DATA: MoveData = {
+  id: "struggle",
+  displayName: "Struggle",
+  type: "normal",
+  category: "physical",
+  power: 50,
+  accuracy: 100,
+  pp: 1,
+  priority: 0,
+  target: "adjacent-foe",
+  flags: {
+    contact: true,
+    sound: false,
+    bullet: false,
+    pulse: false,
+    punch: false,
+    bite: false,
+    wind: false,
+    slicing: false,
+    powder: false,
+    protect: false,
+    mirror: false,
+    snatch: false,
+    gravity: false,
+    defrost: false,
+    recharge: false,
+    charge: false,
+    bypassSubstitute: false,
+  },
+  effect: null,
+  description: "Struggle",
+  generation: 1,
+};
+
+/**
  * The core battle engine. Manages the battle state machine, delegates
  * generation-specific behavior to the provided ruleset, and emits
  * a stream of BattleEvents for UI/logging consumers.
@@ -2313,45 +2354,11 @@ export class BattleEngine implements BattleEventEmitter {
 
     // Source: pokered — Struggle goes through the normal accuracy check (including 1/256 miss bug).
     // Gen 1 Struggle has 100% accuracy but is still subject to accuracy/evasion modifiers.
-    // Build a minimal Struggle MoveData for the accuracy check.
-    const struggleMoveData: import("@pokemon-lib-ts/core").MoveData = {
-      id: "struggle",
-      displayName: "Struggle",
-      type: "normal",
-      category: "physical",
-      power: 50,
-      accuracy: 100,
-      pp: 1,
-      priority: 0,
-      target: "adjacent-foe",
-      flags: {
-        contact: true,
-        sound: false,
-        bullet: false,
-        pulse: false,
-        punch: false,
-        bite: false,
-        wind: false,
-        slicing: false,
-        powder: false,
-        protect: false,
-        mirror: false,
-        snatch: false,
-        gravity: false,
-        defrost: false,
-        recharge: false,
-        charge: false,
-        bypassSubstitute: false,
-      },
-      effect: null,
-      description: "Struggle",
-      generation: 1,
-    };
     if (
       !this.ruleset.doesMoveHit({
         attacker: actor,
         defender,
-        move: struggleMoveData,
+        move: STRUGGLE_MOVE_DATA,
         state: this.state,
         rng: this.state.rng,
       })


### PR DESCRIPTION
## Summary
- Extracts inline Struggle `MoveData` construction in `BattleEngine.executeStruggle()` to a named module constant `STRUGGLE_MOVE_DATA`
- No behavioral change -- avoids reconstructing the 15+ field object on every Struggle execution

## Test plan
- [x] All 552 battle tests pass
- [x] TypeScript compiles clean (`@pokemon-lib-ts/battle` typecheck passes)
- [x] Biome lint clean

Closes #781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized battle engine's Struggle move data handling to reduce redundant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->