### PR TITLE
fix: sync lucky chant state in battle engine

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -3566,6 +3566,7 @@ export class BattleEngine implements BattleEventEmitter {
           turns: result.screenSet.turnsLeft,
         });
       }
+      this.syncLuckyChant(screenSide);
     }
 
     // Screen clear (Haze or switch-out removes screens from a side)
@@ -4875,6 +4876,7 @@ export class BattleEngine implements BattleEventEmitter {
         }
         return true;
       });
+      this.syncLuckyChant(side);
     }
   }
 
@@ -4899,6 +4901,18 @@ export class BattleEngine implements BattleEventEmitter {
         screen: removedScreen.type,
       });
     }
+
+    this.syncLuckyChant(side);
+  }
+
+  private syncLuckyChant(side: BattleSide): void {
+    const luckyChantScreen = side.screens.find(
+      (screen) => (screen.type as string) === "lucky-chant",
+    );
+    side.luckyChant = {
+      active: luckyChantScreen !== undefined,
+      turnsLeft: luckyChantScreen?.turnsLeft ?? 0,
+    };
   }
 
   private processTailwindCountdown(): void {

--- a/packages/battle/tests/engine/process-effect-result-self.test.ts
+++ b/packages/battle/tests/engine/process-effect-result-self.test.ts
@@ -306,6 +306,54 @@ describe("processEffectResult — self-targeted effects", () => {
     );
   });
 
+  describe("screenSet", () => {
+    it("given screenSet screen='lucky-chant' on the attacker, when move is used, then the lucky-chant screen and side field stay synchronized", () => {
+      // Arrange
+      const ruleset = new MockRuleset();
+      ruleset.getEndOfTurnOrder = () => [];
+      let callCount = 0;
+      ruleset.executeMoveEffect = () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            statusInflicted: null,
+            volatileInflicted: null,
+            statChanges: [],
+            recoilDamage: 0,
+            healAmount: 0,
+            switchOut: false,
+            messages: [],
+            screenSet: { screen: "lucky-chant", turnsLeft: 5, side: "attacker" as const },
+          };
+        }
+        return {
+          statusInflicted: null,
+          volatileInflicted: null,
+          statChanges: [],
+          recoilDamage: 0,
+          healAmount: 0,
+          switchOut: false,
+          messages: [],
+        };
+      };
+
+      const { engine } = createEngine({ ruleset });
+      engine.start();
+
+      // Act
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert — Lucky Chant is tracked in both places so Gen 4 crit suppression can read it
+      expect(engine.state.sides[0].screens).toHaveLength(1);
+      expect(engine.state.sides[0].screens[0]?.turnsLeft).toBe(5);
+      expect((engine.state.sides[0].screens[0] as { type: string } | undefined)?.type).toBe(
+        "lucky-chant",
+      );
+      expect(engine.state.sides[0].luckyChant).toEqual({ active: true, turnsLeft: 5 });
+    });
+  });
+
   describe("statStagesReset", () => {
     // Source: pokered move_effects/haze.asm:15-43 — Haze resets stat stages for one or both
     // sides independently of status; status is NOT cured by statStagesReset.


### PR DESCRIPTION
Syncs Lucky Chant into BattleSide.luckyChant whenever screen state changes, so Gen 4 crit suppression can read the same source of truth as the screen list.

Verification:
- npx vitest run packages/battle/tests/engine/process-effect-result-self.test.ts
- npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/process-effect-result-self.test.ts
- npm run build --workspace @pokemon-lib-ts/battle

Closes #881