### PR TITLE
docs: add battle extension specs

### DIFF
--- a/specs/battle/11-custom-ruleset.md
+++ b/specs/battle/11-custom-ruleset.md
@@ -1,0 +1,430 @@
+# Custom Ruleset System
+
+## Overview
+
+`CustomRuleset` is a configuration-driven wrapper class that lives in `@pokemon-lib-ts/battle`. It wraps any existing gen's `GenerationRuleset` and overrides specific behaviors — gimmick availability and use policy, ban lists, competitive clauses, and mechanical subsystem swaps. The result implements `GenerationRuleset` and plugs directly into `BattleEngine` unchanged.
+
+This is the foundation for TPPC custom battle formats, Battle Tower rulesets, and any consumer that wants to run a non-standard format.
+
+## Design Decisions
+
+Three design patterns were evaluated before settling on this approach. See the decision log at the end of this document.
+
+## Consumer API
+
+```typescript
+import { CustomRuleset } from '@pokemon-lib-ts/battle';
+import { Gen9Ruleset } from '@pokemon-lib-ts/gen9';
+import { Gen7MegaEvolution } from '@pokemon-lib-ts/gen7';
+
+// Minimal: just ban some items
+const ruleset = new CustomRuleset({
+  base: new Gen9Ruleset(dataManager),
+  bans: { items: ['soul-dew', 'kings-rock'] },
+});
+
+// Full: mix gimmicks + clauses + bans + mechanic overrides
+const ruleset = new CustomRuleset({
+  base: new Gen9Ruleset(dataManager),
+  name: 'TPPC Battle Tower',
+  gimmicks: {
+    available: {
+      tera: true,                    // use Gen 9's Terastallization as-is
+      mega: new Gen7MegaEvolution(), // bring in Gen 7's Mega Evolution
+    },
+    usePolicy: 'one-per-type',       // each gimmick type can be used once per side
+  },
+  bans: {
+    species: ['arceus', 'mewtwo'],
+    items: ['soul-dew'],
+    moves: ['double-team', 'minimize'],
+    abilities: ['moody'],
+  },
+  clauses: [
+    { type: 'sleep', maxPerSide: 1 },
+    { type: 'species' },
+    { type: 'item' },
+    { type: 'level-cap', maxLevel: 50 },
+    { type: 'evasion' },
+  ],
+  mechanics: {
+    leafOverrides: {
+      critMultiplier: 2.0,     // restore Gen 5 crit damage
+    },
+  },
+});
+
+// Validate teams before battle start
+const p1Result = ruleset.validateTeam(team1);
+const p2Result = ruleset.validateTeam(team2);
+if (!p1Result.valid || !p2Result.valid) { /* handle */ }
+
+// Drop into BattleEngine exactly like any other ruleset
+const engine = new BattleEngine(config, ruleset, dataManager);
+engine.start();
+```
+
+## Configuration Types
+
+### `CustomRulesetConfig`
+
+```typescript
+interface CustomRulesetConfig {
+  /** The base generation ruleset. All unmodified behavior delegates here. */
+  readonly base: GenerationRuleset;
+  /** Override the generation identifier (e.g., for display). Defaults to base.generation. */
+  readonly generation?: Generation;
+  /** Override the ruleset name. Defaults to `"Custom (${base.name})"`. */
+  readonly name?: string;
+  /** Gimmick availability and use policy. If omitted, uses base ruleset's gimmicks unchanged. */
+  readonly gimmicks?: GimmickConfig;
+  /** Ban list. Enforced at team validation and at runtime. */
+  readonly bans?: BanListConfig;
+  /** Active competitive clauses. Enforced at team validation and during battle. */
+  readonly clauses?: readonly ClauseConfig[];
+  /** Mechanical subsystem overrides. */
+  readonly mechanics?: MechanicOverrides;
+}
+```
+
+### `GimmickConfig`
+
+```typescript
+type GimmickUsePolicy =
+  | 'one-per-battle'  // One total gimmick activation per side (default)
+  | 'one-per-type'    // Each gimmick type can be used once per side (Gen 7 model)
+  | 'unlimited';      // No usage restrictions
+
+interface GimmickConfig {
+  /**
+   * Which gimmicks are enabled and which implementations to use.
+   *   true         → use the base ruleset's implementation for this type
+   *   BattleGimmick → use this custom implementation
+   *   omitted key  → gimmick is disabled
+   */
+  readonly available: Partial<Record<BattleGimmickType, true | BattleGimmick>>;
+  /** Default: 'one-per-battle'. */
+  readonly usePolicy?: GimmickUsePolicy;
+  /**
+   * Whether a single Pokemon can accumulate multiple gimmick transformations
+   * (e.g., Mega Evolve AND Terastallize the same Pokemon). Default: false.
+   */
+  readonly allowStacking?: boolean;
+}
+```
+
+#### Forward-Only Gimmick Constraint
+
+Gimmicks can only be enabled on base rulesets from their introduction generation or later. The `CustomRuleset` constructor validates this using each `BattleGimmick`'s `generations` field:
+
+| Gimmick | Minimum Base Gen |
+|---------|-----------------|
+| Mega Evolution | Gen 6+ |
+| Z-Moves | Gen 7+ |
+| Dynamax/Gigantamax | Gen 8+ |
+| Terastallization | Gen 9+ |
+
+Attempting to enable a gimmick on a base gen that predates it (e.g., Mega Evolution on a Gen 3 base) throws a construction-time error. This ensures the base ruleset has the required infrastructure (abilities, held items, stat recalc, type chart) that gimmicks depend on.
+
+#### Gimmick Portability
+
+All gimmick implementations were analyzed for cross-gen portability:
+
+| Gimmick | Portability | Notes |
+|---------|------------|-------|
+| `Gen6MegaEvolution` | High | Self-contained `MEGA_STONE_DATA`, uses core `calculateStat` (identical Gen 3-9), no gen-specific damage/type references |
+| `Gen7MegaEvolution` | High | Same as Gen 6 + Rayquaza. Already uses internal `usedBySide` tracking, compatible with multi-gimmick scenarios |
+| `Gen7ZMove` | High | Self-contained power tables (`Z_MOVE_NAMES`, `SPECIES_Z_BASE_MOVES`), `modifyMove` only touches `MoveData` fields |
+| `Gen8Dynamax` | Medium | Self-contained HP scaling and Max Move conversion. Cross-cutting: engine has hardcoded `isDynamaxed` Choice lock check; anti-Dynamax moves live in `Gen8DamageCalc` |
+| `Gen9Terastallization` | High (gimmick) / Low (STAB) | Gimmick class is self-contained. However `calculateTeraStab` is consumed by `Gen9DamageCalc` — any non-Gen-9 base using Tera must integrate STAB calculation into its damage calc |
+
+**Gimmick behavior follows home gen rules.** Gimmick implementations carry their own data tables (`MEGA_STONE_DATA`, `Z_MOVE_NAMES`, `SPECIES_Z_BASE_MOVES`, Max Move power tables, etc.). No cross-gen data merging is needed. Cross-cutting concerns (Tera STAB, anti-Dynamax moves) are handled by the base gen's damage calc hooks.
+
+#### Use Policy Implementation
+
+`CustomRuleset` wraps each enabled `BattleGimmick` in a `PolicyWrappedGimmick` (internal class) that intercepts `canUse()` and `activate()` to enforce the configured policy. This requires zero engine changes.
+
+`PolicyWrappedGimmick` uses internal `usedBySide: Set<0 | 1>` tracking (same pattern as Gen 7's dual-gimmick implementation) and conditionally manages `BattleSide.gimmickUsed` for backward compatibility.
+
+Policy behavior:
+- `'one-per-battle'`: any gimmick activation marks all gimmick types as used for that side
+- `'one-per-type'`: activation marks only the activated gimmick type as used
+- `'unlimited'`: no usage tracking, `canUse()` only checks the gimmick's own preconditions
+
+### `BanListConfig`
+
+```typescript
+interface BanListConfig {
+  readonly items?: readonly string[];
+  readonly moves?: readonly string[];
+  readonly species?: readonly string[];
+  readonly abilities?: readonly string[];
+}
+```
+
+Ban list IDs use the same string format as the gen data files (lowercase hyphenated, e.g., `'soul-dew'`, `'double-team'`, `'arceus'`).
+
+**Enforcement:**
+- **Pre-battle** (team validation): `CustomRuleset.validatePokemon()` extends the base gen's validation to check species, ability, item, and move bans.
+- **Runtime** (during battle): Move bans enforced via `checkMoveRestriction?()` hook (see Engine Changes below).
+
+### `ClauseConfig`
+
+```typescript
+type ClauseConfig =
+  | { readonly type: 'sleep'; readonly maxPerSide: number }
+  | { readonly type: 'species' }
+  | { readonly type: 'item' }
+  | { readonly type: 'level-cap'; readonly maxLevel: number }
+  | { readonly type: 'evasion' }
+  | { readonly type: 'ohko' }
+  | { readonly type: 'endless-battle' }
+  | {
+      readonly type: 'custom';
+      readonly id: string;
+      /** Runs at team validation time. */
+      readonly validate?: (teams: [PokemonInstance[], PokemonInstance[]]) => ValidationResult;
+      /** Runs during battle. */
+      readonly enforce?: ClauseEnforcer;
+    };
+
+interface ClauseEnforcer {
+  /** Called when checking if an action can be submitted. Return false to reject. */
+  canSubmitAction?(action: BattleAction, state: BattleState): { allowed: boolean; reason?: string };
+  /** Called before move execution. Return false to block the move. */
+  canExecuteMove?(actor: ActivePokemon, move: MoveData, state: BattleState): { allowed: boolean; reason?: string };
+}
+```
+
+**Built-in clause behavior:**
+
+| Clause | Pre-battle | In-battle |
+|--------|-----------|----------|
+| `sleep` | — | Block sleep-inflicting moves when `maxPerSide` Pokemon already asleep on target's side |
+| `species` | No duplicate species on a team | — |
+| `item` | No duplicate held items on a team | — |
+| `level-cap` | Reject Pokemon above `maxLevel` | — |
+| `evasion` | — | Block moves that unconditionally boost evasion (Double Team, Minimize) |
+| `ohko` | — | Block OHKO moves (Fissure, Guillotine, Horn Drill, Sheer Cold) |
+| `endless-battle` | — | Future: detect and terminate infinite loops |
+| `custom` | `validate()` callback | `enforce` callbacks |
+
+### `MechanicOverrides`
+
+```typescript
+interface MechanicOverrides {
+  /**
+   * Swap entire subsystems from another gen's ruleset.
+   * All methods belonging to that sub-interface are sourced from the provided ruleset instance.
+   * That instance's private state and `this` context are preserved.
+   */
+  readonly subsystems?: Partial<Record<SubsystemName, GenerationRuleset>>;
+  /**
+   * Declarative overrides for individual leaf methods.
+   * These are methods with no internal `this` dependencies or `super` calls —
+   * safe to override as pure values.
+   */
+  readonly leafOverrides?: LeafOverrides;
+}
+
+interface LeafOverrides {
+  /** Crit damage multiplier. Gen 3-5: 2.0. Gen 6+: 1.5. */
+  readonly critMultiplier?: number;
+  /** Sleep duration range [min, max] inclusive turns. */
+  readonly sleepTurns?: [min: number, max: number];
+  /** Burn damage as 1/N of max HP per turn. Gen 1-5: 8 (1/8). Gen 6+: 16 (1/16). */
+  readonly burnDamageFraction?: number;
+  /** Confusion self-hit chance. Gen 1-6: 0.5. Gen 7+: 0.33. */
+  readonly confusionSelfHitChance?: number;
+  /** Protect success decay formula. Default: 'halving' (Gen 3+). */
+  readonly protectStaling?: 'halving' | 'thirding' | 'none';
+}
+
+type SubsystemName =
+  | 'typeSystem'
+  | 'statCalculator'
+  | 'damageSystem'
+  | 'criticalHitSystem'
+  | 'turnOrderSystem'
+  | 'moveSystem'
+  | 'statusSystem'
+  | 'abilitySystem'
+  | 'itemSystem'
+  | 'bagItemSystem'
+  | 'weatherSystem'
+  | 'terrainSystem'
+  | 'hazardSystem'
+  | 'switchSystem'
+  | 'fleeSystem'
+  | 'catchSystem'
+  | 'endOfTurnSystem'
+  | 'validationSystem';
+```
+
+#### Subsystem Swap Safety
+
+**Do not mix methods within a subsystem across different gen instances.** Several subsystems have private state that binds their methods together:
+- `TurnOrderSystem`: `Gen5Ruleset._currentWeather` is set in `resolveTurnOrder` and read in `getEffectiveSpeed`. Splitting these methods across instances breaks Chlorophyll/Swift Swim speed doubling silently.
+- `SwitchSystem`: `Gen9Ruleset._pendingShedTailSub` is set in `onSwitchOut` and read in `onSwitchIn`. Splitting breaks Shed Tail.
+
+Subsystem-level swaps are safe because all methods in a subsystem stay on the same instance, preserving private state and `super` chain.
+
+**High-value subsystem swaps:**
+- `damageSystem` — use Gen 5's damage formula with Gen 9's everything else
+- `typeSystem` — use a custom type chart (add/remove types, change effectiveness)
+- `criticalHitSystem` — change crit frequency and multiplier together
+- `statusSystem` — change status damage rates and duration tables
+- `endOfTurnSystem` — change end-of-turn ordering and Protect staling
+
+**Construction-time diagnostics:** The constructor warns about known-dangerous subsystem swaps, e.g., swapping `typeSystem` from a pre-Gen-6 ruleset onto a Gen 6+ base causes Fairy-type moves to produce undefined behavior.
+
+## Team Validation
+
+`CustomRuleset` adds a `validateTeam()` method (not part of `GenerationRuleset`) for team-level cross-Pokemon checks:
+
+```typescript
+class CustomRuleset implements GenerationRuleset {
+  /** Per-Pokemon validation including ban checks. */
+  validatePokemon(pokemon: PokemonInstance, species: PokemonSpeciesData): ValidationResult;
+
+  /** Team-level validation for clauses that span multiple Pokemon. */
+  validateTeam(team: PokemonInstance[]): ValidationResult;
+}
+```
+
+`validateTeam` checks: Species Clause (no duplicate species IDs), Item Clause (no duplicate held items), Level Cap (all Pokemon below `maxLevel`), and any `custom` clause `validate` callbacks.
+
+## `CustomRuleset` Class Sketch
+
+```typescript
+class CustomRuleset implements GenerationRuleset {
+  readonly generation: Generation;
+  readonly name: string;
+  /** The resolved, frozen config. Readable at runtime for debugging/serialization. */
+  readonly config: Readonly<CustomRulesetConfig>;
+
+  constructor(config: CustomRulesetConfig) { ... }
+
+  // INTERCEPTED: gimmick dispatch with policy wrapping
+  getBattleGimmick(type: BattleGimmickType): BattleGimmick | null { ... }
+
+  // INTERCEPTED: per-Pokemon validation with ban checks
+  validatePokemon(pokemon: PokemonInstance, species: PokemonSpeciesData): ValidationResult { ... }
+
+  // NEW: team-level validation for clauses
+  validateTeam(team: PokemonInstance[]): ValidationResult { ... }
+
+  // INTERCEPTED: move restriction hook (bans + clause enforcers)
+  checkMoveRestriction?(actor: ActivePokemon, move: MoveData, state: BattleState):
+    { allowed: boolean; reason?: string } | undefined { ... }
+
+  // ALL OTHER METHODS: delegate to base (or subsystem override source)
+  getTypeChart() { return this._resolveSubsystem('typeSystem').getTypeChart(); }
+  calculateDamage(ctx) { return this._resolveSubsystem('damageSystem').calculateDamage(ctx); }
+  // ... all ~55 remaining GenerationRuleset methods
+}
+```
+
+Delegation for subsystem overrides:
+```typescript
+private _resolveSubsystem(name: SubsystemName): GenerationRuleset {
+  return this._subsystemOverrides.get(name) ?? this.config.base;
+}
+```
+
+## Engine Changes Required
+
+### 1. `checkMoveRestriction?()` hook on `GenerationRuleset`
+
+Add to `MoveSystem` sub-interface in `GenerationRuleset.ts`:
+
+```typescript
+/** Optional: called to check if a move is restricted under the active format rules.
+ *  Return undefined (or omit the method) to allow all moves.
+ *  Used by CustomRuleset to enforce ban lists and clause enforcers. */
+checkMoveRestriction?(
+  actor: ActivePokemon,
+  move: MoveData,
+  state: BattleState,
+): { readonly allowed: boolean; readonly reason?: string } | undefined;
+```
+
+Add default no-op to `BaseRuleset`:
+```typescript
+checkMoveRestriction?() { return undefined; }
+```
+
+`BattleEngine` calls this in two places:
+1. `getAvailableMoves()` — to filter moves at action selection time
+2. `canExecuteMove()` — as a final check before execution (catches mid-turn restrictions)
+
+### 2. No other engine changes
+
+`BattleConfig` stays unchanged. The Dynamax `!actor.isDynamaxed` Choice lock check at `BattleEngine.ts:1152` is left as-is — it is harmless when Dynamax is disabled (flag is always false) and correct when Dynamax is enabled.
+
+## File Locations
+
+All new code in `packages/battle/src/`:
+
+| File | Changes |
+|------|---------|
+| `ruleset/CustomRuleset.ts` | New file: `CustomRuleset` class + `PolicyWrappedGimmick` internal class |
+| `context/types.ts` | Add: `CustomRulesetConfig`, `GimmickConfig`, `GimmickUsePolicy`, `BanListConfig`, `ClauseConfig`, `ClauseEnforcer`, `MechanicOverrides`, `LeafOverrides`, `SubsystemName` |
+| `ruleset/GenerationRuleset.ts` | Add `checkMoveRestriction?()` to `MoveSystem` sub-interface |
+| `ruleset/BaseRuleset.ts` | Add default no-op for `checkMoveRestriction?()` |
+| `index.ts` | Export `CustomRuleset` + all new config types |
+
+## Tests
+
+### Unit Tests (`packages/battle/tests/CustomRuleset.test.ts`)
+
+- Ban enforcement: item, move, species, ability bans at `validatePokemon()` and `validateTeam()`
+- Each clause: sleep (count tracking), species (dupe detection), item (dupe detection), level-cap, evasion (block Double Team/Minimize), ohko (block Fissure/Guillotine/Horn Drill/Sheer Cold), custom (callbacks invoked)
+- Gimmick policies: one-per-battle, one-per-type, unlimited — verify use tracking
+- Gimmick stacking: `allowStacking: false` blocks a mega-evolved Pokemon from also terastallizing
+- `PolicyWrappedGimmick`: verify internal `usedBySide` tracking with side 0 and side 1 independently
+- Leaf overrides: `critMultiplier`, `sleepTurns`, `burnDamageFraction`, `confusionSelfHitChance`, `protectStaling`
+- Subsystem swap: delegate correct subsystem methods to override source, all other methods to base
+- `validateTeam()`: species clause (reject duplicate species), item clause (reject duplicate items), level cap (reject overlevel)
+- Backward compatibility: existing gen rulesets pass through `new CustomRuleset({ base: genXRuleset })` unchanged
+
+### Integration Tests (`packages/battle/tests/CustomRulesetIntegration.test.ts`)
+
+- Gen 9 base + Mega Evolution (`Gen7MegaEvolution`) + Terastallization, `one-per-type` policy: verify both gimmicks work in the same battle on the same side
+- Gen 9 base + all four gimmicks, `one-per-battle` policy: verify only one gimmick activates per side
+- Gen 9 base + ban list + Sleep Clause: verify banned move blocked at move selection, sleep correctly capped
+- Sub-interface swap: Gen 9 base with `criticalHitSystem` from a Gen 5-equivalent instance returning `getCritMultiplier: () => 2.0` — verify crit deals 2× not 1.5×
+
+## Design Decision Log
+
+### API Pattern
+
+Three patterns were evaluated: Builder, Config Object (factory function), and Decorator/Wrapper Class.
+
+**Builder** was rejected: mutable intermediate state, weak type safety on accumulated config, harder to unit-test individual build steps.
+
+**Config Object** was preferred for ergonomics: full shape validated at call site, serializable, testable as data.
+
+**Wrapper Class** was chosen for its addition of `instanceof` introspection, runtime `ruleset.config` access, and clean delegation structure.
+
+The final design is a **Config Object + Wrapper Class** hybrid.
+
+### Mechanic Override Granularity
+
+Three granularities were evaluated: sub-interface level, method level, layered (both).
+
+**Method level was rejected** due to private state coupling discovered in the implementations:
+- `Gen5Ruleset._currentWeather` is set by `resolveTurnOrder` and read by `getEffectiveSpeed` — splitting these across instances silently breaks speed modifiers
+- `Gen9Ruleset._pendingShedTailSub` is set by `onSwitchOut` and read by `onSwitchIn` — splitting breaks Shed Tail
+- Cross-sub-interface calls (`resolveTurnOrder` → `applyAbility`, `executeMoveEffect` → `rollProtectSuccess`) cause silent semantic errors when methods are split across instances
+- `super` calls resolve at class definition time; method-level overrides cannot redirect them
+
+**Sub-interface level** was chosen because the ISP decomposition already reflects the coupling boundaries. Subsystem swaps preserve all private state and `super` chains within a subsystem.
+
+**Declarative leaf overrides** (a small supplement to sub-interface swaps) cover the most commonly customized individual parameters — these are provably safe because they are pure value returns with no `this` dependencies.
+
+### Gimmick Portability
+
+**Home gen rules** was chosen over "adapt to base gen" or "consumer decides."
+
+Evidence: all gimmick implementations are self-contained data bundles that do not reference gen-specific damage calcs or type charts. The stat recalc formula used by Mega Evolution (`calculateStat` from core) is identical across Gen 3-9. Z-Move power tables and Max Move conversions are generation-invariant. Only Tera's STAB calculation is gen-dependent, and it is handled by the base gen's damage calc, not by the gimmick class itself.

--- a/specs/battle/12-doubles.md
+++ b/specs/battle/12-doubles.md
@@ -1,0 +1,328 @@
+# Doubles Battle Support
+
+## Overview
+
+The battle engine supports singles only. This spec designs doubles support — 2 active Pokemon per side, 4 actions per turn, multi-target move resolution, and doubles-specific mechanics (redirection, ally abilities, screen reduction).
+
+**Scope**: Doubles only. Triples and Rotation battles are deferred to separate specs.
+
+## Current State
+
+### Already doubles-ready (no changes needed)
+
+| Component | Location | Status |
+|-----------|----------|--------|
+| `BattleFormat` type | `BattleState.ts:35` | Includes `"doubles"` |
+| `BattleSide.active` | `BattleSide.ts:26` | `(ActivePokemon \| null)[]` — array, comment says "2 for doubles" |
+| `MoveAction.targetSide/targetSlot` | `BattleAction.ts:33-36` | Fields exist, currently unused |
+| `MoveTarget` type | `move.ts:9-26` | 11 targeting categories covering all doubles scenarios |
+| Move data `target` field | All `moves.json` | Every move carries correct `target` value |
+| Spread move modifier | Gen 5-9 `*DamageCalc.ts` | 0.75x when `format !== "singles"` and target is spread |
+| Quick Guard | Gen 5+ `MoveEffectsField.ts` | Blocks priority > 0 moves |
+| Wide Guard | Gen 5+ `MoveEffectsField.ts` | Blocks spread moves |
+| Mat Block | Gen 8 `MoveEffects.ts` | Blocks damaging moves, first turn only |
+| Crafty Shield | Gen 8 `MoveEffects.ts` | Blocks status moves targeting side |
+| `SwitchInEvent.slot` | `BattleEvent.ts:135` | Already carries slot index |
+| Follow Me / Rage Powder priority | Move data | Correct priority values |
+
+### Must change
+
+| Component | Issue |
+|-----------|-------|
+| `BattleEngine.ts` | 63+ hardcoded `active[0]` references; single-target move execution; 2-action turn resolution; single-slot faint handling; single-slot EoT processing |
+| `BattleAction.ts` | `SwitchAction` lacks `slot` field; all action types need `slot` for which active position is acting |
+| `BaseRuleset.ts` | `resolveTurnOrder()` reads `active[0]` for speed comparison |
+| AI controllers | `RandomAI` hardcoded to `active[0]`, returns 1 action per side |
+| `BattleEvent.ts` | Most events lack `slot` field |
+
+### Not yet implemented (doubles-specific mechanics)
+
+| Mechanic | Notes |
+|----------|-------|
+| Redirection | Follow Me, Rage Powder, Lightning Rod/Storm Drain in doubles |
+| Ally abilities | Plus/Minus (#141), Friend Guard, Battery, Power Spot, Telepathy, Flower Gift |
+| Helping Hand | 1.5x damage boost to ally's next move |
+| Screen reduction | 2/3 in doubles instead of 1/2 in singles |
+| Intimidate (doubles) | Must affect all opponents, not just one |
+| Pledge combos | Grass+Fire/Water Pledge doubles combinations (deferred) |
+
+## Refactoring Strategy
+
+**Incremental helper-method migration.**
+
+A separate `if (format === "doubles")` code path was rejected — it would duplicate ~80% of the turn loop logic, doubling maintenance burden. A massive single refactor of all 63+ sites in a 5400-line file was rejected as unreviewable. Incremental helpers let Phase 0 change zero behavior (all singles tests pass unchanged), then subsequent phases add doubles behavior behind the helpers.
+
+## Phase 0: Foundation Refactor
+
+**Goal**: Replace all `active[0]` references with slot-aware helpers. Zero behavioral change — all 546 existing battle tests must pass unchanged.
+
+### New helper methods on BattleEngine
+
+```typescript
+/** Get the active Pokemon in a specific slot. */
+getActiveSlot(side: 0 | 1, slot: number): ActivePokemon | null
+
+/** Get all living active Pokemon for a side. */
+getAllActive(side: 0 | 1): ActivePokemon[]
+
+/** Get all living active opponents. */
+getOpponents(side: 0 | 1): ActivePokemon[]
+
+/** Get the ally in the other active slot (doubles). */
+getAlly(side: 0 | 1, slot: number): ActivePokemon | null
+
+/** Determine which slot an ActivePokemon occupies. */
+getSlotIndex(side: 0 | 1, active: ActivePokemon): number
+
+/** Iterate all living active Pokemon on both sides. */
+forEachActive(callback: (active: ActivePokemon, side: 0 | 1, slot: number) => void): void
+```
+
+### Migration targets
+
+- `getActive(side)` → calls `getActiveSlot(side, 0)` (kept temporarily as alias)
+- `getOpponentActive(side)` → kept temporarily, callers migrate to `getOpponents()`
+- `getSideIndex(active)` → checks all slots, not just `active[0]`
+- `createSide()` → initializes `active` array with format-based length (1 singles, 2 doubles)
+- All ~15 EoT methods → iterate all active slots instead of `active[0]`
+- `checkMidTurnFaints()` → checks all active slots
+- `needsSwitchPrompt()` → checks all active slots
+- `recordParticipation()` → tracks all active-vs-active pairings
+
+### Files changed
+
+`BattleEngine.ts` only. ~800 lines. Low risk.
+
+## Phase 1: Core Doubles Turn Loop
+
+**Goal**: The engine accepts 2 actions per side, sorts 4 actions by priority, and executes moves with correct targeting.
+
+### Action submission
+
+```typescript
+/** New — accepts array of actions, one per active slot. */
+submitActions(side: 0 | 1, actions: BattleAction[]): void
+
+/** Existing — kept for backwards compat, wraps in single-element array. */
+submitAction(side: 0 | 1, action: BattleAction): void
+```
+
+`pendingActions` changes from `Map<0 | 1, BattleAction>` to `Map<0 | 1, BattleAction[]>`.
+
+Validation: `actions.length` must equal the number of living active Pokemon on that side. Both sides' submissions trigger `resolveTurn()`.
+
+### Add `slot` field to action types
+
+```typescript
+// BattleAction.ts — add to MoveAction, SwitchAction, StruggleAction, RechargeAction
+readonly slot?: number; // which active slot is acting (default 0 for singles)
+```
+
+### Target resolution
+
+New `resolveTargets(action, actor, moveData)` method returns `ActivePokemon[]`:
+
+| `MoveTarget` | Singles | Doubles |
+|-------------|---------|---------|
+| `adjacent-foe` | Single opponent | Target from `targetSide/targetSlot`. Retarget if fainted. |
+| `any` | Single opponent | Target from `targetSide/targetSlot`. Can target ally. |
+| `random-foe` | Single opponent | Random living opponent via RNG |
+| `all-adjacent-foes` | Single opponent | All living opponents |
+| `all-foes` | Single opponent | All living opponents |
+| `all-adjacent` | Single opponent | All living opponents + ally |
+| `adjacent-ally` | — (fails) | The partner in the other slot |
+| `self` | Actor | Actor |
+| `user-and-allies` | Actor | All living Pokemon on actor's side |
+| `user-field` | — (field effect) | — (field effect) |
+| `foe-field` | — (field effect) | — (field effect) |
+| `entire-field` | — (field effect) | — (field effect) |
+
+**Retarget on faint**: If the chosen target fainted mid-turn, auto-retarget to the other opponent slot. If no valid target, move fails.
+
+### Multi-target move execution
+
+`executeMove()` loops over resolved targets. Each target gets its own:
+- Accuracy check
+- Damage calculation (spread modifier already in damage calcs)
+- Effect application
+- Ability/item trigger checks
+
+### Turn order fix
+
+`BaseRuleset.resolveTurnOrder()` reads `active[action.slot ?? 0]` instead of `active[0]` for speed comparison.
+
+### Event updates
+
+Add optional `slot?: number` to: `SwitchOutEvent`, `MoveStartEvent`, `FaintEvent`. Defaults to 0 for backwards compatibility.
+
+### Files changed
+
+`BattleEngine.ts`, `BattleAction.ts`, `BattleEvent.ts`, `BaseRuleset.ts`. ~1100 lines across 2 PRs.
+
+## Phase 2: Faint Handling and Switches
+
+**Goal**: Correct mid-turn faint behavior and post-faint slot replacement.
+
+### Doubles faint rules (Showdown behavior)
+
+- **Mid-turn faint**: Slot becomes null immediately. Partner continues acting.
+- **Replacement timing**: End of turn, after all actions and EoT effects resolve.
+- **Both Pokemon faint**: Battle may end immediately if no reserves.
+- **Replacement order**: Faster Pokemon switches in first (for entry ability trigger order).
+
+### Data structure changes
+
+- `sidesNeedingSwitch`: `Set<0 | 1>` → `Map<0 | 1, number[]>` (side → slot indices needing replacement)
+- `pendingSwitches`: keyed by `"${side}-${slot}"` for per-slot replacement
+
+### API updates
+
+```typescript
+submitSwitch(side: 0 | 1, teamSlot: number, activeSlot?: number): void
+```
+
+`executeSwitch()` uses `action.slot` to switch out the correct active position.
+
+### Self-switch moves
+
+U-turn, Volt Switch, Baton Pass, Shed Tail: the switch-out applies to the specific slot that used the move.
+
+### Files changed
+
+`BattleEngine.ts`. ~400 lines.
+
+## Phase 3: Battle Start and Entry Abilities
+
+**Goal**: Doubles battles correctly send out 2 Pokemon per side at start and fire entry abilities in the right order.
+
+### `start()` method
+
+```typescript
+const slotsToFill = this.state.format === "doubles" ? 2 : 1;
+for (let slot = 0; slot < slotsToFill && slot < side.team.length; slot++) {
+  this.sendOut(side, slot, /* skipAbility */ true, /* activeSlot */ slot);
+}
+// Then fire entry abilities in speed order across all 4 Pokemon
+```
+
+### Entry ability ordering
+
+With 4 Pokemon entering simultaneously, sort by speed for ability trigger order (faster Pokemon's ability fires first). Current code handles 2 — generalize to sort all entering Pokemon.
+
+### Intimidate in doubles
+
+Must fire against all opponents. The engine calls `applyAbility("on-switch-in", ...)` once per opponent and processes each result separately. This avoids changing the `AbilityContext` interface — Intimidate's handler returns a stat drop, the engine applies it to each opponent in sequence.
+
+### Files changed
+
+`BattleEngine.ts`, possibly `context/types.ts`. ~300 lines.
+
+## Phase 4: AI Controller Update
+
+**Goal**: AI controllers produce valid doubles actions.
+
+### Interface addition
+
+```typescript
+/** Returns one BattleAction per active slot. */
+chooseActions(side: 0 | 1, state: BattleState, ruleset: GenerationRuleset, rng: SeededRandom): BattleAction[]
+
+/** Updated: forSlot parameter indicates which slot needs replacement. */
+chooseSwitchIn(side: 0 | 1, state: BattleState, forSlot?: number): number
+```
+
+### RandomAI update
+
+- Iterate all active slots on the side
+- For each slot: pick random move, assign target based on `MoveTarget` type
+- Single-target moves: pick random living opponent slot
+- Self/ally/field moves: no target selection
+- Switch targets: exclude Pokemon already active in other slots
+- Include `slot`, `targetSide`, `targetSlot` in `MoveAction`
+
+### Files changed
+
+`AIController.ts`, `RandomAI.ts`. ~200 lines.
+
+## Phase 5: Doubles-Specific Mechanics
+
+**Goal**: Implement mechanics that only apply or behave differently in doubles.
+
+### Redirection
+
+**Follow Me / Rage Powder**: Before target resolution, check for redirection volatiles on opponents. Single-target moves are redirected to the Pokemon with the volatile.
+- Rage Powder: blocked by Safety Goggles, Overcoat, and Grass-types
+- Implementation: `resolveTargets()` checks for redirection as a pre-pass
+
+**Lightning Rod / Storm Drain (doubles)**: Redirect Electric/Water single-target moves to the ability holder (including ally moves). Already implemented as abilities in singles (immunity + stat boost), but doubles redirection is new behavior.
+
+### Screen reduction in doubles
+
+Reflect/Light Screen reduce by 2/3 (~0.66x) in doubles instead of 1/2 (0.5x) in singles. Damage calc screen modifier code needs a `format` check. Currently hardcoded to `Math.floor(baseDamage / 2)`.
+
+### Ally-affecting abilities
+
+| Ability | Effect | Gens |
+|---------|--------|------|
+| Plus / Minus | 1.5x SpAtk when ally has the complementary ability | 3+ |
+| Friend Guard | Ally takes 0.75x damage | 5+ |
+| Battery | Ally's special moves deal 1.3x damage | 7+ |
+| Power Spot | Ally's moves deal 1.3x damage | 8+ |
+| Flower Gift | Ally gets 1.5x Attack and 1.5x SpDef in sun | 4+ |
+| Telepathy | Immune to ally's spread moves | 5+ |
+
+### Helping Hand
+
+1.5x damage multiplier on the ally's next move this turn. Sets a `helping-hand` volatile on the target ally. The damage calc checks for this volatile and applies the modifier.
+
+### Protect variants (context-aware)
+
+Already implemented as move effects. In doubles, their targeting resolution changes:
+- Wide Guard: blocks spread moves targeting any Pokemon on the user's side
+- Quick Guard: blocks priority moves targeting any Pokemon on the user's side
+- These already check volatiles — the engine's target resolution and accuracy check need to honor them for all side members, not just slot 0
+
+### Files changed
+
+Gen-specific ability/damage calc files, `BattleEngine.ts`. ~500 lines.
+
+## Deferred (not in this spec)
+
+| Feature | Reason |
+|---------|--------|
+| Triples | Adjacency rules (slot 0 can't target slot 2). Separate spec. |
+| Rotation | Completely different mechanic (3 Pokemon, 1 attacks). Separate spec. |
+| Pledge combos | Grass+Fire/Water combinations. Low priority, complex coordination. |
+| Ally Switch | Position-swapping with complex targeting interactions. |
+| Doubles-specific AI strategies | Threat assessment, synergy. Separate effort. |
+| Doubles competitive clauses | Rule enforcement belongs in CustomRuleset, not engine. |
+| Gen 3 spread penalty | Uses `/ 2` not 0.75x. Minor data fix, not architectural. |
+| Gen 4 spread penalty | Not implemented. Minor addition to Gen4DamageCalc. |
+
+## File Change Summary
+
+| File | Phases | Scope |
+|------|--------|-------|
+| `packages/battle/src/engine/BattleEngine.ts` | 0-3, 5 | Major |
+| `packages/battle/src/events/BattleAction.ts` | 1 | Minor — add `slot` to all action types |
+| `packages/battle/src/events/BattleEvent.ts` | 1 | Minor — add `slot` to several events |
+| `packages/battle/src/ai/AIController.ts` | 4 | Minor — add `chooseActions()` |
+| `packages/battle/src/ai/RandomAI.ts` | 4 | Moderate — multi-slot actions |
+| `packages/battle/src/ruleset/BaseRuleset.ts` | 1 | Minor — slot-aware speed lookup |
+| `packages/battle/src/context/types.ts` | 3 | Minor — `opponents?` on AbilityContext |
+| Gen 3-9 damage calcs | 5 | Moderate — screen reduction, ally ability modifiers |
+| Gen 3-9 ability handlers | 5 | Moderate — Intimidate multi-target, ally abilities |
+| `packages/battle/src/state/BattleSide.ts` | — | None |
+| `packages/battle/src/state/BattleState.ts` | — | None |
+
+## Verification Plan
+
+| Phase | Test Strategy |
+|-------|--------------|
+| 0 | All 546 existing singles tests pass unchanged. New tests for helper methods. |
+| 1 | `doubles-turn-loop.test.ts` — 4-action submission, priority sort, spread moves, single-target resolution |
+| 2 | `doubles-faint-handling.test.ts` — mid-turn faint, slot replacement, double faint |
+| 3 | `doubles-battle-start.test.ts` — 2 leads per side, entry ability ordering |
+| 4 | `doubles-ai.test.ts` — RandomAI valid doubles actions |
+| 5 | `doubles-mechanics.test.ts` — Follow Me, screen reduction, Helping Hand, ally abilities |
+| Integration | Full doubles battles with Gen 5 or Gen 9, deterministic seeds |

--- a/specs/battle/13-implementation-roadmap.md
+++ b/specs/battle/13-implementation-roadmap.md
@@ -1,0 +1,42 @@
+# Battle Engine Implementation Roadmap
+
+## Next Features
+
+Two major features are pending implementation after Gen 1-9 are complete:
+
+- **Doubles battle support** — `specs/battle/12-doubles.md`
+- **Custom Ruleset system** — `specs/battle/11-custom-ruleset.md`
+
+## Decided Ordering
+
+### 1. Doubles Phases 0–4
+
+Implement the slot-aware engine refactor and core doubles mechanics first.
+
+**Why first:** Doubles Phase 0 replaces 63+ hardcoded `active[0]` references in `BattleEngine.ts` with slot-aware helpers (`getActiveSlot`, `getAllActive`, `forEachActive`). This is a foundational infrastructure change. Building CustomRuleset on the pre-refactor API means its engine integration points get written against single-slot assumptions and immediately need updating.
+
+### 2. CustomRuleset
+
+Implement the configuration-driven wrapper class after the engine is slot-aware.
+
+**Why second:** `CustomRuleset` wraps `GenerationRuleset` and delegates — it is format-agnostic by design. Its clause enforcers operate on `BattleState`, which already has `active` as an array. Building it after doubles means it naturally works with both formats from day one with no retrofitting.
+
+### 3. Doubles Phase 5
+
+Implement doubles-specific mechanics (redirection, ally abilities, Helping Hand, screen reduction) last.
+
+**Why last:** The doubles spec explicitly defers competitive clause enforcement to CustomRuleset (e.g., Sleep Clause counting asleep Pokemon per side). Phase 5 needs CustomRuleset to exist so clause enforcement can be wired up correctly.
+
+## Dependency Graph
+
+```
+Doubles Phases 0-4
+      ↓
+ CustomRuleset
+      ↓
+Doubles Phase 5
+```
+
+## Exception
+
+If TPPC needs (ban lists, Battle Tower rulesets) become urgent before doubles work starts, CustomRuleset can ship first. The maintenance cost of keeping its 2 engine call sites (`getAvailableMoves`, `canExecuteMove`) working through the doubles Phase 0 refactor is small.


### PR DESCRIPTION
## Summary
- add the Custom Ruleset system spec
- add the Doubles battle support spec
- add the implementation roadmap tying those battle specs together

## Scope
This PR includes only:
- `specs/battle/11-custom-ruleset.md`
- `specs/battle/12-doubles.md`
- `specs/battle/13-implementation-roadmap.md`

## Test plan
- [x] Docs only; no code changes

Closes: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification for custom ruleset configuration system for battles.
  * Added specification for doubles battle support and implementation phases.
  * Added implementation roadmap outlining future battle engine work priorities.

* **New Features**
  * Added move restriction checking capability for custom battle rule enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->