### PR TITLE
fix(battle): warn on missing defender move data

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -5211,6 +5211,12 @@ export class BattleEngine implements BattleEventEmitter {
       const moveData = this.dataManager.getMove(moveSlot.moveId);
       return { id: moveData.id, category: moveData.category };
     } catch {
+      this.emit({
+        type: "engine-warning",
+        message:
+          `Move "${moveSlot.moveId}" not found while resolving defenderSelectedMove ` +
+          `for Sucker Punch. Treating this as missing move data, not a switch action.`,
+      });
       return null;
     }
   }

--- a/packages/battle/tests/engine/battle-engine-branches.test.ts
+++ b/packages/battle/tests/engine/battle-engine-branches.test.ts
@@ -364,6 +364,49 @@ describe("BattleEngine — branch coverage", () => {
     });
   });
 
+  describe("getDefenderSelectedMove with unknown move data", () => {
+    it("given the defender selected a move missing from the data manager, when Sucker Punch resolves, then the engine emits a warning instead of silently treating it as switching", () => {
+      // Source: Showdown sim/battle-actions.ts Gen 4 — Sucker Punch depends on the target's selected move.
+      // Issue #843: missing move data must be surfaced distinctly from the normal null sentinel used for switching.
+      const team2 = [
+        createTestPokemon(9, 50, {
+          uid: "blastoise-1",
+          nickname: "Blastoise",
+          moves: [{ moveId: "nonexistent-move", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 200,
+            attack: 100,
+            defense: 100,
+            spAttack: 100,
+            spDefense: 100,
+            speed: 80,
+          },
+          currentHp: 200,
+        }),
+      ];
+
+      const { engine, events } = createEngine({ team2 });
+      engine.start();
+
+      // Simulate the turn state the engine would have when resolving Sucker Punch.
+      (engine as any).currentTurnActions = [
+        { type: "move", side: 0, moveIndex: 0 },
+        { type: "move", side: 1, moveIndex: 0 },
+      ];
+
+      const defenderSelectedMove = (engine as any).getDefenderSelectedMove(1);
+
+      expect(defenderSelectedMove).toBeNull();
+      const warning = events.find((e) => e.type === "engine-warning");
+      expect(warning).toEqual(
+        expect.objectContaining({
+          type: "engine-warning",
+          message: expect.stringContaining("defenderSelectedMove"),
+        }),
+      );
+    });
+  });
+
   describe("sleep status handling", () => {
     it("given a sleeping pokemon, when it tries to move, then it cannot act", () => {
       // Arrange


### PR DESCRIPTION
## Summary
- Emit an engine warning when defender move lookup fails while resolving Sucker Punch state.
- Keep the existing null sentinel for real non-move cases like switching.
- Add a regression test that proves the warning is emitted for missing move data.

Closes #843