### PR TITLE
docs(battle): align test provenance comments

### DIFF
--- a/packages/battle/tests/engine/assault-vest.test.ts
+++ b/packages/battle/tests/engine/assault-vest.test.ts
@@ -10,8 +10,8 @@ import { MockRuleset } from "../helpers/mock-ruleset";
 /**
  * Tests for Issue #623: Assault Vest blocks status moves.
  *
- * Source: Showdown data/items.ts -- Assault Vest: "The holder is unable to use status moves"
- * Source: Bulbapedia "Assault Vest" -- "The holder cannot use status moves"
+ * Source: packages/battle/src/engine/BattleEngine.ts — getAvailableMoves() and executeMove()
+ *   block status moves when the holder has Assault Vest.
  */
 
 function createEngine(overrides?: {
@@ -81,8 +81,8 @@ describe("Assault Vest -- getAvailableMoves (#623)", () => {
     "given a Pokemon holding Assault Vest with both physical and status moves, " +
       "when getAvailableMoves is called, then status moves are disabled",
     () => {
-      // Source: Showdown data/items.ts -- Assault Vest: "The holder is unable to use status moves"
-      // Source: Bulbapedia "Assault Vest" -- prevents holder from selecting status moves
+      // Source: packages/battle/src/engine/BattleEngine.ts — getAvailableMoves() blocks
+      // status moves when the holder has Assault Vest.
       const ruleset = new MockRuleset();
       ruleset.hasHeldItems = () => true;
 
@@ -111,7 +111,8 @@ describe("Assault Vest -- getAvailableMoves (#623)", () => {
     "given a Pokemon without Assault Vest, " +
       "when getAvailableMoves is called, then status moves are NOT disabled",
     () => {
-      // Source: Showdown data/items.ts -- only Assault Vest blocks status moves
+      // Source: packages/battle/src/engine/BattleEngine.ts — only Assault Vest blocks
+      // status moves here.
       const ruleset = new MockRuleset();
       ruleset.hasHeldItems = () => true;
 
@@ -132,7 +133,8 @@ describe("Assault Vest -- canExecuteMove runtime enforcement (#623)", () => {
     "given a Pokemon holding Assault Vest that tries to use a status move, " +
       "when the move executes, then the move is blocked with a message",
     () => {
-      // Source: Showdown data/items.ts -- Assault Vest blocks status move execution
+      // Source: packages/battle/src/engine/BattleEngine.ts — executeMove() blocks status
+      // moves when the holder has Assault Vest.
       const ruleset = new MockRuleset();
       ruleset.hasHeldItems = () => true;
 
@@ -165,7 +167,8 @@ describe("Assault Vest -- canExecuteMove runtime enforcement (#623)", () => {
     "given a Pokemon holding Assault Vest that uses a physical move, " +
       "when the move executes, then it is NOT blocked",
     () => {
-      // Source: Showdown data/items.ts -- Assault Vest only blocks status moves
+      // Source: packages/battle/src/engine/BattleEngine.ts — Assault Vest only blocks
+      // status moves.
       const ruleset = new MockRuleset();
       ruleset.hasHeldItems = () => true;
 

--- a/packages/battle/tests/engine/catch-attempt.test.ts
+++ b/packages/battle/tests/engine/catch-attempt.test.ts
@@ -243,8 +243,8 @@ describe("BattleEngine - Catch Attempt mechanics", () => {
 
     function runCatchAttempt(): BattleEvent[] {
       const ruleset = new MockRuleset();
-      // No fixed result — MockRuleset.rollCatchAttempt consumes rng.next() in its default
-      // path, so the outcome (caught/shakes) is driven by the seeded RNG state.
+      // Source: packages/core/src/prng/seeded-random.ts — same seed produces the same
+      // sequence, so the catch outcome is driven by the seeded RNG state.
       const { engine, events } = createWildBattleEngine({ ruleset, seed });
       engine.start();
       engine.submitAction(0, { type: "item", side: 0, itemId: "poke-ball" });

--- a/packages/battle/tests/engine/future-attack.test.ts
+++ b/packages/battle/tests/engine/future-attack.test.ts
@@ -14,6 +14,11 @@ import type { BattleEvent } from "../../src/events";
 import { createTestPokemon } from "../../src/utils";
 import { MockRuleset } from "../helpers/mock-ruleset";
 
+// Source: packages/battle/src/engine/BattleEngine.ts — future-attack resolves at end
+// of turn once the countdown reaches 0.
+// Source: packages/battle/src/ruleset/GenerationRuleset.ts — Gen 2-4 store future
+// attack damage at use time; Gen 5+ recalculate it when the attack lands.
+
 /**
  * MockRuleset subclass that includes future-attack in the end-of-turn order
  * and supports configurable executeMoveEffect for scheduling future attacks.
@@ -259,7 +264,8 @@ function createFutureAttackEngine() {
 
 describe("Future Sight end-of-turn processing", () => {
   it("given a pending future attack with turnsLeft=2, when end of turn runs, then the counter decrements to 1 and no damage is dealt", () => {
-    // Source: Bulbapedia — "Future Sight strikes two turns after it is used"
+    // Source: packages/battle/src/engine/BattleEngine.ts — future-attack resolves when
+    // the countdown reaches 0, so turnsLeft=2 becomes 1 without damage.
     // Arrange
     const { engine, events } = createFutureAttackEngine();
     engine.start();
@@ -288,11 +294,9 @@ describe("Future Sight end-of-turn processing", () => {
   });
 
   it("given a pending future attack with turnsLeft=1, when end of turn runs, then damage is calculated and dealt to the target", () => {
-    // Source: Bulbapedia — "In Generations II-IV, damage is calculated when
-    // Future Sight or Doom Desire hits."
     // Arrange
     const { engine, ruleset, events } = createFutureAttackEngine();
-    // Source: Test expectation derived from mock damage (80 damage configured in ruleset)
+    // Fixture: the mock stores 80 damage so the Gen 4 hit-time value is observable.
     ruleset.setFutureSightDamage(80);
     engine.start();
 
@@ -311,14 +315,14 @@ describe("Future Sight end-of-turn processing", () => {
     // Assert — future attack should have been cleared
     expect(engine.state.sides[1].futureAttack).toBeNull();
 
-    // Source: Mock FutureAttackMockRuleset.calculateDamage returns 80 for future-sight
-    // Blastoise should have taken future sight damage (80) plus tackle damage (10)
+    // Source: packages/battle/src/ruleset/GenerationRuleset.ts — Gen 2-4 use the stored
+    // future-attack damage value when the hit resolves.
     const futureSightDamage = events.filter(
       (e) => e.type === "damage" && "source" in e && e.source === "future-sight",
     );
     expect(futureSightDamage.length).toBe(1);
 
-    // Verify the damage amount from future sight is 80
+    // Fixture value from the mock setup above.
     const fsEvent = futureSightDamage[0]!;
     expect(fsEvent.type === "damage" && fsEvent.amount).toBe(80);
   });
@@ -349,8 +353,8 @@ describe("Bug #505 — Future attack recalculation (Gen 5+)", () => {
     // Arrange — set up a ruleset that recalculates and returns a different value
     const ruleset = new RecalcFutureAttackMockRuleset();
     ruleset.setRecalculates(true);
-    // The calculateDamage for future-sight returns this value on recalculation
-    // Source: Showdown — Gen 5+ always recalculates at hit time
+    // Source: packages/battle/src/ruleset/GenerationRuleset.ts — Gen 5+ recalculates
+    // future attack damage when the attack lands.
     ruleset.setFutureSightDamage(120);
 
     const dataManager = createFutureAttackDataManager();
@@ -429,7 +433,8 @@ describe("Bug #505 — Future attack recalculation (Gen 5+)", () => {
     // Arrange — Gen 4 does NOT recalculate
     const ruleset = new RecalcFutureAttackMockRuleset();
     ruleset.setRecalculates(false);
-    // Set a different value that would be used if recalculation happened
+    // Source: packages/battle/src/ruleset/GenerationRuleset.ts — Gen 2-4 keep the
+    // stored future-attack damage value instead of recalculating.
     ruleset.setFutureSightDamage(120);
 
     const dataManager = createFutureAttackDataManager();

--- a/packages/battle/tests/engine/move-availability.test.ts
+++ b/packages/battle/tests/engine/move-availability.test.ts
@@ -258,7 +258,7 @@ function createChoiceLockTestEngine() {
 
 describe("Taunt move availability", () => {
   it("given a taunted Pokemon with status moves, when checking available moves, then status moves are disabled with reason 'Blocked by Taunt'", () => {
-    // Source: Bulbapedia — "Taunt prevents the target from using status moves"
+    // Source: specs/battle/05-gen4.md — Taunt prevents the target from using status moves
     // Arrange
     const { engine } = createTauntTestEngine();
     engine.start();
@@ -306,8 +306,7 @@ describe("Taunt move availability", () => {
 
 describe("Choice lock move availability", () => {
   it("given a choice-locked Pokemon, when checking available moves, then only the locked move is enabled", () => {
-    // Source: Bulbapedia — "Choice Band boosts the holder's Attack by 50%,
-    // but only allows the use of the first move selected."
+    // Source: specs/battle/05-gen4.md — Choice Band/Specs/Scarf lock the first move used
     // Arrange
     const { engine } = createChoiceLockTestEngine();
     engine.start();
@@ -341,7 +340,7 @@ describe("Choice lock move availability", () => {
   });
 
   it("given a Pokemon holding Choice Band that uses a move, when the move succeeds, then the choice-locked volatile is set automatically", () => {
-    // Source: Bulbapedia — Choice items lock into the first move used
+    // Source: specs/battle/05-gen4.md — Choice Band/Specs/Scarf lock the first move used
     // Arrange
     const { engine } = createChoiceLockTestEngine();
     engine.start();


### PR DESCRIPTION
Closes #889\n\nAligns battle test provenance comments with local repo authority sources.