### PR TITLE
fix(gen1): stop advertising unsupported bag item support

### DIFF
--- a/packages/gen1/src/Gen1Ruleset.ts
+++ b/packages/gen1/src/Gen1Ruleset.ts
@@ -1295,7 +1295,7 @@ export class Gen1Ruleset implements GenerationRuleset {
   }
 
   canUseBagItems(): boolean {
-    return true;
+    return false;
   }
 
   applyBagItem(_itemId: string, _target: ActivePokemon, _state: BattleState): BagItemResult {

--- a/packages/gen1/tests/ruleset-branches.test.ts
+++ b/packages/gen1/tests/ruleset-branches.test.ts
@@ -1788,6 +1788,12 @@ describe("Gen1Ruleset applyStatusDamage (toxic escalation)", () => {
   });
 });
 
+describe("Gen1Ruleset bag item support", () => {
+  it("given Gen 1 has no implemented bag item data or effects, when querying bag item support, then it reports unsupported", () => {
+    expect(ruleset.canUseBagItems()).toBe(false);
+  });
+});
+
 // ============================================================================
 // No-op Method Return Values
 // ============================================================================


### PR DESCRIPTION
## Summary
- stop Gen1Ruleset from advertising bag item support that the package does not implement
- keep the existing no-op bag item handler as a defensive fallback until single-player bag items are actually added
- add a regression test proving canUseBagItems() is false on current behavior

Closes #912

## Verification
- npx vitest run packages/gen1/tests/ruleset-branches.test.ts -t "bag item support"
- npx @biomejs/biome check packages/gen1/src/Gen1Ruleset.ts packages/gen1/tests/ruleset-branches.test.ts