### PR TITLE
fix: preserve battle event logs across deserialize

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -654,7 +654,13 @@ export class BattleEngine implements BattleEventEmitter {
     );
 
     return JSON.stringify(
-      { state: this.state, participantTracker: participantTrackerObj },
+      {
+        state: this.state,
+        participantTracker: participantTrackerObj,
+        // Source: bug fix — getEventLog() promises the ordered log of all events
+        // emitted since start(), so save/load must preserve the emitted history.
+        eventLog: this.eventLog,
+      },
       (_key, value) => {
         if (value instanceof Map) {
           return { __type: "Map", entries: [...value.entries()] };
@@ -692,7 +698,11 @@ export class BattleEngine implements BattleEventEmitter {
         return rng;
       }
       return value;
-    }) as { state: BattleState; participantTracker?: Record<string, string[]> };
+    }) as {
+      state: BattleState;
+      participantTracker?: Record<string, string[]>;
+      eventLog?: BattleEvent[];
+    };
 
     // Create the engine instance without running the constructor.
     // This avoids: (1) stat recalculation, (2) HP reset to max,
@@ -714,7 +724,12 @@ export class BattleEngine implements BattleEventEmitter {
       ruleset: { value: ruleset, writable: false, enumerable: false, configurable: false },
       dataManager: { value: dataManager, writable: false, enumerable: false, configurable: false },
       listeners: { value: new Set(), writable: true, enumerable: false, configurable: false },
-      eventLog: { value: [], writable: true, enumerable: false, configurable: false },
+      eventLog: {
+        value: parsed.eventLog ?? [],
+        writable: true,
+        enumerable: false,
+        configurable: false,
+      },
       pendingActions: { value: new Map(), writable: true, enumerable: false, configurable: false },
       pendingSwitches: { value: new Map(), writable: true, enumerable: false, configurable: false },
       sidesNeedingSwitch: {

--- a/packages/battle/tests/engine/deserialize.test.ts
+++ b/packages/battle/tests/engine/deserialize.test.ts
@@ -138,6 +138,29 @@ describe("BattleEngine.deserialize", () => {
     expect(damageEvents.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("given a serialized battle state, when deserialized, then the event log matches the saved battle history", () => {
+    // Arrange — start a battle and execute one turn so the event log contains
+    // both battle-start and turn-resolution events.
+    const ruleset = new MockRuleset();
+    ruleset.setFixedDamage(10);
+    const dataManager = createMockDataManager();
+    const { engine } = createTestEngine({ ruleset, dataManager });
+    engine.start();
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    const savedEventLog = engine.getEventLog();
+    const serialized = engine.serialize();
+
+    // Act — deserialize the battle state.
+    const restored = BattleEngine.deserialize(serialized, ruleset, dataManager);
+
+    // Assert — the restored engine should preserve the full event log so replay,
+    // undo, and audit consumers still see the same history after load.
+    expect(restored.getEventLog()).toEqual(savedEventLog);
+  });
+
   it("given a serialized state with a specific PRNG state, when deserialized, then PRNG continues from that exact state", () => {
     // Arrange — create two engines with the same seed, advance one by some RNG calls
     const ruleset = new MockRuleset();


### PR DESCRIPTION
## Summary
- persist `eventLog` in `BattleEngine.serialize()`
- restore the saved event log in `BattleEngine.deserialize()` instead of resetting it
- add regression coverage proving save/load preserves the emitted battle history

Closes #860

## Verification
- `npx vitest run packages/battle/tests/engine/deserialize.test.ts`
- `npm run build --workspace @pokemon-lib-ts/battle`
- `npm run test --workspace @pokemon-lib-ts/battle`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/deserialize.test.ts`
