### PR TITLE
Fix safeguard double countdown in Gen 4-8

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -4982,6 +4982,11 @@ export class BattleEngine implements BattleEventEmitter {
   private processScreenCountdown(): void {
     for (const side of this.state.sides) {
       side.screens = side.screens.filter((screen) => {
+        // Safeguard has its own countdown handler in Gen 4-8 so it can keep the
+        // legacy wear-off message without being decremented twice per turn.
+        if ((screen.type as string) === "safeguard") {
+          return true;
+        }
         if (screen.turnsLeft < 0) return true; // permanent sentinel — never expires
         screen.turnsLeft--;
         if (screen.turnsLeft <= 0) {

--- a/packages/battle/tests/engine/battle-engine-advanced.test.ts
+++ b/packages/battle/tests/engine/battle-engine-advanced.test.ts
@@ -395,6 +395,33 @@ describe("BattleEngine — advanced scenarios", () => {
       expect(safeguardWearOffMessageIndex).toBeGreaterThanOrEqual(0);
       expect(screenEndIndex).toBeLessThan(safeguardWearOffMessageIndex);
     });
+
+    it("given Safeguard at 5 turns remaining, when both screen-countdown and safeguard-countdown run, then it only loses one turn", () => {
+      // Arrange
+      const ruleset = new MockRuleset();
+      const originalOrder = ruleset.getEndOfTurnOrder();
+      const patchedRuleset = Object.create(ruleset) as MockRuleset;
+      patchedRuleset.getEndOfTurnOrder = () => [
+        "screen-countdown" as const,
+        "safeguard-countdown" as const,
+        ...originalOrder,
+      ];
+
+      const { engine, events } = createEngine({ ruleset: patchedRuleset });
+      engine.start();
+
+      // Source: specs/battle/05-gen4.md lists Safeguard as lasting 5 turns in Gen 4.
+      engine.state.sides[0].screens = [{ type: "safeguard", turnsLeft: 5 }];
+
+      // Act
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert
+      expect(engine.state.sides[0].screens).toEqual([{ type: "safeguard", turnsLeft: 4 }]);
+      const screenEnd = events.find((event) => event.type === "screen-end");
+      expect(screenEnd).toBeUndefined();
+    });
   });
 
   describe("hazard removal effects", () => {


### PR DESCRIPTION
Closes #892\n\n## Summary\n- Keep the generic screen countdown from decrementing Safeguard\n- Preserve the dedicated safeguard countdown handler and its wear-off messaging\n- Add a regression test proving Safeguard only loses one turn when both countdown effects run\n\n## Verification\n- npx vitest run packages/battle/tests/engine/battle-engine-advanced.test.ts -t "only loses one turn"\n- npx vitest run packages/battle/tests/engine/battle-engine-advanced.test.ts\n- npx biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/battle-engine-advanced.test.ts\n- npm run typecheck -w @pokemon-lib-ts/battle