### PR TITLE
fix: validate submitSwitch replacement targets

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -353,6 +353,21 @@ export class BattleEngine implements BattleEventEmitter {
       throw new Error(`Side ${side} does not need to switch`);
     }
 
+    const sideState = this.state.sides[side];
+    const candidate = sideState.team[teamSlot];
+    if (!candidate) {
+      throw new Error(`Invalid switch slot ${teamSlot}`);
+    }
+
+    const active = sideState.active[0];
+    if (active?.teamSlot === teamSlot) {
+      throw new Error(`Team slot ${teamSlot} is already active`);
+    }
+
+    if (candidate.currentHp <= 0) {
+      throw new Error(`Team slot ${teamSlot} has fainted`);
+    }
+
     this.pendingSwitches.set(side, teamSlot);
 
     // Process when all pending switches are submitted

--- a/packages/battle/tests/engine/battle-engine-advanced.test.ts
+++ b/packages/battle/tests/engine/battle-engine-advanced.test.ts
@@ -440,6 +440,48 @@ describe("BattleEngine — advanced scenarios", () => {
         "Cannot submit switch in phase action-select",
       );
     });
+
+    it("given switch-prompt, when submitSwitch is called with an already-active team slot, then it throws", () => {
+      const team2 = [
+        createTestPokemon(9, 50, {
+          uid: "blastoise-1",
+          nickname: "Blastoise",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 200,
+            attack: 100,
+            defense: 100,
+            spAttack: 100,
+            spDefense: 100,
+            speed: 80,
+          },
+          currentHp: 1,
+        }),
+        createTestPokemon(25, 50, {
+          uid: "pikachu-2",
+          nickname: "Pikachu2",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 120,
+            attack: 80,
+            defense: 60,
+            spAttack: 80,
+            spDefense: 80,
+            speed: 130,
+          },
+          currentHp: 120,
+        }),
+      ];
+      const { engine } = createEngine({ team2 });
+      engine.start();
+      engine.getActive(1)!.pokemon.currentHp = 1;
+
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      expect(engine.getPhase()).toBe("switch-prompt");
+      expect(() => engine.submitSwitch(1, 0)).toThrow("Team slot 0 is already active");
+    });
   });
 
   describe("action on ended battle", () => {

--- a/packages/battle/tests/engine/battle-engine-edge-cases.test.ts
+++ b/packages/battle/tests/engine/battle-engine-edge-cases.test.ts
@@ -369,55 +369,6 @@ describe("BattleEngine — edge cases", () => {
     });
   });
 
