### PR TITLE
fix: reject malformed move actions without moveIndex

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -327,6 +327,18 @@ export class BattleEngine implements BattleEventEmitter {
       throw new Error("MoveAction requires an integer moveIndex");
     }
 
+    if (action.type === "move") {
+      const activePokemon = this.getActive(side);
+
+      if (!activePokemon) {
+        throw new Error(`Side ${side} has no active Pokemon to execute MoveAction`);
+      }
+
+      if (action.moveIndex < 0 || action.moveIndex >= activePokemon.pokemon.moves.length) {
+        throw new Error(`MoveAction moveIndex ${action.moveIndex} is out of range`);
+      }
+    }
+
     this.pendingActions.set(side, action);
 
     // When both sides have submitted, resolve the turn

--- a/packages/battle/tests/engine/battle-engine.test.ts
+++ b/packages/battle/tests/engine/battle-engine.test.ts
@@ -215,12 +215,23 @@ describe("BattleEngine", () => {
       const { engine } = createTestEngine();
       engine.start();
 
+      // Source: BattleEngine.submitAction moveIndex integer validation guard.
       expect(() =>
         engine.submitAction(0, {
           type: "move",
           side: 0,
         } as unknown as Parameters<typeof engine.submitAction>[1]),
       ).toThrow("MoveAction requires an integer moveIndex");
+    });
+
+    it("given a move action with an out-of-range moveIndex, when submitAction is called, then it throws instead of silently skipping the move", () => {
+      const { engine } = createTestEngine();
+      engine.start();
+
+      // Source: createTestEngine gives the active Pokemon exactly one move, so valid indexes stop at 0.
+      expect(() => engine.submitAction(0, { type: "move", side: 0, moveIndex: 99 })).toThrow(
+        "MoveAction moveIndex 99 is out of range",
+      );
     });
 
     it("given both sides submit moves, when turn resolves, then move-start events are emitted", () => {


### PR DESCRIPTION
## Summary
- reject malformed `MoveAction` payloads that omit `moveIndex`
- add a regression test proving `submitAction()` fails fast instead of silently skipping the bad action

Closes #876

## Verification
- `npx vitest run packages/battle/tests/engine/battle-engine.test.ts`
- `npm run test --workspace @pokemon-lib-ts/battle`
- `npm run typecheck --workspace @pokemon-lib-ts/battle`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/battle-engine.test.ts`
