### PR TITLE
fix(battle): reject unknown stat stage keys

### DIFF
--- a/packages/battle/src/utils/statStageHelpers.ts
+++ b/packages/battle/src/utils/statStageHelpers.ts
@@ -1,3 +1,4 @@
+import type { BattleStat } from "@pokemon-lib-ts/core";
 import type { ActivePokemon } from "../state";
 
 /**
@@ -19,7 +20,7 @@ import type { ActivePokemon } from "../state";
  */
 export function getEffectiveStatStage(
   pokemon: ActivePokemon,
-  stat: string,
+  stat: BattleStat,
   opponent?: ActivePokemon,
   statContext: "offense" | "defense" = "offense",
 ): number {
@@ -46,7 +47,11 @@ export function getEffectiveStatStage(
     return 0;
   }
 
-  const raw = (pokemon.statStages as Record<string, number>)[stat] ?? 0;
+  if (!(stat in pokemon.statStages)) {
+    throw new Error(`Unknown battle stat "${stat}"`);
+  }
+
+  const raw = pokemon.statStages[stat] ?? 0;
   // Suppress Simple only when computing the DEFENDER's defensive stat and the attacker
   // (opponent) has Mold Breaker — the Mold Breaker user bypasses the target's ability.
   // When computing the ATTACKER's offensive stat, the defender's Mold Breaker does NOT

--- a/packages/battle/tests/utils/stat-stage-helpers.test.ts
+++ b/packages/battle/tests/utils/stat-stage-helpers.test.ts
@@ -1,0 +1,22 @@
+import type { BattleStat } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import { createActivePokemon, createTestPokemon } from "../../src/utils";
+import { getEffectiveStatStage } from "../../src/utils/statStageHelpers";
+
+describe("getEffectiveStatStage", () => {
+  it("given an invalid stat key from an untyped caller, when the helper is invoked, then it throws instead of returning a plausible stage", () => {
+    const active = createActivePokemon(createTestPokemon(6, 50), 0, ["fire", "flying"]);
+    active.statStages.spAttack = 2;
+
+    expect(() => getEffectiveStatStage(active, "spAtk" as BattleStat)).toThrow(
+      'Unknown battle stat "spAtk"',
+    );
+  });
+
+  it("given a valid stat key, when the helper is invoked, then it returns the configured stage", () => {
+    const active = createActivePokemon(createTestPokemon(6, 50), 0, ["fire", "flying"]);
+    active.statStages.spAttack = 2;
+
+    expect(getEffectiveStatStage(active, "spAttack")).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary\n- narrow  to typed battle-stat keys\n- throw for unknown keys from untyped callers instead of returning a plausible zero stage\n- add focused helper coverage for invalid and valid stat keys\n\n## Testing\n- npx vitest run packages/battle/tests/utils/stat-stage-helpers.test.ts --reporter=dot\n- npx @biomejs/biome check packages/battle/src/utils/statStageHelpers.ts packages/battle/tests/utils/stat-stage-helpers.test.ts\n- npm run typecheck --workspace @pokemon-lib-ts/battle\n\nCloses #886