### PR TITLE
fix(battle): warn on future attack lookup failures

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -3762,7 +3762,12 @@ export class BattleEngine implements BattleEventEmitter {
           });
           launchDamage = calcResult.damage;
         } catch {
-          // Move data missing — launchDamage stays 0 as final fallback
+          this.emit({
+            type: "engine-warning",
+            message:
+              `Future attack move "${result.futureAttack.moveId}" data missing while scheduling. ` +
+              "Storing 0 damage fallback.",
+          });
         }
         targetSideState.futureAttack = {
           moveId: result.futureAttack.moveId,
@@ -4489,7 +4494,12 @@ export class BattleEngine implements BattleEventEmitter {
                     try {
                       moveData = this.dataManager.getMove(side.futureAttack.moveId);
                     } catch {
-                      // Move data missing — use fallback damage
+                      this.emit({
+                        type: "engine-warning",
+                        message:
+                          `Future attack move "${side.futureAttack.moveId}" data missing while resolving. ` +
+                          "Using stored fallback damage.",
+                      });
                     }
                     if (moveData) {
                       const result = this.ruleset.calculateDamage({

--- a/packages/battle/tests/engine/future-attack.test.ts
+++ b/packages/battle/tests/engine/future-attack.test.ts
@@ -508,3 +508,88 @@ describe("Bug #505 — Future attack recalculation (Gen 5+)", () => {
     expect(fsEvent.type === "damage" && fsEvent.amount).toBe(50);
   });
 });
+
+describe("Future attack integrity warnings", () => {
+  it("given scheduling uses missing move data, when a future attack is created, then the engine emits a warning instead of silently storing zero damage", () => {
+    const { engine, ruleset, events } = createFutureAttackEngine();
+    ruleset.setEffectHandler((context) => {
+      if (context.move.id !== "future-sight") {
+        return {
+          statusInflicted: null,
+          volatileInflicted: null,
+          statChanges: [],
+          recoilDamage: 0,
+          healAmount: 0,
+          switchOut: false,
+          messages: [],
+        };
+      }
+
+      return {
+        statusInflicted: null,
+        volatileInflicted: null,
+        statChanges: [],
+        recoilDamage: 0,
+        healAmount: 0,
+        switchOut: false,
+        messages: [],
+        futureAttack: {
+          moveId: "missing-future-move",
+          turnsLeft: 2,
+          sourceSide: 0,
+        },
+      };
+    });
+
+    engine.start();
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 1 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === "engine-warning" &&
+          event.message.includes(
+            'Future attack move "missing-future-move" data missing while scheduling.',
+          ),
+      ),
+    ).toBe(true);
+    expect(engine.state.sides[1].futureAttack?.damage).toBe(0);
+  });
+
+  it("given future attack resolution uses missing move data, when the hit resolves, then the engine emits a warning before falling back to stored damage", () => {
+    const { engine, ruleset, events } = createFutureAttackEngine();
+    Object.assign(ruleset, {
+      recalculatesFutureAttackDamage: () => true,
+    });
+    engine.start();
+
+    engine.state.sides[1].futureAttack = {
+      moveId: "missing-future-move",
+      turnsLeft: 1,
+      damage: 33,
+      sourceSide: 0,
+    };
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === "engine-warning" &&
+          event.message.includes(
+            'Future attack move "missing-future-move" data missing while resolving.',
+          ),
+      ),
+    ).toBe(true);
+
+    const futureSightDamage = events.filter(
+      (event) =>
+        event.type === "damage" && "source" in event && event.source === "missing-future-move",
+    );
+    expect(futureSightDamage).toHaveLength(1);
+    const damageEvent = futureSightDamage[0]!;
+    expect(damageEvent.type === "damage" && damageEvent.amount).toBe(33);
+  });
+});


### PR DESCRIPTION
## Summary\n- emit integrity warnings when future-attack move data is missing at schedule time or hit resolution\n- preserve the existing zero/stored damage fallback instead of silently degrading\n- add regression coverage for both warning paths\n\n## Testing\n- npx vitest run packages/battle/tests/engine/future-attack.test.ts --reporter=dot\n- npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/future-attack.test.ts\n- npm run typecheck --workspace @pokemon-lib-ts/battle\n- npm run test --workspace @pokemon-lib-ts/battle -- --run tests/engine/future-attack.test.ts\n\nCloses #841