### PR TITLE
fix(battle): end encore when moveId target runs out of pp

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -5759,6 +5759,32 @@ export class BattleEngine implements BattleEventEmitter {
    * Decrements the Encore counter. If it reaches 0, or the encored move has 0 PP,
    * remove the Encore volatile status.
    */
+  private resolveEncoredMoveSlot(active: ActivePokemon, encoreData: unknown) {
+    const moveIndex =
+      typeof encoreData === "object" &&
+      encoreData !== null &&
+      "moveIndex" in encoreData &&
+      typeof encoreData.moveIndex === "number"
+        ? encoreData.moveIndex
+        : undefined;
+    if (moveIndex !== undefined) {
+      return active.pokemon.moves[moveIndex];
+    }
+
+    const moveId =
+      typeof encoreData === "object" &&
+      encoreData !== null &&
+      "moveId" in encoreData &&
+      typeof encoreData.moveId === "string"
+        ? encoreData.moveId
+        : undefined;
+    if (moveId === undefined) {
+      return undefined;
+    }
+
+    return active.pokemon.moves.find((moveSlot) => moveSlot.moveId === moveId);
+  }
+
   private processEncoreCountdown(): void {
     for (const side of this.state.sides) {
       const active = side.active[0];
@@ -5771,9 +5797,8 @@ export class BattleEngine implements BattleEventEmitter {
 
       // Check if encore should end: counter reached 0 or encored move has 0 PP
       let shouldEnd = encoreState.turnsLeft <= 0;
-      if (!shouldEnd && encoreState.data?.moveIndex !== undefined) {
-        const moveIdx = encoreState.data.moveIndex as number;
-        const moveSlot = active.pokemon.moves[moveIdx];
+      if (!shouldEnd) {
+        const moveSlot = this.resolveEncoredMoveSlot(active, encoreState.data);
         if (moveSlot && moveSlot.currentPP <= 0) {
           shouldEnd = true;
         }

--- a/packages/battle/tests/engine/battle-engine-advanced.test.ts
+++ b/packages/battle/tests/engine/battle-engine-advanced.test.ts
@@ -332,6 +332,37 @@ describe("BattleEngine — advanced scenarios", () => {
     });
   });
 
+  describe("encore countdown", () => {
+    it("given encore tracked by moveId, when the encored move reaches 0 PP, then encore ends at end of turn", () => {
+      // Arrange
+      const ruleset = new MockRuleset();
+      const originalOrder = ruleset.getEndOfTurnOrder();
+      const patchedRuleset = Object.create(ruleset) as MockRuleset;
+      patchedRuleset.getEndOfTurnOrder = () => ["encore-countdown" as const, ...originalOrder];
+
+      const { engine, events } = createEngine({ ruleset: patchedRuleset });
+      engine.start();
+
+      const active = engine.state.sides[0].active[0] as ActivePokemon;
+      active.pokemon.moves[0] = { moveId: "tackle", currentPP: 1, maxPP: 35, ppUps: 0 };
+      active.volatileStatuses.set("encore", {
+        turnsLeft: 2,
+        data: { moveId: "tackle" },
+      });
+
+      // Act
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert
+      expect(active.volatileStatuses.has("encore")).toBe(false);
+      const encoreEnd = events.find(
+        (event) => event.type === "volatile-end" && event.side === 0 && event.volatile === "encore",
+      );
+      expect(encoreEnd).toBeDefined();
+    });
+  });
+
   describe("flinch", () => {
     it("given a pokemon with flinch volatile, when it tries to move, then it cannot move", () => {
       // Arrange


### PR DESCRIPTION
## Summary
- make the Encore PP-end countdown resolve the encored move by moveId or moveIndex
- keep the end-of-turn removal logic aligned with the existing move-lock path
- add a regression test for the Gen3+ moveId payload path

Closes #825

## Verification
- npx vitest run packages/battle/tests/engine/battle-engine-advanced.test.ts -t "encore tracked by moveId"
- npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/battle-engine-advanced.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Encore status mechanics to ensure proper removal when the encored move runs out of PP, making battle behavior more reliable and consistent.

* **Tests**
  * Added test coverage for Encore countdown behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->