### PR TITLE
Delegate Perish Song countdown to the ruleset

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -5875,24 +5875,19 @@ export class BattleEngine implements BattleEventEmitter {
       if (!active || active.pokemon.currentHp <= 0) continue;
       if (!active.volatileStatuses.has("perish-song")) continue;
 
-      const perishState = active.volatileStatuses.get("perish-song");
-      if (!perishState) continue;
-      const counter = (perishState.data?.counter as number) ?? perishState.turnsLeft;
+      // Source: GenerationRuleset.processPerishSong contract — the ruleset owns
+      // Perish Song countdown semantics, so the engine delegates the mutation and
+      // uses the returned state to drive messaging / faint handling.
+      const perishResult = this.ruleset.processPerishSong(active);
 
       this.emit({
         type: "message",
-        text: `${getPokemonName(active)}'s perish count fell to ${counter - 1}!`,
+        text: `${getPokemonName(active)}'s perish count fell to ${perishResult.newCount}!`,
       });
 
-      if (counter <= 1) {
+      if (perishResult.fainted) {
         active.pokemon.currentHp = 0;
         // Don't emit faint here — checkMidTurnFaints() handles it
-      } else {
-        if (perishState.data) {
-          perishState.data.counter = counter - 1;
-        } else {
-          perishState.turnsLeft = counter - 1;
-        }
       }
     }
   }

--- a/packages/battle/tests/engine/battle-engine-advanced.test.ts
+++ b/packages/battle/tests/engine/battle-engine-advanced.test.ts
@@ -89,6 +89,26 @@ class RecursiveEscapeRuleset extends MockRuleset {
   }
 }
 
+class DelegatingPerishSongRuleset extends MockRuleset {
+  private perishSongCalls = 0;
+
+  getPerishSongCalls(): number {
+    return this.perishSongCalls;
+  }
+
+  override getEndOfTurnOrder(): readonly ("perish-song" | "status-damage")[] {
+    return ["perish-song", "status-damage"];
+  }
+
+  override processPerishSong(active: ActivePokemon): {
+    readonly newCount: number;
+    readonly fainted: boolean;
+  } {
+    this.perishSongCalls += 1;
+    return super.processPerishSong(active);
+  }
+}
+
 describe("BattleEngine — advanced scenarios", () => {
   describe("move miss", () => {
     it("given the ruleset says move misses, when a move is used, then move-miss event is emitted", () => {
@@ -421,6 +441,32 @@ describe("BattleEngine — advanced scenarios", () => {
       expect(engine.state.sides[0].screens).toEqual([{ type: "safeguard", turnsLeft: 4 }]);
       const screenEnd = events.find((event) => event.type === "screen-end");
       expect(screenEnd).toBeUndefined();
+    });
+  });
+
+  describe("perish song countdown", () => {
+    it("given a pokemon affected by Perish Song, when end of turn processes, then the engine delegates the countdown to the ruleset contract", () => {
+      // Arrange
+      const ruleset = new DelegatingPerishSongRuleset();
+      ruleset.setAlwaysHit(false);
+      const { engine } = createEngine({ ruleset });
+      engine.start();
+
+      const active = engine.state.sides[0].active[0];
+      active!.volatileStatuses.set("perish-song", {
+        turnsLeft: -1,
+        data: { counter: 2 },
+      });
+      const initialHp = active!.pokemon.currentHp;
+
+      // Act
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert
+      expect(ruleset.getPerishSongCalls()).toBe(1);
+      expect(active!.volatileStatuses.get("perish-song")?.data?.counter).toBe(1);
+      expect(active!.pokemon.currentHp).toBe(initialHp);
     });
   });
 


### PR DESCRIPTION
Closes #824\n\n## Summary\n- Make BattleEngine call GenerationRuleset.processPerishSong() instead of duplicating Perish Song countdown logic\n- Keep the legacy wear-off message / faint handling behavior in the engine\n- Add an engine regression that proves the contract method is actually invoked\n\n## Verification\n- npx vitest run packages/battle/tests/engine/battle-engine-advanced.test.ts -t "delegates the countdown to the ruleset contract"\n- npx vitest run packages/battle/tests/engine/battle-engine-advanced.test.ts\n- npx biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/battle-engine-advanced.test.ts\n- npm run typecheck -w @pokemon-lib-ts/battle