### PR TITLE
Fix duplicate test Pokemon UIDs

### DIFF
--- a/packages/battle/src/utils/BattleHelpers.ts
+++ b/packages/battle/src/utils/BattleHelpers.ts
@@ -2,6 +2,8 @@ import type { BattleStat, PokemonInstance, PokemonType } from "@pokemon-lib-ts/c
 import type { PokemonSnapshot } from "../events";
 import type { ActivePokemon } from "../state";
 
+let testPokemonUidCounter = 0;
+
 /** Create a PokemonSnapshot from an ActivePokemon (public-facing info only) */
 export function createPokemonSnapshot(active: ActivePokemon): PokemonSnapshot {
   return {
@@ -102,13 +104,18 @@ export function getPokemonName(active: ActivePokemon): string {
  * Create a minimal test Pokemon with sane defaults.
  * Useful for tests — avoids needing a full DataManager.
  */
+function createTestPokemonUid(speciesId: number, level: number): string {
+  testPokemonUidCounter += 1;
+  return `test-${speciesId}-${level}-${testPokemonUidCounter}`;
+}
+
 export function createTestPokemon(
   speciesId: number,
   level: number,
   overrides?: Partial<PokemonInstance>,
 ): PokemonInstance {
   return {
-    uid: `test-${speciesId}-${level}`,
+    uid: createTestPokemonUid(speciesId, level),
     speciesId,
     nickname: null,
     level,

--- a/packages/battle/tests/utils/battle-helpers.test.ts
+++ b/packages/battle/tests/utils/battle-helpers.test.ts
@@ -39,6 +39,17 @@ describe("BattleHelpers", () => {
       expect(pokemon.moves[0]?.moveId).toBe("tackle");
     });
 
+    it("given repeated calls with the same species and level, when createTestPokemon is called, then each Pokemon has a unique uid", () => {
+      // Act
+      const firstPokemon = createTestPokemon(6, 50);
+      const secondPokemon = createTestPokemon(6, 50);
+
+      // Assert
+      expect(firstPokemon.uid).not.toBe(secondPokemon.uid);
+      expect(firstPokemon.uid).toMatch(/^test-6-50-\d+$/);
+      expect(secondPokemon.uid).toMatch(/^test-6-50-\d+$/);
+    });
+
     it("given overrides, when createTestPokemon is called, then overrides are applied", () => {
       // Act
       const pokemon = createTestPokemon(25, 30, {


### PR DESCRIPTION
## Summary
- Make `createTestPokemon()` assign a unique UID per call instead of deriving it only from species and level.
- Add a regression test proving repeated same-species/same-level fixtures no longer collide.

## Verification
- `npm exec -- vitest run packages/battle/tests/utils/battle-helpers.test.ts`
- `npx @biomejs/biome check packages/battle/src/utils/BattleHelpers.ts packages/battle/tests/utils/battle-helpers.test.ts`
- `npm exec -- tsc -p packages/battle/tsconfig.json --noEmit` currently fails on an unrelated existing issue in `packages/battle/src/ruleset/BaseRuleset.ts`.

Closes #839