### PR TITLE
fix: reject unsupported multi-active battle inputs

### DIFF
--- a/packages/battle/src/context/types.ts
+++ b/packages/battle/src/context/types.ts
@@ -856,7 +856,7 @@ export type EndOfTurnEffect =
 export interface BattleConfig {
   /** Game generation (1–9); determines which ruleset mechanics apply */
   readonly generation: Generation;
-  /** Battle format (`"singles"`, `"doubles"`, `"triples"`, or `"rotation"`) */
+  /** Battle format; BattleEngine currently only supports `"singles"` */
   readonly format: BattleFormat;
   /** Both sides' teams as arrays of `PokemonInstance`; index 0 is player, index 1 is opponent */
   readonly teams: readonly [PokemonInstance[], PokemonInstance[]];

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -118,8 +118,18 @@ export class BattleEngine implements BattleEventEmitter {
     }
   }
 
+  private static assertSinglesOnlyFormat(
+    source: "BattleEngine" | "BattleEngine.deserialize",
+    format: BattleState["format"],
+  ): void {
+    if (format !== "singles") {
+      throw new Error(`${source}: battle format "${format}" is not supported`);
+    }
+  }
+
   constructor(config: BattleConfig, ruleset: GenerationRuleset, dataManager: DataManager) {
     BattleEngine.assertRulesetGenerationMatches("BattleEngine", config.generation, ruleset);
+    BattleEngine.assertSinglesOnlyFormat("BattleEngine", config.format);
     this.ruleset = ruleset;
     this.dataManager = dataManager;
 
@@ -334,6 +344,15 @@ export class BattleEngine implements BattleEventEmitter {
 
     if (side !== action.side) {
       throw new Error(`Submitted side ${side} does not match action.side ${action.side}`);
+    }
+
+    if (
+      action.type === "move" &&
+      (action.targetSide !== undefined || action.targetSlot !== undefined)
+    ) {
+      throw new Error(
+        "BattleEngine: move targetSide/targetSlot are not supported in singles battles",
+      );
     }
 
     if (action.type === "move" && !Number.isInteger(action.moveIndex)) {
@@ -743,6 +762,7 @@ export class BattleEngine implements BattleEventEmitter {
       parsed.state.generation,
       ruleset,
     );
+    BattleEngine.assertSinglesOnlyFormat("BattleEngine.deserialize", parsed.state.format);
 
     // Create the engine instance without running the constructor.
     // This avoids: (1) stat recalculation, (2) HP reset to max,

--- a/packages/battle/src/events/BattleAction.ts
+++ b/packages/battle/src/events/BattleAction.ts
@@ -30,9 +30,9 @@ export interface MoveAction {
   readonly side: 0 | 1;
   /** Index into the active Pokémon's move array (0–3) */
   readonly moveIndex: number;
-  /** Target side for multi-target scenarios (doubles/triples); omit for singles */
+  /** Reserved for future multi-active support; BattleEngine currently rejects this field */
   readonly targetSide?: 0 | 1;
-  /** Target slot within the target side (doubles/triples); omit for singles */
+  /** Reserved for future multi-active support; BattleEngine currently rejects this field */
   readonly targetSlot?: number;
   /** `true` to mega evolve this turn (Gen 6+); only valid once per battle */
   readonly mega?: boolean;

--- a/packages/battle/src/events/BattleEvent.ts
+++ b/packages/battle/src/events/BattleEvent.ts
@@ -107,7 +107,7 @@ export type BattleEvent =
 export interface BattleStartEvent {
   /** Discriminant: always `"battle-start"` */
   readonly type: "battle-start";
-  /** The battle format (singles, doubles, triples, or rotation) */
+  /** The battle format; BattleEngine currently emits `"singles"` only */
   readonly format: BattleFormat;
   /** The game generation (1–9) governing all mechanics */
   readonly generation: Generation;
@@ -134,7 +134,7 @@ export interface SwitchInEvent {
   readonly side: 0 | 1;
   /** Snapshot of the Pokémon's public state at the moment it enters */
   readonly pokemon: PokemonSnapshot;
-  /** Active slot index on the side (0 for singles, 0–1 for doubles, etc.) */
+  /** Active slot index on the side (always 0 in current singles-only support) */
   readonly slot: number;
 }
 

--- a/packages/battle/src/state/BattleState.ts
+++ b/packages/battle/src/state/BattleState.ts
@@ -27,10 +27,8 @@ export type BattlePhase =
 
 /**
  * The battle format determines how many Pokémon are active per side at once.
- * - `singles` — 1 vs 1 (most common format)
- * - `doubles` — 2 vs 2
- * - `triples` — 3 vs 3 (Gen 5–6)
- * - `rotation` — 3 on each side, only 1 attacks per turn (Gen 5)
+ * BattleEngine currently only runs `singles`; the broader union is reserved for
+ * future multi-active support and rejected at runtime.
  */
 export type BattleFormat = "singles" | "doubles" | "triples" | "rotation";
 
@@ -84,7 +82,7 @@ export interface BattleState {
   phase: BattlePhase;
   /** Game generation (1–9); immutable after construction */
   readonly generation: Generation;
-  /** Battle format; immutable after construction */
+  /** Battle format; BattleEngine currently stores `"singles"` only */
   readonly format: BattleFormat;
   /** 1-based turn counter; incremented at the start of each new turn */
   turnNumber: number;

--- a/packages/battle/tests/engine/battle-engine.test.ts
+++ b/packages/battle/tests/engine/battle-engine.test.ts
@@ -110,6 +110,20 @@ describe("BattleEngine", () => {
         "BattleEngine: ruleset generation 9 does not match battle generation 1",
       );
     });
+
+    it("given a non-singles battle format, when engine is created, then it rejects unsupported multi-active formats", () => {
+      const dataManager = createMockDataManager();
+      const config: BattleConfig = {
+        generation: 1,
+        format: "doubles",
+        teams: [[createTestPokemon(6, 50)], [createTestPokemon(9, 50)]],
+        seed: 12345,
+      };
+
+      expect(() => new BattleEngine(config, new MockRuleset(), dataManager)).toThrow(
+        'BattleEngine: battle format "doubles" is not supported',
+      );
+    });
   });
 
   describe("start", () => {
@@ -226,6 +240,21 @@ describe("BattleEngine", () => {
       expect(() => engine.submitAction(0, { type: "move", side: 1, moveIndex: 0 })).toThrow(
         "Submitted side 0 does not match action.side 1",
       );
+    });
+
+    it("given a move action with targetSide and targetSlot, when submitAction is called, then it rejects unsupported multi-active targeting fields", () => {
+      const { engine } = createTestEngine();
+      engine.start();
+
+      expect(() =>
+        engine.submitAction(0, {
+          type: "move",
+          side: 0,
+          moveIndex: 0,
+          targetSide: 1,
+          targetSlot: 0,
+        }),
+      ).toThrow("BattleEngine: move targetSide/targetSlot are not supported in singles battles");
     });
 
     it("given a move action without moveIndex, when submitAction is called, then it throws instead of accepting a malformed action", () => {

--- a/packages/battle/tests/engine/deserialize.test.ts
+++ b/packages/battle/tests/engine/deserialize.test.ts
@@ -78,6 +78,20 @@ describe("BattleEngine.deserialize", () => {
     ).toThrow("BattleEngine.deserialize: ruleset generation 9 does not match battle generation 1");
   });
 
+  it("given a serialized battle state with a non-singles format, when deserialized, then it rejects unsupported multi-active formats", () => {
+    const { engine } = createTestEngine();
+    const parsed = JSON.parse(engine.serialize()) as {
+      state: {
+        format: string;
+      };
+    };
+    parsed.state.format = "triples";
+
+    expect(() =>
+      BattleEngine.deserialize(JSON.stringify(parsed), new MockRuleset(), createMockDataManager()),
+    ).toThrow('BattleEngine.deserialize: battle format "triples" is not supported');
+  });
+
   it("given a serialized battle state where currentHp is less than maxHp, when deserialized, then currentHp matches the saved value (not recalculated)", () => {
     // Arrange — create an engine, start it, deal some damage to reduce HP
     const ruleset = new MockRuleset();


### PR DESCRIPTION
Closes #852

## Summary
- reject non-`singles` battle formats at construction and deserialize time
- reject `MoveAction.targetSide` and `targetSlot` until multi-active battles are actually supported
- tighten public docs around the current singles-only runtime contract

## Verification
- `npm run build --workspace @pokemon-lib-ts/core`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/src/events/BattleAction.ts packages/battle/src/state/BattleState.ts packages/battle/src/events/BattleEvent.ts packages/battle/tests/engine/battle-engine.test.ts packages/battle/tests/engine/deserialize.test.ts`
- `npx vitest run packages/battle/tests/engine/battle-engine.test.ts packages/battle/tests/engine/deserialize.test.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/battle`