### PR TITLE
docs(battle): refresh README install guidance and surface wording

### DIFF
--- a/packages/battle/README.md
+++ b/packages/battle/README.md
@@ -4,17 +4,22 @@ Pluggable Pokemon battle engine. Bring your own generation ruleset.
 
 ## Features
 
-- **GenerationRuleset interface** — ~20 methods defining gen-specific behavior (damage calc, type chart, crit formula, turn order, etc.)
+- **GenerationRuleset interface** — battle contract for generation-specific behavior (damage calc, type chart, crit formula, turn order, etc.)
 - **BaseRuleset** — abstract class with Gen 3+ defaults
 - **BattleEngine** — state machine: start, action select, turn resolve, end of turn, faint check, battle end
-- **Event-driven** — emits 35+ event types for UI rendering, logging, replay
+- **Event-driven** — emits typed `BattleEvent` values for UI rendering, logging, and replay
 - **Deterministic** — same seed + same inputs = same outputs
 - **AI controllers** — RandomAI included, interface for custom AI
 
 ## Installation
 
+These packages are not yet published to npm. Clone the monorepo and build from the root:
+
 ```bash
-npm install @pokemon-lib-ts/battle @pokemon-lib-ts/core
+git clone https://github.com/uehlbran/pokemon-lib-ts.git
+cd pokemon-lib-ts
+npm install
+npm run build
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- Replace the npm install snippet with the monorepo-local clone/build instructions used elsewhere in the repo.
- Remove brittle method/event counts and use stable wording for the battle surface.

## Verification
- `git diff --check`
- Manual comparison against `README.md` and `packages/battle/CLAUDE.md`

Closes #826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature descriptions for improved clarity
  * Installation method changed from npm to cloning the repository and building locally
  * Note: packages are not yet published to npm

<!-- end of auto-generated comment: release notes by coderabbit.ai -->