### PR TITLE
fix(battle): emit stat-change for held-item boosts

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -1,4 +1,10 @@
-import type { DataManager, ItemData, MoveData, PrimaryStatus } from "@pokemon-lib-ts/core";
+import type {
+  BattleStat,
+  DataManager,
+  ItemData,
+  MoveData,
+  PrimaryStatus,
+} from "@pokemon-lib-ts/core";
 import { getExpForLevel, getStatStageMultiplier, SeededRandom } from "@pokemon-lib-ts/core";
 import type { AvailableMove, BattleConfig, MoveEffectResult } from "../context";
 import type {
@@ -5507,11 +5513,21 @@ export class BattleEngine implements BattleEventEmitter {
           // Stage boost to the specified stat for the holder.
           // Uses effect.stages if present (e.g., Weakness Policy = +2), defaulting to +1.
           // Source: Showdown -- stat pinch berries (+1), Weakness Policy (+2) onEat/onDamagingHit
-          const stat = effect.value as string;
+          const stat = effect.value as BattleStat;
           const boostStages = effect.stages ?? 1;
           const statStages = pokemon.statStages as Record<string, number>;
           if (stat in statStages) {
-            statStages[stat] = Math.min(6, (statStages[stat] ?? 0) + boostStages);
+            const currentStage = statStages[stat] ?? 0;
+            const newStage = Math.max(-6, Math.min(6, currentStage + boostStages));
+            statStages[stat] = newStage;
+            this.emit({
+              type: "stat-change",
+              side,
+              pokemon: getPokemonName(pokemon),
+              stat,
+              stages: boostStages,
+              currentStage: newStage,
+            });
           }
           break;
         }

--- a/packages/battle/tests/engine/held-item-stat-change.test.ts
+++ b/packages/battle/tests/engine/held-item-stat-change.test.ts
@@ -1,0 +1,111 @@
+import type { BattleConfig, ItemContext } from "../../src/context";
+import { BattleEngine } from "../../src/engine";
+import type { BattleEvent, StatChangeEvent } from "../../src/events";
+import { createTestPokemon } from "../../src/utils";
+import { createMockDataManager } from "../helpers/mock-data-manager";
+import { MockRuleset } from "../helpers/mock-ruleset";
+
+function makeStats(hp: number, speed: number) {
+  return {
+    hp,
+    attack: 100,
+    defense: 100,
+    spAttack: 100,
+    spDefense: 100,
+    speed,
+  };
+}
+
+class HeldItemStatBoostRuleset extends MockRuleset {
+  readonly itemTriggers: string[] = [];
+
+  override hasHeldItems(): boolean {
+    return true;
+  }
+
+  override calculateDamage() {
+    // Fixture: return super-effective damage so a Weakness Policy-style item activates.
+    return {
+      damage: 20,
+      effectiveness: 2,
+      isCrit: false,
+      randomFactor: 1,
+    };
+  }
+
+  override applyHeldItem(trigger: string, context: ItemContext) {
+    this.itemTriggers.push(trigger);
+
+    if (trigger === "on-damage-taken" && context.pokemon.pokemon.heldItem === "weakness-policy") {
+      return {
+        activated: true,
+        effects: [
+          // Source: packages/gen9/tests/items.test.ts -- Weakness Policy raises Attack and SpAtk by 2 stages.
+          { type: "stat-boost", target: "self", value: "attack", stages: 2 },
+          { type: "stat-boost", target: "self", value: "spAttack", stages: 2 },
+        ],
+        messages: ["Weakness Policy activated!"],
+      };
+    }
+
+    return { activated: false, effects: [], messages: [] };
+  }
+}
+
+function createHeldItemStatBoostEngine(ruleset: HeldItemStatBoostRuleset) {
+  const config: BattleConfig = {
+    generation: 9,
+    format: "singles",
+    teams: [
+      [
+        createTestPokemon(6, 50, {
+          uid: "charizard-1",
+          nickname: "Charizard",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: makeStats(200, 120),
+          currentHp: 200,
+        }),
+      ],
+      [
+        createTestPokemon(9, 50, {
+          uid: "blastoise-1",
+          nickname: "Blastoise",
+          heldItem: "weakness-policy",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: makeStats(200, 80),
+          currentHp: 200,
+        }),
+      ],
+    ],
+    seed: 42,
+  };
+
+  ruleset.setGenerationForTest(config.generation);
+  return new BattleEngine(config, ruleset, createMockDataManager());
+}
+
+describe("BattleEngine held-item stat boosts", () => {
+  it("given a held item stat-boost effect, when damage resolves, then a stat-change event is emitted and the stage is applied", () => {
+    const ruleset = new HeldItemStatBoostRuleset();
+    const engine = createHeldItemStatBoostEngine(ruleset);
+    const events: BattleEvent[] = [];
+    engine.on((event) => events.push(event));
+    engine.start();
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    const statChangeEvents = events.filter(
+      (event): event is StatChangeEvent => event.type === "stat-change",
+    );
+    expect(statChangeEvents).toHaveLength(2);
+    expect(statChangeEvents.map((event) => event.stat)).toEqual(["attack", "spAttack"]);
+    expect(statChangeEvents.map((event) => event.stages)).toEqual([2, 2]);
+    expect(statChangeEvents.map((event) => event.currentStage)).toEqual([2, 2]);
+
+    const defender = engine.state.sides[1].active[0];
+    expect(defender!.statStages.attack).toBe(2);
+    expect(defender!.statStages.spAttack).toBe(2);
+    expect(ruleset.itemTriggers).toContain("on-damage-taken");
+  });
+});


### PR DESCRIPTION
Closes #846\n\nEmits structured stat-change events when held-item stat boosts resolve through the shared item pipeline.