### PR TITLE
Fix forced-move missing-data warnings

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -829,25 +829,31 @@ export class BattleEngine implements BattleEventEmitter {
     if (active.forcedMove) {
       const forcedSlot = active.pokemon.moves[active.forcedMove.moveIndex];
       if (forcedSlot) {
-        return active.pokemon.moves.map((slot, index) => {
+        return active.pokemon.moves.flatMap((slot, index) => {
           const isForcedMove = index === active.forcedMove?.moveIndex;
           let moveData: MoveData | undefined;
           try {
             moveData = this.dataManager.getMove(slot.moveId);
           } catch {
-            // skip
+            this.emit({
+              type: "engine-warning",
+              message: `Move "${slot.moveId}" not found in data for Pokémon "${active.pokemon.speciesId}". Slot skipped.`,
+            });
+            return [];
           }
-          return {
-            index,
-            moveId: slot.moveId,
-            displayName: moveData?.displayName ?? slot.moveId,
-            type: moveData?.type ?? ("normal" as const),
-            category: moveData?.category ?? ("physical" as const),
-            pp: slot.currentPP,
-            maxPp: slot.maxPP,
-            disabled: !isForcedMove,
-            disabledReason: isForcedMove ? undefined : "Locked into move",
-          };
+          return [
+            {
+              index,
+              moveId: slot.moveId,
+              displayName: moveData.displayName,
+              type: moveData.type,
+              category: moveData.category,
+              pp: slot.currentPP,
+              maxPp: slot.maxPP,
+              disabled: !isForcedMove,
+              disabledReason: isForcedMove ? undefined : "Locked into move",
+            },
+          ];
         });
       }
     }

--- a/packages/battle/tests/engine/battle-engine-branches.test.ts
+++ b/packages/battle/tests/engine/battle-engine-branches.test.ts
@@ -362,6 +362,44 @@ describe("BattleEngine — branch coverage", () => {
       const warning = events.find((e) => e.type === "engine-warning");
       expect(warning).toBeDefined();
     });
+
+    it("given a pokemon locked into a missing forced move, when getAvailableMoves is called, then the move is skipped and a warning is emitted", () => {
+      // Arrange
+      const team1 = [
+        createTestPokemon(6, 50, {
+          uid: "charizard-1",
+          nickname: "Charizard",
+          moves: [
+            { moveId: "nonexistent-move", currentPP: 10, maxPP: 15, ppUps: 0 },
+            { moveId: "scratch", currentPP: 20, maxPP: 20, ppUps: 0 },
+          ],
+          currentHp: 200,
+        }),
+      ];
+
+      const { engine, events } = createEngine({ team1 });
+      engine.start();
+
+      const active = engine.state.sides[0].active[0];
+      expect(active).not.toBeNull();
+      active!.forcedMove = { moveIndex: 0, moveId: "nonexistent-move" };
+
+      // Act
+      const moves = engine.getAvailableMoves(0);
+
+      // Assert — the missing forced move is skipped, and the remaining move stays locked
+      expect(moves).toHaveLength(1);
+      expect(moves[0]).toEqual(
+        expect.objectContaining({
+          index: 1,
+          moveId: "scratch",
+          disabled: true,
+          disabledReason: "Locked into move",
+        }),
+      );
+      const warning = events.find((e) => e.type === "engine-warning");
+      expect(warning).toBeDefined();
+    });
   });
 
   describe("getDefenderSelectedMove with unknown move data", () => {


### PR DESCRIPTION
## Summary\n- Emit the same engine warning on forced-move lookups when move data is missing\n- Skip the bad slot instead of fabricating fallback metadata\n- Add regression coverage for the forced-move path\n\nCloses #837