### PR TITLE
Remove dead weather-immunity ability effect

### DIFF
--- a/packages/battle/src/context/types.ts
+++ b/packages/battle/src/context/types.ts
@@ -466,7 +466,6 @@ export type AbilityEffectType =
   | "status-inflict"
   | "damage-reduction"
   | "type-change"
-  | "weather-immunity"
   | "weather-set"
   | "ability-change"
   | "heal"
@@ -504,7 +503,6 @@ export type AbilityEffect =
       readonly target: "self" | "opponent";
       readonly types: readonly import("@pokemon-lib-ts/core").PokemonType[];
     }
-  | { readonly effectType: "weather-immunity"; readonly target: "self" | "opponent" }
   | { readonly effectType: "status-cure"; readonly target: "self" | "opponent" | "ally" }
   | {
       readonly effectType: "ability-change";

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -5871,10 +5871,10 @@ export class BattleEngine implements BattleEventEmitter {
           break;
         }
         default:
-          // damage-reduction, weather-immunity are intentionally NOT processed
-          // here. They are passive checks handled inline by the ruleset's calculateDamage()
-          // and ability trigger systems — not post-hoc engine effects. This is by design
-          // per the cardinal rule: the engine delegates ALL gen-specific behavior to rulesets.
+          // damage-reduction is intentionally NOT processed here. It is a passive check
+          // handled inline by the ruleset's calculateDamage() and ability trigger systems,
+          // not a post-hoc engine effect. This is by design per the cardinal rule: the
+          // engine delegates ALL gen-specific behavior to rulesets.
           break;
       }
     }

--- a/packages/gen5/src/Gen5AbilitiesSwitch.ts
+++ b/packages/gen5/src/Gen5AbilitiesSwitch.ts
@@ -1,5 +1,5 @@
 import type { AbilityContext, AbilityEffect, AbilityResult } from "@pokemon-lib-ts/battle";
