### PR TITLE
fix: route custom damage through battle damage hooks

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -219,6 +219,13 @@ export class BattleEngine implements BattleEventEmitter {
     }
   }
 
+  private normalizeCustomDamageAmount(damage: number): number {
+    if (!Number.isFinite(damage)) {
+      return 0;
+    }
+    return Math.max(0, Math.trunc(damage));
+  }
+
   private applyCustomDamage(
     target: ActivePokemon,
     sourcePokemon: ActivePokemon,
@@ -228,8 +235,29 @@ export class BattleEngine implements BattleEventEmitter {
     type?: MoveData["type"] | null,
   ): void {
     const moveData = this.getCustomDamageMoveData(source, type);
-    let damage = amount;
-    const maxHp = target.pokemon.calculatedStats?.hp ?? target.pokemon.currentHp;
+    if (target.pokemon.currentHp <= 0) {
+      return;
+    }
+
+    let damage = this.normalizeCustomDamageAmount(amount);
+
+    if (damage > 0 && target.substituteHp > 0 && !moveData.flags.bypassSubstitute) {
+      target.substituteHp = Math.max(0, target.substituteHp - damage);
+      this.emit({
+        type: "message",
+        text: "The substitute took damage!",
+      });
+      if (target.substituteHp === 0) {
+        target.volatileStatuses.delete("substitute");
+        this.emit({
+          type: "volatile-end",
+          side: targetSide,
+          pokemon: getPokemonName(target),
+          volatile: "substitute",
+        });
+      }
+      return;
+    }
 
     if (this.ruleset.capLethalDamage) {
       const survivalResult = this.ruleset.capLethalDamage(
@@ -239,7 +267,7 @@ export class BattleEngine implements BattleEventEmitter {
         moveData,
         this.state,
       );
-      damage = survivalResult.damage;
+      damage = this.normalizeCustomDamageAmount(survivalResult.damage);
       for (const message of survivalResult.messages) {
         this.emit({ type: "message", text: message });
       }
@@ -254,6 +282,7 @@ export class BattleEngine implements BattleEventEmitter {
       }
     }
 
+    const maxHp = target.pokemon.calculatedStats?.hp ?? target.pokemon.currentHp;
     target.pokemon.currentHp = Math.max(0, target.pokemon.currentHp - damage);
     target.lastDamageTaken = damage;
     target.lastDamageType = type ?? moveData.type;

--- a/packages/battle/tests/engine/damage-path-regression.test.ts
+++ b/packages/battle/tests/engine/damage-path-regression.test.ts
@@ -1,9 +1,14 @@
 import type { MoveData, PokemonInstance } from "@pokemon-lib-ts/core";
 import { describe, expect, it } from "vitest";
 import type {
+  AbilityContext,
+  AbilityResult,
+  AbilityTrigger,
   BattleConfig,
   DamageContext,
   DamageResult,
+  ItemContext,
+  ItemResult,
   MoveEffectResult,
 } from "../../src/context";
 import { BattleEngine } from "../../src/engine";
@@ -105,6 +110,8 @@ class MultiHitEndureMockRuleset extends AlwaysEndureMockRuleset {
 
 class CustomDamageHookMockRuleset extends MockRuleset {
   damageReceivedCalls: Array<{ defenderUid: string; damage: number; moveId: string }> = [];
+  abilityTriggerCalls: string[] = [];
+  heldItemTriggerCalls: string[] = [];
 
   override capLethalDamage(
     damage: number,
@@ -134,6 +141,28 @@ class CustomDamageHookMockRuleset extends MockRuleset {
       damage,
       moveId: move.id,
     });
+  }
+
+  override hasAbilities(): boolean {
+    return true;
+  }
+
+  override applyAbility(trigger: AbilityTrigger, _context: AbilityContext): AbilityResult {
+    if (trigger === "on-damage-taken" || trigger === "on-contact") {
+      this.abilityTriggerCalls.push(trigger);
+    }
+    return { activated: false, effects: [], messages: [] };
+  }
+
+  override hasHeldItems(): boolean {
+    return true;
+  }
+
+  override applyHeldItem(trigger: string, _context: ItemContext): ItemResult {
+    if (trigger === "on-damage-taken" || trigger === "on-contact") {
+      this.heldItemTriggerCalls.push(trigger);
+    }
+    return { activated: false, effects: [], messages: [] };
   }
 }
 
@@ -198,9 +227,12 @@ describe("BattleEngine — damage path regression (#531, #538, #539)", () => {
   describe("#829 — customDamage uses the shared damage pipeline", () => {
     it("given a move effect that applies lethal custom damage, when it resolves, then the engine still applies capLethalDamage and onDamageReceived", () => {
       const ruleset = new CustomDamageHookMockRuleset();
+      ruleset.setFixedDamage(0);
       ruleset.setMoveEffectResult({
         customDamage: {
           target: "defender",
+          // Source: 999 is intentionally over any plausible Gen 1 HP total so the
+          // test always exercises the capLethalDamage branch.
           amount: 999,
           source: "tackle",
           type: "normal",
@@ -222,29 +254,287 @@ describe("BattleEngine — damage path regression (#531, #538, #539)", () => {
         currentHp: 200,
       });
 
-      const { engine, events } = createEngine({ ruleset, team1: [charizard] });
+      const { engine, events } = createEngine({
+        ruleset,
+        team1: [charizard],
+        team2: [
+          createTestPokemon(9, 50, {
+            uid: "blastoise-1",
+            nickname: "Blastoise",
+            moves: [{ moveId: "swords-dance", currentPP: 20, maxPP: 20, ppUps: 0 }],
+            calculatedStats: {
+              hp: 200,
+              attack: 100,
+              defense: 100,
+              spAttack: 100,
+              spDefense: 100,
+              speed: 80,
+            },
+            currentHp: 200,
+          }),
+        ],
+      });
       engine.start();
 
       engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
       engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
 
       const defender = engine.getState().sides[1].active[0];
-      expect(defender?.pokemon.currentHp).toBe(1);
+      expect(defender).toBeDefined();
+      const defenderMaxHp = defender!.pokemon.calculatedStats?.hp ?? defender!.pokemon.currentHp;
+      const expectedDamage = defenderMaxHp - 1;
+      expect(defender!.pokemon.currentHp).toBe(1);
 
       const damageEvent = events.find((event) => event.type === "damage" && event.side === 1);
-      expect(damageEvent).toBeDefined();
-      expect(damageEvent && "amount" in damageEvent ? damageEvent.amount : null).toBe(153);
+      expect(damageEvent).toMatchObject({
+        type: "damage",
+        side: 1,
+        amount: expectedDamage,
+        currentHp: 1,
+        maxHp: defenderMaxHp,
+        source: "tackle",
+      });
 
       expect(ruleset.damageReceivedCalls).toContainEqual({
         defenderUid: "blastoise-1",
-        damage: 153,
+        damage: expectedDamage,
         moveId: "tackle",
       });
 
       const surviveMessage = events.find(
         (event) => event.type === "message" && event.text === "Custom damage was capped",
       );
-      expect(surviveMessage).toBeDefined();
+      expect(surviveMessage).toMatchObject({
+        type: "message",
+        text: "Custom damage was capped",
+      });
+    });
+
+    it("given a non-lethal custom damage amount, when it resolves, then the engine applies the exact damage once", () => {
+      const ruleset = new MockRuleset();
+      ruleset.setFixedDamage(0);
+      ruleset.setMoveEffectResult({
+        customDamage: {
+          target: "defender",
+          // Source: this fixture is intentionally below max HP so the test verifies
+          // the direct subtraction path rather than the capLethalDamage branch.
+          amount: 37,
+          source: "tackle",
+          type: "normal",
+        },
+      });
+
+      const charizard = createTestPokemon(6, 50, {
+        uid: "charizard-1",
+        nickname: "Charizard",
+        moves: [{ moveId: "swords-dance", currentPP: 20, maxPP: 20, ppUps: 0 }],
+        calculatedStats: {
+          hp: 200,
+          attack: 100,
+          defense: 100,
+          spAttack: 100,
+          spDefense: 100,
+          speed: 120,
+        },
+        currentHp: 200,
+      });
+
+      const { engine, events } = createEngine({
+        ruleset,
+        team1: [charizard],
+        team2: [
+          createTestPokemon(9, 50, {
+            uid: "blastoise-1",
+            nickname: "Blastoise",
+            moves: [{ moveId: "swords-dance", currentPP: 20, maxPP: 20, ppUps: 0 }],
+            calculatedStats: {
+              hp: 200,
+              attack: 100,
+              defense: 100,
+              spAttack: 100,
+              spDefense: 100,
+              speed: 80,
+            },
+            currentHp: 200,
+          }),
+        ],
+      });
+      engine.start();
+
+      const defender = engine.getState().sides[1].active[0];
+      expect(defender).toBeDefined();
+      const startingHp = defender!.pokemon.currentHp;
+
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      expect(defender!.pokemon.currentHp).toBe(startingHp - 37);
+
+      const damageEvent = events.find((event) => event.type === "damage" && event.side === 1);
+      expect(damageEvent).toMatchObject({
+        type: "damage",
+        side: 1,
+        amount: 37,
+        currentHp: startingHp - 37,
+        source: "tackle",
+      });
+    });
+
+    it("given custom damage hits a substitute, when it resolves, then the substitute absorbs it and reactive hooks stay silent", () => {
+      const ruleset = new CustomDamageHookMockRuleset();
+      ruleset.setFixedDamage(0);
+      ruleset.setMoveEffectResult({
+        customDamage: {
+          target: "defender",
+          // Source: this fixture uses contact move data so the regression covers the
+          // same hook path as normal damaging contact attacks.
+          amount: 30,
+          source: "tackle",
+          type: "normal",
+        },
+      });
+
+      const charizard = createTestPokemon(6, 50, {
+        uid: "charizard-1",
+        nickname: "Charizard",
+        moves: [{ moveId: "swords-dance", currentPP: 20, maxPP: 20, ppUps: 0 }],
+        calculatedStats: {
+          hp: 200,
+          attack: 100,
+          defense: 100,
+          spAttack: 100,
+          spDefense: 100,
+          speed: 120,
+        },
+        currentHp: 200,
+      });
+
+      const { engine, events } = createEngine({
+        ruleset,
+        team1: [charizard],
+        team2: [
+          createTestPokemon(9, 50, {
+            uid: "blastoise-1",
+            nickname: "Blastoise",
+            moves: [{ moveId: "swords-dance", currentPP: 20, maxPP: 20, ppUps: 0 }],
+            calculatedStats: {
+              hp: 200,
+              attack: 100,
+              defense: 100,
+              spAttack: 100,
+              spDefense: 100,
+              speed: 80,
+            },
+            currentHp: 200,
+          }),
+        ],
+      });
+      engine.start();
+
+      const defender = engine.getState().sides[1].active[0];
+      expect(defender).toBeDefined();
+      defender!.substituteHp = 50;
+      defender!.volatileStatuses.set("substitute", { turnsLeft: -1 });
+      const startingHp = defender!.pokemon.currentHp;
+
+      events.length = 0;
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      expect(defender!.substituteHp).toBe(20);
+      expect(defender!.pokemon.currentHp).toBe(startingHp);
+      expect(ruleset.damageReceivedCalls).toEqual([]);
+      expect(ruleset.abilityTriggerCalls).toEqual([]);
+      expect(ruleset.heldItemTriggerCalls).toEqual([]);
+
+      const substituteMessage = events.find(
+        (event) => event.type === "message" && event.text === "The substitute took damage!",
+      );
+      expect(substituteMessage).toMatchObject({
+        type: "message",
+        text: "The substitute took damage!",
+      });
+
+      const defenderDamageEvent = events.find(
+        (event) => event.type === "damage" && event.side === 1,
+      );
+      expect(defenderDamageEvent).toBeUndefined();
+    });
+
+    it.each([
+      [-5],
+      [Number.NaN],
+    ])("given custom damage amount %s, when it resolves, then it is normalized to zero and does not heal or fire hooks", (amount) => {
+      const ruleset = new CustomDamageHookMockRuleset();
+      ruleset.setFixedDamage(0);
+      ruleset.setMoveEffectResult({
+        customDamage: {
+          target: "defender",
+          // Source: invalid inputs are clamped to zero so they cannot heal or
+          // trigger the downstream reactive hooks.
+          amount,
+          source: "tackle",
+          type: "normal",
+        },
+      });
+
+      const charizard = createTestPokemon(6, 50, {
+        uid: "charizard-1",
+        nickname: "Charizard",
+        moves: [{ moveId: "swords-dance", currentPP: 20, maxPP: 20, ppUps: 0 }],
+        calculatedStats: {
+          hp: 200,
+          attack: 100,
+          defense: 100,
+          spAttack: 100,
+          spDefense: 100,
+          speed: 120,
+        },
+        currentHp: 200,
+      });
+
+      const { engine, events } = createEngine({
+        ruleset,
+        team1: [charizard],
+        team2: [
+          createTestPokemon(9, 50, {
+            uid: "blastoise-1",
+            nickname: "Blastoise",
+            moves: [{ moveId: "swords-dance", currentPP: 20, maxPP: 20, ppUps: 0 }],
+            calculatedStats: {
+              hp: 200,
+              attack: 100,
+              defense: 100,
+              spAttack: 100,
+              spDefense: 100,
+              speed: 80,
+            },
+            currentHp: 200,
+          }),
+        ],
+      });
+      engine.start();
+
+      const defender = engine.getState().sides[1].active[0];
+      expect(defender).toBeDefined();
+      const startingHp = defender!.pokemon.currentHp;
+
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      expect(defender!.pokemon.currentHp).toBe(startingHp);
+      expect(ruleset.damageReceivedCalls).toEqual([]);
+      expect(ruleset.abilityTriggerCalls).toEqual([]);
+      expect(ruleset.heldItemTriggerCalls).toEqual([]);
+
+      const damageEvent = events.find((event) => event.type === "damage" && event.side === 1);
+      expect(damageEvent).toMatchObject({
+        type: "damage",
+        side: 1,
+        amount: 0,
+        currentHp: startingHp,
+        source: "tackle",
+      });
     });
   });
 


### PR DESCRIPTION
Closes #829

## Summary
- route `MoveEffectResult.customDamage` through a shared helper instead of raw HP subtraction
- apply `capLethalDamage`, `onDamageReceived`, and defender item/ability/contact hooks to custom damage
- add a regression covering lethal custom damage on a status move path

## Verification
- `npx vitest run packages/battle/tests/engine/damage-path-regression.test.ts -t "customDamage uses the shared damage pipeline"`
- `npx vitest run packages/battle/tests/engine/damage-path-regression.test.ts`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/damage-path-regression.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unified custom damage application to properly route through the full damage pipeline, including substitute interactions, lethal-damage capping, and reactive ability/held-item triggers.
  * Improved switch-in ability ordering logic for scenarios involving multiple ability holders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->