### PR TITLE
fix: preserve action-select state across save/load

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -702,6 +702,8 @@ export class BattleEngine implements BattleEventEmitter {
 
   /** Serialize battle state for save/load or network transmission */
   serialize(): string {
+    this.assertSerializablePhase();
+
     // participantTracker is an engine-private field (not in BattleState), so we must
     // include it separately. Convert Map<string, Set<string>> → plain object for JSON.
     // Source: bug fix — tracker was silently dropped on serialize/deserialize round-trips,
@@ -714,6 +716,7 @@ export class BattleEngine implements BattleEventEmitter {
       {
         state: this.state,
         participantTracker: participantTrackerObj,
+        pendingActions: this.pendingActions,
         // Source: bug fix — getEventLog() promises the ordered log of all events
         // emitted since start(), so save/load must preserve the emitted history.
         eventLog: this.eventLog,
@@ -758,6 +761,7 @@ export class BattleEngine implements BattleEventEmitter {
     }) as {
       state: BattleState;
       participantTracker?: Record<string, string[]>;
+      pendingActions?: Map<0 | 1, BattleAction>;
       eventLog?: BattleEvent[];
     };
 
@@ -794,7 +798,12 @@ export class BattleEngine implements BattleEventEmitter {
         enumerable: false,
         configurable: false,
       },
-      pendingActions: { value: new Map(), writable: true, enumerable: false, configurable: false },
+      pendingActions: {
+        value: parsed.pendingActions ?? new Map(),
+        writable: true,
+        enumerable: false,
+        configurable: false,
+      },
       pendingSwitches: { value: new Map(), writable: true, enumerable: false, configurable: false },
       sidesNeedingSwitch: {
         value: new Set(),
@@ -829,6 +838,24 @@ export class BattleEngine implements BattleEventEmitter {
     });
 
     return engine;
+  }
+
+  private assertSerializablePhase(): void {
+    const stableCheckpointPhases: ReadonlySet<BattlePhase> = new Set([
+      "battle-start",
+      "action-select",
+      "switch-prompt",
+      "battle-end",
+    ]);
+
+    if (stableCheckpointPhases.has(this.state.phase)) {
+      return;
+    }
+
+    throw new Error(
+      `BattleEngine.serialize cannot save during phase ${this.state.phase}; ` +
+        `save only from stable checkpoint phases`,
+    );
   }
 
   // --- Private Methods ---

--- a/packages/battle/tests/engine/deserialize.test.ts
+++ b/packages/battle/tests/engine/deserialize.test.ts
@@ -66,6 +66,56 @@ function createTestEngine(overrides?: {
 }
 
 describe("BattleEngine.deserialize", () => {
+  it("given one side has already submitted an action, when serialized and deserialized, then the pending action is preserved", () => {
+    const ruleset = new MockRuleset();
+    ruleset.setFixedDamage(10);
+    const dataManager = createMockDataManager();
+    const { engine } = createTestEngine({ ruleset, dataManager });
+    engine.start();
+
+    const initialHpSide0 = engine.getActive(0)!.pokemon.currentHp;
+    const initialHpSide1 = engine.getActive(1)!.pokemon.currentHp;
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+
+    const serialized = engine.serialize();
+    const restored = BattleEngine.deserialize(serialized, ruleset, dataManager);
+
+    restored.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    expect(restored.getState().turnNumber).toBe(1);
+    expect(restored.getActive(0)?.pokemon.currentHp).toBe(initialHpSide0 - 10);
+    expect(restored.getActive(1)?.pokemon.currentHp).toBe(initialHpSide1 - 10);
+  });
+
+  it("given serialize is called during turn resolution, when a save is attempted, then it throws instead of producing a lossy snapshot", () => {
+    const ruleset = new MockRuleset();
+    const dataManager = createMockDataManager();
+    const { engine } = createTestEngine({ ruleset, dataManager });
+    engine.start();
+
+    let serializeError: Error | null = null;
+
+    engine.on((event) => {
+      if (event.type !== "damage") {
+        return;
+      }
+
+      try {
+        engine.serialize();
+      } catch (error) {
+        serializeError = error as Error;
+      }
+    });
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    expect(serializeError?.message).toBe(
+      "BattleEngine.serialize cannot save during phase turn-resolve; save only from stable checkpoint phases",
+    );
+  });
+
   it("given serialized state and a ruleset whose generation does not match the saved battle generation, when deserialized, then it throws", () => {
     const { engine } = createTestEngine();
     const serialized = engine.serialize();


### PR DESCRIPTION
Closes #859

## Summary
- preserve a side's queued action when serializing during `action-select`
- reject serialize calls from non-checkpoint phases instead of producing lossy snapshots
- add deserialize regressions for queued-action restoration and unsafe mid-resolution saves

## Verification
- `npm run test --workspace @pokemon-lib-ts/battle -- deserialize.test.ts`
- `npx biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/deserialize.test.ts`
- `npm run test --workspace @pokemon-lib-ts/battle` *(currently hits an unrelated shared-workspace failure in BaseRuleset nature loading outside this diff)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved save/load reliability by preserving pending action states during serialization.
  * Added safeguards to prevent saves during active battle resolution, ensuring game state consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->