-import type { AbilityTrigger, PokemonType, VolatileStatus } from "@pokemon-lib-ts/core";
+import type { AbilityTrigger, PokemonType } from "@pokemon-lib-ts/core";
 
 /**
  * Gen 5 switch-in, contact, switch-out, and passive ability handlers.
@@ -779,25 +779,16 @@ function handlePassiveImmunity(ctx: AbilityContext): AbilityResult {
     }
 
     case "overcoat": {
-      // Source: Showdown data/mods/gen5/abilities.ts — Overcoat Gen 5: only immune to
-      //   sandstorm/hail chip damage. Does NOT block powder moves (Gen 6+ addition).
-      // Source: Bulbapedia — Overcoat (Gen 5): "Protects from sandstorm and hail damage."
-      return {
-        activated: true,
-        effects: [{ effectType: "weather-immunity", target: "self" }],
-        messages: [],
-      };
+      // Source: Showdown data/mods/gen5/abilities.ts — Overcoat's weather immunity is handled
+      // by the weather module, not the passive-immunity ability hook.
+      return NO_EFFECT;
     }
 
     case "sand-rush": {
-      // Source: Showdown data/abilities.ts — Sand Rush: sandstorm immunity
-      // Speed doubling is handled in getEffectiveSpeed, not here
+      // Source: Showdown data/abilities.ts — Sand Rush's weather immunity is handled by the
+      // weather module, while speed doubling is handled in getEffectiveSpeed.
       // Source: Bulbapedia — Sand Rush: "Doubles Speed in sandstorm. Immune to sandstorm damage."
-      return {
-        activated: true,
-        effects: [{ effectType: "weather-immunity", target: "self" }],
-        messages: [],
-      };
+      return NO_EFFECT;
     }
 
     case "sap-sipper": {

--- a/packages/gen5/tests/abilities-correctness-audit.test.ts
+++ b/packages/gen5/tests/abilities-correctness-audit.test.ts
@@ -643,14 +643,15 @@ describe("Moxie -- +1 Attack after KOing a Pokemon", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Overcoat -- Gen 5: ONLY weather immunity; powder block is Gen 6+
+// Overcoat -- Gen 5: weather immunity is handled in the weather module;
+// powder block is Gen 6+
 // ---------------------------------------------------------------------------
 
-describe("Overcoat -- Gen 5: weather immunity only (powder block is Gen 6+)", () => {
-  it("given Overcoat and passive-immunity trigger, when called, then activates with weather-immunity effect", () => {
+describe("Overcoat -- Gen 5: passive-immunity hook is a no-op for weather", () => {
+  it("given Overcoat and passive-immunity trigger, when called, then does not produce a weather-immunity effect", () => {
     // Source: Showdown data/mods/gen5/abilities.ts -- overcoat:
     //   onImmunity(type): if (type === 'sandstorm' || type === 'hail') return false;
-    //   onTryHit() {} -- empty override, powder/spore NOT blocked in Gen 5
+    // Weather immunity is handled by the weather module; passive-immunity is for move immunities.
     // Source: Bulbapedia -- Overcoat (Gen 5): "Protects from sandstorm and hail damage."
     const ctx = makeAbilityContext({
       ability: "overcoat",
@@ -658,9 +659,8 @@ describe("Overcoat -- Gen 5: weather immunity only (powder block is Gen 6+)", ()
     });
     const result = handleGen5SwitchAbility("passive-immunity", ctx);
 
-    expect(result.activated).toBe(true);
-    const weatherEffect = result.effects.find((e) => e.effectType === "weather-immunity");
-    expect(weatherEffect).toBeDefined();
+    expect(result.activated).toBe(false);
+    expect(result.effects).toHaveLength(0);
   });
 });
 

--- a/packages/gen5/tests/abilities-switch-contact.test.ts
+++ b/packages/gen5/tests/abilities-switch-contact.test.ts
@@ -1317,13 +1317,14 @@ describe("handleGen5SwitchAbility passive-immunity -- Dry Skin", () => {
 });
 
 describe("handleGen5SwitchAbility passive-immunity -- Overcoat", () => {
-  it("given Overcoat, when passive check triggered, then grants weather immunity", () => {
-    // Source: Showdown data/mods/gen5/abilities.ts — Overcoat: sandstorm/hail immunity only
+  it("given Overcoat, when passive check triggered, then returns no passive-immunity effect", () => {
+    // Source: Showdown data/mods/gen5/abilities.ts — Overcoat's weather immunity is handled
+    // by the weather module, not the passive-immunity ability hook.
     const ctx = makeContext({ ability: "overcoat", trigger: "passive-immunity" });
     const result = handleGen5SwitchAbility("passive-immunity", ctx);
 
-    expect(result.activated).toBe(true);
-    expect(result.effects[0]).toEqual({ effectType: "weather-immunity", target: "self" });
+    expect(result.activated).toBe(false);
+    expect(result.effects).toHaveLength(0);
   });
 
   it("given Overcoat, when passive check triggered, then no messages (silent)", () => {
@@ -1336,13 +1337,14 @@ describe("handleGen5SwitchAbility passive-immunity -- Overcoat", () => {
 });
 
 describe("handleGen5SwitchAbility passive-immunity -- Sand Rush", () => {
-  it("given Sand Rush, when passive check triggered, then grants weather immunity", () => {
-    // Source: Showdown data/abilities.ts — Sand Rush: sandstorm immunity
+  it("given Sand Rush, when passive check triggered, then returns no passive-immunity effect", () => {
+    // Source: Showdown data/abilities.ts — Sand Rush's sandstorm immunity is handled by the
+    // weather module, not the passive-immunity ability hook.
     const ctx = makeContext({ ability: "sand-rush", trigger: "passive-immunity" });
     const result = handleGen5SwitchAbility("passive-immunity", ctx);
 
-    expect(result.activated).toBe(true);
-    expect(result.effects[0]).toEqual({ effectType: "weather-immunity", target: "self" });
+    expect(result.activated).toBe(false);
+    expect(result.effects).toHaveLength(0);
   });
 
   it("given Sand Rush, when passive check triggered, then speed doubling handled elsewhere", () => {
@@ -1350,7 +1352,7 @@ describe("handleGen5SwitchAbility passive-immunity -- Sand Rush", () => {
     const ctx = makeContext({ ability: "sand-rush", trigger: "passive-immunity" });
     const result = handleGen5SwitchAbility("passive-immunity", ctx);
 
-    // Just confirm it returns weather-immunity, not stat-change
+    // Just confirm it remains a no-op, not a stat-change hook.
     expect(result.effects.every((e) => e.effectType !== "stat-change")).toBe(true);
   });
 });

--- a/packages/gen6/src/Gen6AbilitiesSwitch.ts
+++ b/packages/gen6/src/Gen6AbilitiesSwitch.ts
@@ -783,22 +783,14 @@ function handlePassiveImmunity(ctx: AbilityContext): AbilityResult {
           messages: [`${name}'s Overcoat protected it from the powder move!`],
         };
       }
-      // Weather immunity handled at the engine level via the weather-immunity effect
-      return {
-        activated: true,
-        effects: [{ effectType: "weather-immunity", target: "self" }],
-        messages: [],
-      };
+      // Weather immunity is handled by the weather module, not the passive-immunity hook.
+      return NO_EFFECT;
     }
 
     case "sand-rush": {
-      // Source: Showdown data/abilities.ts — Sand Rush: sandstorm immunity
-      // Speed doubling is handled in getEffectiveSpeed, not here
-      return {
-        activated: true,
-        effects: [{ effectType: "weather-immunity", target: "self" }],
-        messages: [],
-      };
+      // Source: Showdown data/abilities.ts — Sand Rush's weather immunity is handled by the
+      // weather module, while speed doubling is handled in getEffectiveSpeed.
+      return NO_EFFECT;
     }
 
     case "sap-sipper": {

--- a/packages/gen6/tests/abilities-switch-contact.test.ts
+++ b/packages/gen6/tests/abilities-switch-contact.test.ts
@@ -767,9 +767,9 @@ describe("Overcoat (Gen 6: blocks powder moves)", () => {
     expect(result.activated).toBe(true);
   });
 
-  it("given Overcoat, when hit by a non-powder move, then returns weather-immunity effect", () => {
-    // Source: Showdown data/abilities.ts -- overcoat: protects from weather damage
-    // Non-powder moves don't trigger the powder block, but Overcoat grants weather immunity
+  it("given Overcoat, when hit by a non-powder move, then returns no passive-immunity effect", () => {
+    // Source: Showdown data/abilities.ts -- overcoat's weather immunity is handled
+    // by the weather module, not the passive-immunity hook.
     const normalMove = makeMove("normal", { flags: {} });
     const ctx = makeContext({
       ability: "overcoat",
@@ -777,8 +777,8 @@ describe("Overcoat (Gen 6: blocks powder moves)", () => {
       move: normalMove,
     });
     const result = handleGen6SwitchAbility("passive-immunity", ctx);
-    expect(result.activated).toBe(true);
-    expect(result.effects[0]?.effectType).toBe("weather-immunity");
+    expect(result.activated).toBe(false);
+    expect(result.effects).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Closes #873\n\n## Summary\n- Remove the unused weather-immunity ability effect from the battle contract\n- Make Gen 5/6 passive-immunity hooks return no effect for weather immunity, since the weather modules already handle that behavior\n- Update the affected Gen 5/6 ability tests to assert the real weather-path boundary\n\n## Verification\n- npx vitest run packages/gen5/tests/abilities-switch-contact.test.ts packages/gen6/tests/abilities-switch-contact.test.ts\n- npx biome check packages/battle/src/context/types.ts packages/battle/src/engine/BattleEngine.ts packages/gen5/src/Gen5AbilitiesSwitch.ts packages/gen5/tests/abilities-correctness-audit.test.ts packages/gen5/tests/abilities-switch-contact.test.ts packages/gen6/src/Gen6AbilitiesSwitch.ts packages/gen6/tests/abilities-switch-contact.test.ts\n- npm run typecheck -w @pokemon-lib-ts/battle