### PR TITLE
fix(gen8): block Ice Face before damage

### DIFF
--- a/packages/battle/tests/engine/ice-face-regression.test.ts
+++ b/packages/battle/tests/engine/ice-face-regression.test.ts
@@ -82,7 +82,7 @@ describe("Bug #890 - Gen 8 Ice Face pre-damage blocking", () => {
     engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
 
     expect(defender.pokemon.currentHp).toBe(startingHp);
-    expect(defender.volatileStatuses.has("ice-face-broken" as never)).toBe(true);
+    expect(defender.volatileStatuses.has("ice-face-broken")).toBe(true);
 
     const damageEvents = events.filter((event) => event.type === "damage" && event.side === 1);
     expect(damageEvents).toHaveLength(1);

--- a/packages/core/src/entities/status.ts
+++ b/packages/core/src/entities/status.ts
@@ -83,6 +83,7 @@ export type VolatileStatus =
   | "obstruct" // Obstruct — protect variant, blocks moves with protect flag; -2 Def on contact (Gen 8)
   | "jaw-lock" // Jaw Lock — traps both user and target (Gen 8)
   | "max-guard" // Max Guard — Dynamax protect variant; blocks ALL moves including other Max Moves (Gen 8)
+  | "ice-face-broken" // Ice Face — Eiscue's first physical-hit shield has been spent (Gen 8)
   | "protosynthesis" // Protosynthesis — boosts highest stat in Sun or with Booster Energy (Gen 9); data: { boostedStat: string }
   | "quarkdrive" // Quark Drive — boosts highest stat on Electric Terrain or with Booster Energy (Gen 9); data: { boostedStat: string }
   | "embody-aspect-used" // Embody Aspect (Ogerpon) — tracks once-per-battle activation (Gen 9)

--- a/packages/gen8/src/Gen8AbilitiesSwitch.ts
+++ b/packages/gen8/src/Gen8AbilitiesSwitch.ts
@@ -878,14 +878,14 @@ function handleIceFaceOnHit(ctx: AbilityContext): AbilityResult {
   if (!ctx.move || ctx.move.category !== "physical") return NO_EFFECT;
 
   // Check if Ice Face is active (not broken)
-  if (ctx.pokemon.volatileStatuses.has("ice-face-broken" as never)) return NO_EFFECT;
+  if (ctx.pokemon.volatileStatuses.has("ice-face-broken")) return NO_EFFECT;
 
   const name = getName(ctx);
   return {
     activated: true,
     effects: [
       { effectType: "damage-reduction", target: "self" },
-      { effectType: "volatile-inflict", target: "self", volatile: "ice-face-broken" as never },
+      { effectType: "volatile-inflict", target: "self", volatile: "ice-face-broken" },
     ],
     messages: [`${name}'s Ice Face absorbed the damage!`],
   };

--- a/packages/gen8/src/Gen8Ruleset.ts
+++ b/packages/gen8/src/Gen8Ruleset.ts
@@ -535,7 +535,7 @@ export class Gen8Ruleset extends BaseRuleset {
       isIceFaceActive(
         defender.pokemon.speciesId,
         defender.ability,
-        defender.volatileStatuses.has("ice-face-broken" as never),
+        defender.volatileStatuses.has("ice-face-broken"),
       )
     ) {
       defender.volatileStatuses.set("ice-face-broken", { turnsLeft: -1 });


### PR DESCRIPTION
## Summary
- Move Gen 8 Ice Face into the pre-damage capLethalDamage hook so Eiscues first physical hit is blocked before HP changes.
- Add a regression test that proves Eiscue keeps full HP and records the broken Ice Face volatile when struck by a physical move.

Closes #890

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ice Face ability mechanics for Eiscue; the ability now properly blocks the first incoming physical hit and transitions to its broken state accordingly.

* **Tests**
  * Added regression test for Ice Face ability behavior to ensure consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->