-  describe("submitSwitch error — side does not need switch", () => {
-    it("given a side in switch-prompt that doesn't need to switch, when submitSwitch is called for that side, then it throws", () => {
-      // Arrange — force only side 1 to need a switch
-      const team2 = [
-        createTestPokemon(9, 50, {
-          uid: "blastoise-1",
-          nickname: "Blastoise",
-          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
-          calculatedStats: {
-            hp: 200,
-            attack: 100,
-            defense: 100,
-            spAttack: 100,
-            spDefense: 100,
-            speed: 80,
-          },
-          currentHp: 1,
-        }),
-        createTestPokemon(25, 50, {
-          uid: "pikachu-2",
-          nickname: "Pikachu2",
-          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
-          calculatedStats: {
-            hp: 120,
-            attack: 80,
-            defense: 60,
-            spAttack: 80,
-            spDefense: 80,
-            speed: 130,
-          },
-          currentHp: 120,
-        }),
-      ];
-
-      const { engine } = createEngine({ team2 });
-      engine.start();
-      engine.getActive(1)!.pokemon.currentHp = 1;
-
-      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
-      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
-
-      // Should now be in switch-prompt for side 1
-      expect(engine.getPhase()).toBe("switch-prompt");
-
-      // Act & Assert — side 0 doesn't need to switch
-      expect(() => engine.submitSwitch(0, 0)).toThrow("Side 0 does not need to switch");
-    });
-  });
-
   describe("events emitted chronologically and completely", () => {
     it("given a normal turn, when both sides use moves, then event log has battle-start, switch-ins, turn-start, move-starts, damages in order", () => {
       // Arrange

--- a/packages/battle/tests/engine/battle-engine.test.ts
+++ b/packages/battle/tests/engine/battle-engine.test.ts
@@ -764,6 +764,150 @@ describe("BattleEngine", () => {
       expect(engine.getPhase()).toBe("action-select");
       expect(engine.getActive(1)?.pokemon.uid).toBe("pikachu-1");
     });
+
+    it("given switch-prompt for side 1, when side 0 submits a switch, then it throws", () => {
+      const team2 = [
+        createTestPokemon(9, 50, {
+          uid: "blastoise-1",
+          nickname: "Blastoise",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 200,
+            attack: 100,
+            defense: 100,
+            spAttack: 100,
+            spDefense: 100,
+            speed: 80,
+          },
+          currentHp: 1,
+        }),
+        createTestPokemon(25, 50, {
+          uid: "pikachu-1",
+          nickname: "Pikachu",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 120,
+            attack: 80,
+            defense: 60,
+            spAttack: 80,
+            spDefense: 80,
+            speed: 130,
+          },
+          currentHp: 120,
+        }),
+      ];
+
+      const { engine } = createTestEngine({ team2 });
+      engine.start();
+      (engine.getActive(1) as ActivePokemon).pokemon.currentHp = 1;
+
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      expect(engine.getPhase()).toBe("switch-prompt");
+      expect(() => engine.submitSwitch(0, 0)).toThrow("Side 0 does not need to switch");
+    });
+
+    it("given switch-prompt, when the chosen replacement has fainted, then submitSwitch throws", () => {
+      const team2 = [
+        createTestPokemon(9, 50, {
+          uid: "blastoise-1",
+          nickname: "Blastoise",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 200,
+            attack: 100,
+            defense: 100,
+            spAttack: 100,
+            spDefense: 100,
+            speed: 80,
+          },
+          currentHp: 1,
+        }),
+        createTestPokemon(25, 50, {
+          uid: "pikachu-1",
+          nickname: "Pikachu",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 120,
+            attack: 80,
+            defense: 60,
+            spAttack: 80,
+            spDefense: 80,
+            speed: 130,
+          },
+          currentHp: 0,
+        }),
+        createTestPokemon(6, 50, {
+          uid: "charizard-2",
+          nickname: "Charizard2",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 180,
+            attack: 100,
+            defense: 90,
+            spAttack: 100,
+            spDefense: 90,
+            speed: 120,
+          },
+          currentHp: 180,
+        }),
+      ];
+
+      const { engine } = createTestEngine({ team2 });
+      engine.start();
+      (engine.getActive(1) as ActivePokemon).pokemon.currentHp = 1;
+      engine.getTeam(1)[1]!.currentHp = 0;
+
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      expect(engine.getPhase()).toBe("switch-prompt");
+      expect(() => engine.submitSwitch(1, 1)).toThrow("Team slot 1 has fainted");
+    });
+
+    it("given switch-prompt, when the chosen replacement is already active, then submitSwitch throws", () => {
+      const team2 = [
+        createTestPokemon(9, 50, {
+          uid: "blastoise-1",
+          nickname: "Blastoise",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 200,
+            attack: 100,
+            defense: 100,
+            spAttack: 100,
+            spDefense: 100,
+            speed: 80,
+          },
+          currentHp: 1,
+        }),
+        createTestPokemon(25, 50, {
+          uid: "pikachu-1",
+          nickname: "Pikachu",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 120,
+            attack: 80,
+            defense: 60,
+            spAttack: 80,
+            spDefense: 80,
+            speed: 130,
+          },
+          currentHp: 120,
+        }),
+      ];
+
+      const { engine } = createTestEngine({ team2 });
+      engine.start();
+      (engine.getActive(1) as ActivePokemon).pokemon.currentHp = 1;
+
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      expect(engine.getPhase()).toBe("switch-prompt");
+      expect(() => engine.submitSwitch(1, 0)).toThrow("Team slot 0 is already active");
+    });
   });
 
   describe("struggle", () => {


### PR DESCRIPTION
## Summary
- reject `submitSwitch()` targets that are missing, already active, or fainted
- add regression coverage on the stable switch-prompt test harness for side mismatch, dead replacements, and already-active targets
- keep `sendOut()` as the execution path while moving public contract validation to `submitSwitch()`

Closes #853

## Verification
- `npx vitest run packages/battle/tests/engine/battle-engine.test.ts packages/battle/tests/engine/battle-engine-advanced.test.ts packages/battle/tests/engine/battle-engine-edge-cases.test.ts`
- `npm run test --workspace @pokemon-lib-ts/battle`
- `npm run typecheck --workspace @pokemon-lib-ts/battle`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/battle-engine.test.ts packages/battle/tests/engine/battle-engine-advanced.test.ts packages/battle/tests/engine/battle-engine-edge-cases.test.ts`
