### PR TITLE
fix: validate submitAction side consistency

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -319,6 +319,10 @@ export class BattleEngine implements BattleEventEmitter {
       throw new Error("Battle has ended");
     }
 
+    if (side !== action.side) {
+      throw new Error(`Submitted side ${side} does not match action.side ${action.side}`);
+    }
+
     this.pendingActions.set(side, action);
 
     // When both sides have submitted, resolve the turn

--- a/packages/battle/tests/engine/battle-engine.test.ts
+++ b/packages/battle/tests/engine/battle-engine.test.ts
@@ -202,6 +202,15 @@ describe("BattleEngine", () => {
       expect(damageEvents.length).toBeGreaterThan(0);
     });
 
+    it("given a mismatched submitAction side and action.side, when submitAction is called, then it throws instead of queueing an inconsistent action", () => {
+      const { engine } = createTestEngine();
+      engine.start();
+
+      expect(() => engine.submitAction(0, { type: "move", side: 1, moveIndex: 0 })).toThrow(
+        "Submitted side 0 does not match action.side 1",
+      );
+    });
+
     it("given both sides submit moves, when turn resolves, then move-start events are emitted", () => {
       // Arrange
       const { engine, events } = createTestEngine();


### PR DESCRIPTION
## Summary
- reject `submitAction(side, action)` calls where the method side and `action.side` disagree
- add a regression test that proves the engine now fails fast instead of queueing an inconsistent action

Closes #854

## Verification
- `npx vitest run packages/battle/tests/engine/battle-engine.test.ts`
- `npm run test --workspace @pokemon-lib-ts/battle`
- `npm run typecheck --workspace @pokemon-lib-ts/battle`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/battle-engine.test.ts`
