### PR TITLE
fix: clone active pokemon types

### DIFF
--- a/packages/battle/src/utils/BattleHelpers.ts
+++ b/packages/battle/src/utils/BattleHelpers.ts
@@ -69,7 +69,7 @@ export function createActivePokemon(
     teamSlot,
     statStages: createDefaultStatStages(),
     volatileStatuses: new Map(),
-    types: teraResolvedTypes,
+    types: [...teraResolvedTypes],
     ability: resolvedAbility,
     suppressedAbility: null,
     itemKnockedOff: false,

--- a/packages/battle/tests/utils/battle-helpers.test.ts
+++ b/packages/battle/tests/utils/battle-helpers.test.ts
@@ -1,3 +1,4 @@
+import type { PokemonType } from "@pokemon-lib-ts/core";
 import { describe, expect, it } from "vitest";
 import {
   createActivePokemon,
@@ -71,6 +72,21 @@ describe("BattleHelpers", () => {
       expect(active.isDynamaxed).toBe(false);
       expect(active.isTerastallized).toBe(false);
       expect(active.stellarBoostedTypes).toEqual([]);
+    });
+
+    it("given a caller-owned types array, when createActivePokemon is called, then the ActivePokemon gets its own copy", () => {
+      const pokemon = createTestPokemon(6, 50);
+      const types: PokemonType[] = ["fire", "flying"];
+
+      const active = createActivePokemon(pokemon, 0, types);
+
+      expect(active.types).toEqual(["fire", "flying"]);
+      expect(active.types).not.toBe(types);
+
+      active.types[0] = "water";
+
+      expect(types).toEqual(["fire", "flying"]);
+      expect(active.types).toEqual(["water", "flying"]);
     });
   });
 


### PR DESCRIPTION
## Summary\n- clone the resolved types array before storing it on \n- add a regression proving the caller-owned array is no longer aliased\n\n## Testing\n- 
 RUN  v1.6.1 /home/uehlbran/projects/pokemon-lib-ts-battle-campaign/.worktrees/fix-887-create-active-pokemon-types-copy

 ✓ |@pokemon-lib-ts/battle| tests/utils/battle-helpers.test.ts  (8 tests) 4ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  20:39:45
   Duration  1.34s (transform 29ms, setup 0ms, collect 29ms, tests 4ms, environment 0ms, prepare 354ms)\n- Checked 2 files in 5ms. No fixes applied.\n\nCloses #887