### PR TITLE
test(battle): remove stale multi-turn TODOs

### DIFF
--- a/packages/battle/tests/engine/battle-engine-edge-cases.test.ts
+++ b/packages/battle/tests/engine/battle-engine-edge-cases.test.ts
@@ -641,16 +641,6 @@ describe("BattleEngine — edge cases", () => {
     });
   });
 
-  describe("multi-turn moves", () => {
-    it.todo(
-      "given a multi-turn move like Hyper Beam, when the first turn executes, then the next turn requires recharge action",
-    );
-
-    it.todo(
-      "given a charging move like Solar Beam, when charge turn executes, then the next turn auto-attacks",
-    );
-  });
-
   describe("struggle when no defender", () => {
     it("given a struggle action with no opponent active, when turn resolves, then struggle emits move-start but does no damage", () => {
       // Arrange — edge case: remove defender mid-turn


### PR DESCRIPTION
## Summary
- Remove stale `it.todo` placeholders from `battle-engine-edge-cases.test.ts`
- Keep the actual Hyper Beam / Solar Beam coverage in the dedicated battle tests that already exercise those mechanics

## Verification
- `npx vitest run tests/engine/battle-engine-edge-cases.test.ts tests/engine/recharge-and-struggle.test.ts tests/engine/two-turn-moves.test.ts`
- `npx @biomejs/biome check tests/engine/battle-engine-edge-cases.test.ts`

Closes #884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed two pending test specifications related to multi-turn move behavior (charge/recharge and auto-attack on subsequent turn). No other tests or assertions were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->