### PR TITLE
docs: clarify BattleEngine getState returns live state

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -626,7 +626,12 @@ export class BattleEngine implements BattleEventEmitter {
 
   // --- State Inspection ---
 
-  /** Get a read-only view of the battle state */
+  /**
+   * Get the live battle state object.
+   *
+   * The engine mutates this state in place during battle resolution. Consumers that
+   * need an immutable snapshot should clone or serialize the returned value.
+   */
   getState(): Readonly<BattleState> {
     return this.state;
   }


### PR DESCRIPTION
## Summary
- correct the stale `getState()` docs to match the live mutable state contract
- point consumers toward cloning or serialization when they need an immutable snapshot
- keep the broader mutable getter/ownership issues tracked separately in `#870` and `#888`

Closes #849

## Verification
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts`
