### PR TITLE
docs: refresh battle status references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ AI reviews are advisory (comments only, never formal approvals). See `.github/AI
 | Package | Status | Tests | Open Bugs | Key Notes |
 |---------|--------|-------|-----------|-----------|
 | core | 100% | 342 | 0 | All entity interfaces, stat calc, type effectiveness, PRNG |
-| battle | 100% (singles) | 546 | 0 | Doubles/Triples deferred |
+| battle | 100% (singles) | 596 | 0 | Doubles/Triples deferred |
 | gen1 | 100% | 800 | 1 (#530 badge glitch — enhancement) | All move handlers done |
 | gen2 | 100% | 757 | 0 | All engine-level bugs closed |
 | gen3 | 100% | 847 | 1 (#141 Plus/Minus — doubles) | Charge/Mud Sport/Water Sport fixed |

--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ cd packages/core && npx vitest run --coverage
 
 ## Project Status
 
-All nine generations are complete. 10,282+ tests across all packages, validated against Showdown and Bulbapedia reference values.
+All nine generations are complete. 10,332+ tests across all packages, validated against Showdown and Bulbapedia reference values.
 
 | Package | Tests | Key Notes |
 |---------|-------|-----------|
 | core | 342 | All entity interfaces, stat calc, type effectiveness, PRNG |
-| battle | 546 | Singles engine complete; doubles deferred |
+| battle | 596 | Singles engine complete; doubles deferred |
 | gen1 | 800 | All move handlers done; Gen 1 quirks (Focus Energy bug, 1/256 miss, etc.) |
 | gen2 | 757 | Gen 2 mechanics complete (held items, weather, Special split) |
 | gen3 | 847 | Abilities system, natures, weather; extends BaseRuleset |

--- a/specs/battle/12-doubles.md
+++ b/specs/battle/12-doubles.md
@@ -54,7 +54,7 @@ A separate `if (format === "doubles")` code path was rejected — it would dupli
 
 ## Phase 0: Foundation Refactor
 
-**Goal**: Replace all `active[0]` references with slot-aware helpers. Zero behavioral change — all 546 existing battle tests must pass unchanged.
+**Goal**: Replace all `active[0]` references with slot-aware helpers. Zero behavioral change — all 596 existing battle tests must pass unchanged.
 
 ### New helper methods on BattleEngine
 
@@ -319,7 +319,7 @@ Gen-specific ability/damage calc files, `BattleEngine.ts`. ~500 lines.
 
 | Phase | Test Strategy |
 |-------|--------------|
-| 0 | All 546 existing singles tests pass unchanged. New tests for helper methods. |
+| 0 | All 596 existing singles tests pass unchanged. New tests for helper methods. |
 | 1 | `doubles-turn-loop.test.ts` — 4-action submission, priority sort, spread moves, single-target resolution |
 | 2 | `doubles-faint-handling.test.ts` — mid-turn faint, slot replacement, double faint |
 | 3 | `doubles-battle-start.test.ts` — 2 leads per side, entry ability ordering |

--- a/specs/reference/battle-status.md
+++ b/specs/reference/battle-status.md
@@ -1,6 +1,6 @@
 # Battle Implementation Status
 
-**Last updated:** 2026-03-22
+**Last updated:** 2026-03-24
 **Overall estimate:** ~100% complete for singles battles (EXP gain + catch mechanics merged)
 **Architecture:** Pluggable gen-agnostic engine. Delegates ALL gen-specific behavior to GenerationRuleset. Depends only on @pokemon-lib-ts/core.
 
@@ -8,21 +8,21 @@
 
 ## DONE
 
-### BattleEngine (`packages/battle/src/engine/BattleEngine.ts` — 3,303 lines)
+### BattleEngine (`packages/battle/src/engine/BattleEngine.ts` — 5,891 lines)
 - Full turn resolution loop (turn-start → action selection → priority sort → turn-resolve → turn-end → faint-check)
 - `start()`, `submitAction()`, `submitSwitch()`, `getAvailableMoves()`, `getAvailableSwitches()`
 - `serialize()`/`deserialize()` — full JSON-safe state serialization
 - Event emitter system (`on`/`off`/`getEventLog`/`emit`)
 - Factory `fromGeneration()` via GenerationRegistry
 
-### GenerationRuleset Interface (`packages/battle/src/ruleset/GenerationRuleset.ts` — 413 lines)
+### GenerationRuleset Interface (`packages/battle/src/ruleset/GenerationRuleset.ts` — 753 lines)
 - 15 sub-interfaces (ISP): TypeSystem, StatCalculator, DamageSystem, CriticalHitSystem, TurnOrderSystem, MoveSystem, StatusSystem, AbilitySystem, ItemSystem, WeatherSystem, TerrainSystem, HazardSystem, SwitchSystem, EndOfTurnSystem, ValidationSystem
 - ~40 methods total; fully covers all battle delegation points
 
-### BaseRuleset (`packages/battle/src/ruleset/BaseRuleset.ts` — 627 lines)
+### BaseRuleset (`packages/battle/src/ruleset/BaseRuleset.ts` — 1,027 lines)
 - All Gen 3+ defaults: stat calc, crit (Gen 6+ 1.5×), turn order, accuracy/evasion, status damage, freeze/thaw, sleep/confusion/paralysis, Struggle, multi-hit, Protect diminishing returns, bind, perish song
 - 17-item EoT order, Pursuit pre-switch, switch-out volatile clearing
-- Tests: 4 files, ~2,187 lines
+- Tests: 4 files, 2,780 lines
 
 ### BattleState, BattleSide, ActivePokemon
 - `BattlePhase` (8 phases), `BattleFormat` (4 formats — singles only implemented), `WeatherState`, `TerrainState`, `TurnRecord`
@@ -73,21 +73,21 @@ Gen 5+ stubs (moody, harvest, grassy-terrain-heal now implemented in gen5+ rules
 ### AI Controllers
 - `AIController` interface — `chooseAction()`, `chooseSwitchIn()`
 - `RandomAI` — random move (with PP) or Struggle; random valid switch, or `null` when no legal replacement exists
-- Tests: 2 files, 758 lines
+- Tests: 2 files, 855 lines
 
 ### MockRuleset + MockDataManager (test helpers)
-- `tests/helpers/mock-ruleset.ts` — 394 lines, configurable fixed damage/hit/crit
-- `tests/helpers/mock-data-manager.ts` — 370 lines
+- `tests/helpers/mock-ruleset.ts` — 586 lines, configurable fixed damage/hit/crit
+- `tests/helpers/mock-data-manager.ts` — 519 lines
 
 ### Serialization
 - `serialize()`/`deserialize()` round-trips full battle state including Map/Set/SeededRandom
-- Tests: `deserialize.test.ts` (228 lines)
+- Tests: `deserialize.test.ts` (737 lines)
 
 ---
 
 ## STUBBED
 
-None — all previously stubbed items are now implemented.
+- `pickup` — Gen 5+ effect (overworld mechanic, negligible singles battle impact); still a stub in engine
 
 ---
 
@@ -98,7 +98,6 @@ None — all previously stubbed items are now implemented.
 | Doubles/Triples/Rotation formats | Massive separate initiative; BattleFormat type exists |
 | Greedy AI controller | Spec'd but deferred; RandomAI is sufficient for current gens |
 | Minimax AI controller | Spec'd but deferred |
-| pickup | Gen 5+ effect (overworld mechanic, negligible singles battle impact); stub in engine |
 
 ---
 


### PR DESCRIPTION
Refresh stale battle status counts and resolve the pickup stub inconsistency in the battle docs.

Verification:
- npm run test --workspace @pokemon-lib-ts/battle
- git diff --check

Closes #827