### PR TITLE
Fix unknown item ids in executeItem

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -2583,7 +2583,10 @@ export class BattleEngine implements BattleEventEmitter {
     try {
       itemData = this.dataManager.getItem(action.itemId);
     } catch {
-      // Item not in data manager — fall through to normal bag item logic
+      this.emit({
+        type: "engine-warning",
+        message: `Item "${action.itemId}" not found in data manager; falling back to bag-item handling.`,
+      });
     }
     if (itemData?.useEffect?.type === "catch") {
       this.executeCatchAttempt(action, itemData);

--- a/packages/battle/tests/engine/item-action.test.ts
+++ b/packages/battle/tests/engine/item-action.test.ts
@@ -398,6 +398,43 @@ describe("BattleEngine - ItemAction bag item usage", () => {
     });
   });
 
+  describe("unknown item ids", () => {
+    it("given an item action with an unknown item id, when it is submitted, then the engine emits a warning and still falls back to bag-item handling", () => {
+      const ruleset = new MockRuleset();
+
+      const { engine, events } = createTestEngine({ ruleset });
+      engine.start();
+
+      engine.submitAction(0, { type: "item", side: 0, itemId: "mystery-item" });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      const warning = events.find((event) => event.type === "engine-warning");
+      expect(warning).toMatchObject({
+        type: "engine-warning",
+        message:
+          'Item "mystery-item" not found in data manager; falling back to bag-item handling.',
+      });
+
+      const usageMessage = events.find(
+        (event) =>
+          event.type === "message" && "text" in event && event.text === "Side 0 used mystery-item!",
+      );
+      expect(usageMessage).toMatchObject({
+        type: "message",
+        text: "Side 0 used mystery-item!",
+      });
+
+      const noEffectMessage = events.find(
+        (event) =>
+          event.type === "message" && "text" in event && event.text === "It had no effect.",
+      );
+      expect(noEffectMessage).toMatchObject({
+        type: "message",
+        text: "It had no effect.",
+      });
+    });
+  });
+
   describe("Full Restore", () => {
     it("given a Full Restore used on a damaged and poisoned pokemon, when item action submitted, then both heal and status cure events emitted", () => {
       // Arrange


### PR DESCRIPTION
Closes #844\n\n## Summary\n- Emit an engine warning when executeItem cannot resolve an item id from the data manager\n- Keep the existing bag-item fallback behavior so the battle flow remains unchanged\n- Add a regression test for unknown item ids\n\n## Verification\n- npx vitest run packages/battle/tests/engine/item-action.test.ts -t "unknown item ids"\n- npx biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/item-action.test.ts\n- npm run typecheck -w @pokemon-lib-ts/battle