### PR TITLE
fix: snapshot battle event log getter

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -320,7 +320,7 @@ export class BattleEngine implements BattleEventEmitter {
    * @returns An immutable view of the event log; safe to iterate or serialize.
    */
   getEventLog(): readonly BattleEvent[] {
-    return this.eventLog;
+    return [...this.eventLog];
   }
 
   private emit(event: BattleEvent): void {

--- a/packages/battle/tests/engine/battle-engine.test.ts
+++ b/packages/battle/tests/engine/battle-engine.test.ts
@@ -1110,6 +1110,21 @@ describe("BattleEngine", () => {
       expect(log.length).toBeGreaterThan(0);
       expect(log[0]?.type).toBe("battle-start");
     });
+
+    it("given a caller mutates the array returned by getEventLog, when getEventLog is called again, then the engine history is unchanged", () => {
+      const { engine } = createTestEngine();
+      engine.start();
+
+      const firstSnapshot = engine.getEventLog();
+      const originalLength = firstSnapshot.length;
+
+      (firstSnapshot as BattleEvent[]).pop();
+
+      const secondSnapshot = engine.getEventLog();
+
+      expect(secondSnapshot).toHaveLength(originalLength);
+      expect(secondSnapshot[0]?.type).toBe("battle-start");
+    });
   });
 
   describe("serialization", () => {


### PR DESCRIPTION
## Summary
- return a defensive copy from `BattleEngine.getEventLog()` instead of the backing array
- add a regression proving caller-side array mutation does not corrupt engine history

## Testing
- `npx vitest run packages/battle/tests/engine/battle-engine.test.ts packages/battle/tests/engine/deserialize.test.ts`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/battle-engine.test.ts`

Closes #848
