### PR TITLE
docs: correct end-of-turn spec coverage

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -4398,7 +4398,6 @@ export class BattleEngine implements BattleEventEmitter {
         }
         case "moody": {
           // Gen 5+ ability: raises one stat by 2 and lowers another by 1 at EoT.
-          // Stub: delegates to ruleset ability hook. No gen currently returns this effect.
           // Source: Showdown sim/abilities.ts — Moody triggers at residual phase
           for (const side of this.state.sides) {
             const active = side.active[0];
@@ -4422,7 +4421,6 @@ export class BattleEngine implements BattleEventEmitter {
         }
         case "harvest": {
           // Gen 5+ ability: 50% chance to restore a consumed Berry at EoT (100% in sun).
-          // Stub: delegates to ruleset ability hook. No gen currently returns this effect.
           // Source: Showdown sim/abilities.ts — Harvest triggers at residual phase
           for (const side of this.state.sides) {
             const active = side.active[0];

--- a/specs/battle/01-core-engine.md
+++ b/specs/battle/01-core-engine.md
@@ -1,6 +1,6 @@
 <!-- SPEC FRONT-MATTER -->
 <!-- status: IMPLEMENTED -->
-<!-- last-updated: 2026-03-21 -->
+<!-- last-updated: 2026-03-23 -->
 
 # Battle Library — Core Engine
 
@@ -590,6 +590,9 @@ Example arrays:
 - `"tailwind-countdown"` — Tailwind duration countdown
 - `"trick-room-countdown"` — Trick Room duration countdown
 - `"speed-boost"` — Speed Boost ability stat increase (via `applyAbility("on-turn-end")`)
+- `"moody"` — Moody ability random stat changes (via `applyAbility("on-turn-end")`)
+- `"harvest"` — Harvest ability berry restoration (via `applyAbility("on-turn-end")`)
+- `"grassy-terrain-heal"` — Grassy Terrain HP recovery (via `applyTerrainEffects()`)
 - `"bad-dreams"` — Bad Dreams ability damage (via `applyAbility("on-turn-end")`)
 - `"poison-heal"` — Poison Heal ability HP recovery (via `applyAbility("on-turn-end")`)
 - `"weather-healing"` — Rain Dish, Dry Skin, Ice Body (via `applyAbility("on-turn-end")`)
@@ -612,11 +615,8 @@ Example arrays:
 - `"magnet-rise-countdown"` — Magnet Rise volatile countdown
 
 ### NOT YET IMPLEMENTED Effects
-The following effect identifiers have stubs in the engine switch statement that delegate to the ruleset, but no gen ruleset currently returns them:
-- `"moody"` — Moody ability random stat changes (Gen 5+; stub delegates to `applyAbility("on-turn-end")`)
-- `"harvest"` — Harvest ability berry restoration (Gen 5+; stub delegates to `applyAbility("on-turn-end")`)
+The following effect identifier still has a stub in the engine switch statement that delegates to the ruleset, but no gen ruleset currently returns it:
 - `"pickup"` — Pickup ability item collection (Gen 5+; stub delegates to `applyAbility("on-turn-end")`)
-- `"grassy-terrain-heal"` — Grassy Terrain HP recovery (Gen 6+; stub delegates to `applyTerrainEffects()`)
 
 ### IN PROGRESS Features
 - EXP gain on faint — feat/battle-exp-gain (participation tracker, awardExpForFaint, ExpGainEvent, LevelUpEvent)


### PR DESCRIPTION
Move live end-of-turn identifiers into the implemented list in specs/battle/01-core-engine.md, reduce the not-yet-implemented list to pickup only, and align nearby BattleEngine comments with current ruleset coverage.

Verification:
- npx @biomejs/biome check specs/battle/01-core-engine.md packages/battle/src/engine/BattleEngine.ts
- npx vitest run tests/ruleset/generation-ruleset-interface.test.ts (packages/battle)
- npx vitest run tests/abilities-stat.test.ts (packages/gen8)

Notes:
- packages/battle / packages/gen5 / packages/gen6 package-entry tests are currently blocked by an existing unresolved @pokemon-lib-ts/battle entry/declaration issue unrelated to this doc fix.

Closes #828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Three end-of-turn battle abilities now fully implemented: `moody`, `harvest`, and `grassy-terrain-heal`

* **Documentation**
  * Updated battle specifications to reflect current implementation status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->