### PR TITLE
fix(battle): honor item-triggered force switches

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -2675,6 +2675,65 @@ export class BattleEngine implements BattleEventEmitter {
     this.recordParticipation();
   }
 
+  private getRandomForcedSwitchSlot(side: BattleSide): number | null {
+    const activeTeamSlot = side.active[0]?.teamSlot ?? -1;
+    const validTargets = side.team
+      .map((pokemon, teamSlot) => ({ pokemon, teamSlot }))
+      .filter(({ pokemon, teamSlot }) => pokemon.currentHp > 0 && teamSlot !== activeTeamSlot);
+
+    if (validTargets.length === 0) {
+      return null;
+    }
+
+    const randomIndex = this.state.rng.int(0, validTargets.length - 1);
+    return validTargets[randomIndex]?.teamSlot ?? null;
+  }
+
+  private performImmediateForcedSwitch(
+    sideIndex: 0 | 1,
+    options?: {
+      readonly markSideAsPhased?: boolean;
+      readonly message?: string;
+    },
+  ): boolean {
+    const side = this.state.sides[sideIndex];
+    const targetTeamSlot = this.getRandomForcedSwitchSlot(side);
+    if (targetTeamSlot === null) {
+      return false;
+    }
+
+    const outgoing = side.active[0];
+    if (outgoing) {
+      this.ruleset.onSwitchOut(outgoing, this.state);
+      this.emit({
+        type: "switch-out",
+        side: sideIndex,
+        pokemon: createPokemonSnapshot(outgoing),
+      });
+      outgoing.statStages = createDefaultStatStages();
+      outgoing.consecutiveProtects = 0;
+      outgoing.turnsOnField = 0;
+      outgoing.movedThisTurn = false;
+      outgoing.lastMoveUsed = null;
+      outgoing.lastDamageTaken = 0;
+      outgoing.lastDamageType = null;
+      outgoing.lastDamageCategory = null;
+    }
+
+    this.sendOut(side, targetTeamSlot);
+    this.recordParticipation();
+
+    if (options?.markSideAsPhased ?? true) {
+      this.phasedSides.add(sideIndex);
+    }
+
+    if (options?.message) {
+      this.emit({ type: "message", text: options.message });
+    }
+
+    return true;
+  }
+
   /**
    * Execute a bag item action (Potion, Antidote, X Attack, Revive, etc.).
    *
@@ -4064,46 +4123,10 @@ export class BattleEngine implements BattleEventEmitter {
     // valid party member. If no valid targets exist, the move effectively fails.
     // Source: Bulbapedia — "Whirlwind forces the target to switch out"
     if (result.switchOut && result.forcedSwitch) {
-      const defenderSideState = this.state.sides[defenderSide];
-      const defenderTeamSlot = defenderSideState.active[0]?.teamSlot ?? -1;
-      const validTargets = defenderSideState.team
-        .map((p, i) => ({ p, i }))
-        .filter(({ p, i }) => p.currentHp > 0 && i !== defenderTeamSlot);
-      if (validTargets.length > 0) {
-        const randomIndex = this.state.rng.int(0, validTargets.length - 1);
-        const switchTarget = validTargets[randomIndex];
-        if (switchTarget) {
-          // Perform the switch using the same infrastructure as voluntary switches
-          const outgoing = defenderSideState.active[0];
-          if (outgoing) {
-            this.ruleset.onSwitchOut(outgoing, this.state);
-            this.emit({
-              type: "switch-out",
-              side: defenderSide,
-              pokemon: createPokemonSnapshot(outgoing),
-            });
-            outgoing.statStages = createDefaultStatStages();
-            outgoing.consecutiveProtects = 0;
-            outgoing.turnsOnField = 0;
-            outgoing.movedThisTurn = false;
-            outgoing.lastMoveUsed = null;
-            outgoing.lastDamageTaken = 0;
-            outgoing.lastDamageType = null;
-            outgoing.lastDamageCategory = null;
-          }
-          this.sendOut(defenderSideState, switchTarget.i);
-          // Record the forced replacement immediately so participation survives
-          // even if entry hazards faint it before the next turn starts.
-          this.recordParticipation();
-          // Mark this side as phased — the replacement should not execute the
-          // original Pokemon's queued action for this turn.
-          this.phasedSides.add(defenderSide);
-          this.emit({
-            type: "message",
-            text: `${getPokemonName(defender)} was blown away!`,
-          });
-        }
-      }
+      this.performImmediateForcedSwitch(defenderSide, {
+        markSideAsPhased: true,
+        message: `${getPokemonName(defender)} was blown away!`,
+      });
     }
   }
 
@@ -5537,6 +5560,12 @@ export class BattleEngine implements BattleEventEmitter {
           break;
         }
         case "none":
+          if (effect.value === "force-switch") {
+            const switchSide =
+              effect.target === "opponent" && opponent ? ((1 - side) as 0 | 1) : side;
+            this.performImmediateForcedSwitch(switchSide, { markSideAsPhased: true });
+          }
+          break;
         case "damage-boost":
         case "speed-boost":
         case "status-prevention":

--- a/packages/battle/tests/engine/item-force-switch.test.ts
+++ b/packages/battle/tests/engine/item-force-switch.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import type { BattleConfig, ItemContext, ItemResult } from "../../src/context";
+import { BattleEngine } from "../../src/engine";
+import { createTestPokemon } from "../../src/utils";
+import { createMockDataManager } from "../helpers/mock-data-manager";
+import { MockRuleset } from "../helpers/mock-ruleset";
+
+class ForceSwitchItemRuleset extends MockRuleset {
+  private activated = false;
+
+  constructor(
+    private readonly mode: "red-card" | "eject-button",
+    private readonly holderUid: string,
+  ) {
+    super();
+  }
+
+  override hasHeldItems(): boolean {
+    return true;
+  }
+
+  override applyHeldItem(trigger: string, context: ItemContext): ItemResult {
+    if (
+      trigger !== "on-contact" ||
+      this.activated ||
+      context.pokemon.pokemon.uid !== this.holderUid
+    ) {
+      return { activated: false, effects: [], messages: [] };
+    }
+
+    this.activated = true;
+    if (this.mode === "red-card") {
+      return {
+        activated: true,
+        effects: [
+          { type: "none", target: "opponent", value: "force-switch" },
+          { type: "consume", target: "self", value: "red-card" },
+        ],
+        messages: ["Blastoise held up its Red Card against the attacker!"],
+      };
+    }
+
+    return {
+      activated: true,
+      effects: [
+        { type: "none", target: "self", value: "force-switch" },
+        { type: "consume", target: "self", value: "eject-button" },
+      ],
+      messages: ["Blastoise's Eject Button activated!"],
+    };
+  }
+}
+
+function createForceSwitchItemEngine(mode: "red-card" | "eject-button") {
+  const ruleset = new ForceSwitchItemRuleset(mode, "blastoise-1");
+  const config: BattleConfig = {
+    generation: 5,
+    format: "singles",
+    teams: [
+      [
+        createTestPokemon(6, 50, {
+          uid: "charizard-1",
+          nickname: "Charizard",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 153,
+            attack: 100,
+            defense: 100,
+            spAttack: 100,
+            spDefense: 100,
+            speed: 120,
+          },
+          currentHp: 153,
+        }),
+        createTestPokemon(25, 50, {
+          uid: "pikachu-side0-bench",
+          nickname: "Pikachu",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 120,
+            attack: 80,
+            defense: 70,
+            spAttack: 80,
+            spDefense: 70,
+            speed: 90,
+          },
+          currentHp: 120,
+        }),
+      ],
+      [
+        createTestPokemon(9, 50, {
+          uid: "blastoise-1",
+          nickname: "Blastoise",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 154,
+            attack: 100,
+            defense: 100,
+            spAttack: 100,
+            spDefense: 100,
+            speed: 80,
+          },
+          currentHp: 154,
+        }),
+        createTestPokemon(25, 50, {
+          uid: "pikachu-bench",
+          nickname: "Pikachu",
+          moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+          calculatedStats: {
+            hp: 120,
+            attack: 80,
+            defense: 70,
+            spAttack: 80,
+            spDefense: 70,
+            speed: 90,
+          },
+          currentHp: 120,
+        }),
+      ],
+    ],
+    seed: 42,
+  };
+
+  ruleset.setGenerationForTest(config.generation);
+  const engine = new BattleEngine(config, ruleset, createMockDataManager());
+  return engine;
+}
+
+describe("Held-item force switch handling", () => {
+  it("given Red Card activates on the defender, when the attacker made contact, then the attacker is switched out immediately", () => {
+    const engine = createForceSwitchItemEngine("red-card");
+
+    engine.start();
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    expect(engine.state.sides[0].active[0]?.pokemon.uid).toBe("pikachu-side0-bench");
+  });
+
+  it("given Eject Button activates before the holder acts, when the holder is switched out, then its queued move is skipped", () => {
+    const engine = createForceSwitchItemEngine("eject-button");
+
+    engine.start();
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    expect(engine.state.sides[1].active[0]?.pokemon.uid).toBe("pikachu-bench");
+    expect(engine.state.sides[0].active[0]?.pokemon.currentHp).toBe(153);
+  });
+});


### PR DESCRIPTION
## Summary\n- execute Red Card and Eject Button force-switch effects through the engine instead of ignoring them\n- share the immediate forced-switch path between phazing moves and held-item force switches\n- add regression coverage for Red Card attacker phazing and Eject Button self-switch action skipping\n\n## Testing\n- npx vitest run packages/battle/tests/engine/item-force-switch.test.ts packages/battle/tests/engine/forced-switch.test.ts --reporter=dot\n- npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/item-force-switch.test.ts packages/battle/tests/engine/forced-switch.test.ts\n- npm run typecheck --workspace @pokemon-lib-ts/battle\n- npm run test --workspace @pokemon-lib-ts/battle\n\nCloses #882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Battle engine now properly handles items that trigger forced switches during combat, such as Red Card (forces opponent switch) and Eject Button (forces user switch).

* **Tests**
  * Added comprehensive test coverage validating item-triggered forced switch behavior in singles format battles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->