### PR TITLE
fix: remove dead item effect variants

### DIFF
--- a/packages/battle/src/context/item-effect-contract.ts
+++ b/packages/battle/src/context/item-effect-contract.ts
@@ -1,0 +1,12 @@
+import type { ItemEffect } from "./types";
+
+// These assignments intentionally fail the package typecheck until the dead
+// public variants are removed from ItemEffect.
+// @ts-expect-error - damage-boost is not a supported ItemEffect variant
+const damageBoostEffect: ItemEffect = { type: "damage-boost", target: "self", value: 1 };
+
+// @ts-expect-error - status-prevention is not a supported ItemEffect variant
+const statusPreventionEffect: ItemEffect = { type: "status-prevention", target: "opponent" };
+
+void damageBoostEffect;
+void statusPreventionEffect;

--- a/packages/battle/src/context/types.ts
+++ b/packages/battle/src/context/types.ts
@@ -594,8 +594,6 @@ export interface ItemContext {
 export type ItemEffectType =
   | "stat-boost"
   | "heal"
-  | "damage-boost"
-  | "status-prevention"
   | "speed-boost"
   | "status-cure"
   | "consume"
@@ -632,8 +630,6 @@ export type ItemEffect =
       readonly value: string;
       readonly stages?: number;
     }
-  | { readonly type: "damage-boost"; readonly target: "self" | "opponent"; readonly value: number }
-  | { readonly type: "status-prevention"; readonly target: "self" | "opponent" }
   | { readonly type: "speed-boost"; readonly target: "self" | "opponent"; readonly value: number }
   | {
       /** Chip damage to a target (Life Orb recoil, Black Sludge, Sticky Barb, Rocky Helmet). */

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -5632,12 +5632,10 @@ export class BattleEngine implements BattleEventEmitter {
             this.performImmediateForcedSwitch(switchSide, { markSideAsPhased: true });
           }
           break;
-        case "damage-boost":
         case "speed-boost":
-        case "status-prevention":
           // These effect types carry no immediate engine action here.
           // 'none' is used for force-switch and other engine-deferred behaviors.
-          // 'damage-boost', 'speed-boost', 'status-prevention' are applied inline in item handlers.
+          // 'speed-boost' is applied inline in item handlers.
           break;
       }
     }


### PR DESCRIPTION
## Summary
Remove the dead `damage-boost` and `status-prevention` item-effect variants from the public battle contract and keep the engine switch aligned with the remaining live variants.

## Related Issue
Closes #850

## Changes
- Removed the dead item-effect variants from `ItemEffectType` / `ItemEffect`.
- Dropped the dead engine no-op branch and kept `speed-boost` as the live inline path.
- Added a compile-time contract guard in `packages/battle/src/context/item-effect-contract.ts` so `tsc` rejects the dead variants.

## Affected Packages
- [ ] `@pokemon-lib-ts/core`
- [x] `@pokemon-lib-ts/battle`
- [ ] `@pokemon-lib-ts/gen1`
- [ ] `@pokemon-lib-ts/gen2`

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Data/schema change
- [x] Tests
- [ ] CI/tooling

## Test Plan
- `npx tsc --noEmit -p packages/battle/tsconfig.json`
- `npx @biomejs/biome check --write packages/battle/src/context/types.ts packages/battle/src/context/item-effect-contract.ts packages/battle/src/engine/BattleEngine.ts`
- `npx vitest run packages/battle/tests/engine/item-action.test.ts`
- `git diff --check`

## Checklist
- [x] Tests pass (`npm run test`)
- [x] Types pass (`npm run typecheck`)
- [x] Lint passes (`npm run lint:check`)
- [x] Coverage >= 80%
- [ ] `/review` run locally (falcon + kestrel + sentinel)