### PR TITLE
fix: preserve damage-side hooks in executeMoveById

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -2331,7 +2331,7 @@ export class BattleEngine implements BattleEventEmitter {
         damage, // damage dealt this hit — required by Life Orb / Shell Bell handlers
       });
       if (atkItemResult.activated) {
-        this.processItemResult(atkItemResult, actor, action.side);
+        this.processItemResult(atkItemResult, actor, defender, action.side);
       }
     }
 
@@ -2611,6 +2611,22 @@ export class BattleEngine implements BattleEventEmitter {
     // Depth guard: only recurse once to prevent infinite chains (Metronome -> Metronome is excluded from the pool but defensive check)
     if (effectResult.recursiveMove) {
       this.executeMoveById(effectResult.recursiveMove, actor, actorSide, defender, defenderSide);
+    }
+
+    // Held item: on-hit trigger for attacker
+    // Recursive move execution should preserve the same attacker item hook parity as executeMove().
+    if (this.ruleset.hasHeldItems() && damage > 0) {
+      const atkItemResult = this.ruleset.applyHeldItem("on-hit", {
+        pokemon: actor,
+        opponent: defender,
+        state: this.state,
+        rng: this.state.rng,
+        damage,
+        move: moveData,
+      });
+      if (atkItemResult.activated) {
+        this.processItemResult(atkItemResult, actor, defender, actorSide);
+      }
     }
 
     actor.lastMoveUsed = moveId;

--- a/packages/battle/tests/engine/execute-move-by-id-hooks.test.ts
+++ b/packages/battle/tests/engine/execute-move-by-id-hooks.test.ts
@@ -162,6 +162,9 @@ describe("BattleEngine.executeMoveById recursive hook parity", () => {
   });
 
   it("given a recursive contact move that deals damage, when executeMoveById resolves it, then on-damage-taken and on-contact hooks fire", () => {
+    // Source of truth: executeMove() should remain the parity baseline for recursive move execution.
+    // A successful damaging contact hit reaches defender on-damage-taken/on-contact hooks and attacker
+    // on-hit item hooks (Life Orb / Shell Bell style post-damage effects) in the normal move path.
     const ruleset = new RecursiveHookRuleset({
       recursiveMoveId: "tackle",
       damageByMoveId: {
@@ -176,8 +179,12 @@ describe("BattleEngine.executeMoveById recursive hook parity", () => {
     engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
     engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
 
+    // Source: executeMove() parity contract for recursive moves.
     expect(ruleset.recursiveEffectCalls).toEqual(["tackle"]);
-    expect(ruleset.itemTriggers).toEqual(expect.arrayContaining(["on-damage-taken", "on-contact"]));
+    expect(ruleset.itemTriggers).toEqual(
+      expect.arrayContaining(["on-damage-taken", "on-contact", "on-hit"]),
+    );
+    // Source: executeMove() parity contract for recursive moves.
     expect(ruleset.damageAbilityTriggers).toEqual(
       expect.arrayContaining(["on-damage-taken", "on-contact"]),
     );


### PR DESCRIPTION
## Summary
- restore executeMoveById passive-immunity handling and defender-side damage hooks
- add focused regressions covering passive immunity and damage-side hook parity

Closes #832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passive-immunity abilities now trigger early when a move deals no damage, preventing follow-up damage/contact effects.
  * Defender-held-item and ability triggers for on-damage-taken and on-contact now run reliably after damage resolution.
  * Substitute interactions improved so contact/damage hooks do not fire when a substitute absorbs the hit.
* **Tests**
  * New tests verify passive-immunity, recursive move effects, and parity of attacker/defender trigger behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->