### PR TITLE
fix(battle): avoid charge-turn damage on two-turn moves

### DIFF
--- a/packages/battle/src/context/types.ts
+++ b/packages/battle/src/context/types.ts
@@ -138,7 +138,9 @@ export interface AccuracyContext {
 
 /**
  * All inputs required when executing a move's secondary effects.
- * Passed to `GenerationRuleset.executeMoveEffect()` after the damage step.
+ * Passed to `GenerationRuleset.executeMoveEffect()` after the damage step for
+ * normal moves, and before accuracy/damage for charge-turn setup handling on
+ * two-turn moves.
  */
 export interface MoveEffectContext {
   /** The Pokémon that used the move */

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -1779,6 +1779,10 @@ export class BattleEngine implements BattleEventEmitter {
       "underwater",
       "shadow-force-charging",
     ];
+    const actorWasCharging =
+      semiInvulnerableVolatiles.some((vol) => actor.volatileStatuses.has(vol)) ||
+      actor.volatileStatuses.has("charging");
+
     for (const vol of semiInvulnerableVolatiles) {
       if (actor.volatileStatuses.has(vol)) {
         actor.volatileStatuses.delete(vol);
@@ -1862,6 +1866,60 @@ export class BattleEngine implements BattleEventEmitter {
           return;
         }
       }
+    }
+
+    const defenderSelectedMove = this.getDefenderSelectedMove(defenderSide as 0 | 1);
+
+    // Charge-turn handlers must run before accuracy and damage. On the setup turn
+    // they can request a forced follow-up move, and on Power Herb turns they can
+    // consume the item and skip the setup turn entirely.
+    let handledChargeMove = false;
+    let chargeMoveEffectResult: MoveEffectResult | null = null;
+    if (effectiveMoveData.flags.charge && !actorWasCharging) {
+      handledChargeMove = true;
+      chargeMoveEffectResult = this.ruleset.executeMoveEffect({
+        attacker: actor,
+        defender,
+        move: effectiveMoveData,
+        damage: 0,
+        state: this.state,
+        rng: this.state.rng,
+        defenderSelectedMove,
+      });
+
+      if (chargeMoveEffectResult.forcedMoveSet) {
+        this.processEffectResult(
+          chargeMoveEffectResult,
+          actor,
+          defender,
+          action.side,
+          defenderSide as 0 | 1,
+        );
+        actor.lastMoveUsed = moveData.id;
+        actor.movedThisTurn = true;
+        return;
+      }
+
+      if (chargeMoveEffectResult.attackerItemConsumed) {
+        this.processEffectResult(
+          chargeMoveEffectResult,
+          actor,
+          defender,
+          action.side,
+          defenderSide as 0 | 1,
+        );
+        if (this.state.ended) {
+          actor.lastMoveUsed = moveData.id;
+          actor.movedThisTurn = true;
+          return;
+        }
+        chargeMoveEffectResult = null;
+      }
+    } else if (effectiveMoveData.flags.charge) {
+      // The attacker was already in its charge volatile, so this is the
+      // follow-up attack turn. Skip the post-damage move-effect hook to avoid
+      // re-triggering the charge setup after the volatile is cleared above.
+      handledChargeMove = true;
     }
 
     // Accuracy check — use effectiveMoveData so gimmick-modified accuracy/flags are applied.
@@ -2216,23 +2274,37 @@ export class BattleEngine implements BattleEventEmitter {
     }
 
     // Apply move effects
-    const effectResult = this.ruleset.executeMoveEffect({
-      attacker: actor,
-      defender,
-      move: effectiveMoveData,
-      damage,
-      state: this.state,
-      rng: this.state.rng,
-      brokeSubstitute,
-      defenderSelectedMove: this.getDefenderSelectedMove(defenderSide as 0 | 1),
-    });
+    const effectResult = handledChargeMove
+      ? chargeMoveEffectResult
+      : this.ruleset.executeMoveEffect({
+          attacker: actor,
+          defender,
+          move: effectiveMoveData,
+          damage,
+          state: this.state,
+          rng: this.state.rng,
+          brokeSubstitute,
+          defenderSelectedMove,
+        });
 
-    this.processEffectResult(effectResult, actor, defender, action.side, defenderSide as 0 | 1);
-    if (this.state.ended) {
-      actor.lastMoveUsed = moveData.id;
-      actor.movedThisTurn = true;
-      return;
+    if (effectResult !== null) {
+      this.processEffectResult(effectResult, actor, defender, action.side, defenderSide as 0 | 1);
+      if (this.state.ended) {
+        actor.lastMoveUsed = moveData.id;
+        actor.movedThisTurn = true;
+        return;
+      }
     }
+
+    const resolvedEffectResult: MoveEffectResult = effectResult ?? {
+      statusInflicted: null,
+      volatileInflicted: null,
+      statChanges: [],
+      recoilDamage: 0,
+      healAmount: 0,
+      switchOut: false,
+      messages: [],
+    };
 
     // Multi-hit move loop: repeat damage for additional hits beyond the first.
     // Source: pokered multi-hit moves — the engine repeats the damage step for each
@@ -2240,11 +2312,11 @@ export class BattleEngine implements BattleEventEmitter {
     // Source: pokered — all hits after the first use the same damage as the first hit.
     // The random factor and stat stage application are locked to the first calculation.
     // Ends early if the target faints or the substitute breaks.
-    if (effectResult.multiHitCount && effectResult.multiHitCount > 0) {
+    if (resolvedEffectResult.multiHitCount && resolvedEffectResult.multiHitCount > 0) {
       // Capture first hit damage; subsequent hits reuse this value (Gen 1 multi-hit rule)
       const firstHitDamage = damage;
       let totalHits = 1; // already dealt the first hit
-      for (let i = 0; i < effectResult.multiHitCount; i++) {
+      for (let i = 0; i < resolvedEffectResult.multiHitCount; i++) {
         // Stop if defender fainted
         if (defender.pokemon.currentHp <= 0 && defender.substituteHp <= 0) break;
         // Stop if substitute was broken (Gen 1: multi-hit ends when sub breaks)
@@ -2254,7 +2326,7 @@ export class BattleEngine implements BattleEventEmitter {
         // When checkPerHitAccuracy is set, re-roll accuracy before each additional hit.
         // If the hit misses, the multi-hit loop stops immediately.
         // Source: Showdown data/moves.ts -- populationbomb: multiaccuracy: true
-        if (effectResult.checkPerHitAccuracy) {
+        if (resolvedEffectResult.checkPerHitAccuracy) {
           if (
             !this.ruleset.doesMoveHit({
               attacker: actor,
@@ -2288,10 +2360,10 @@ export class BattleEngine implements BattleEventEmitter {
         // Prefer perHitDamageFn (lazy, RNG consumed per-hit) over perHitDamage (eager).
         // Source: pret/pokecrystal TripleKickEffect/BeatUpEffect — damage computed in hit loop
         // Source: Bulbapedia — Triple Kick power escalates 10/20/30 per hit
-        let hitDamage = effectResult.perHitDamageFn
-          ? effectResult.perHitDamageFn(i)
-          : effectResult.perHitDamage && i < effectResult.perHitDamage.length
-            ? (effectResult.perHitDamage[i] ?? firstHitDamage)
+        let hitDamage = resolvedEffectResult.perHitDamageFn
+          ? resolvedEffectResult.perHitDamageFn(i)
+          : resolvedEffectResult.perHitDamage && i < resolvedEffectResult.perHitDamage.length
+            ? (resolvedEffectResult.perHitDamage[i] ?? firstHitDamage)
             : firstHitDamage;
         if (hitDamage <= 0) break;
 
@@ -2373,9 +2445,9 @@ export class BattleEngine implements BattleEventEmitter {
 
     // Recursive move execution (Mirror Move, Metronome)
     // Source: pret/pokered MirrorMoveEffect, MetronomeEffect
-    if (effectResult.recursiveMove) {
+    if (resolvedEffectResult.recursiveMove) {
       this.executeMoveById(
-        effectResult.recursiveMove,
+        resolvedEffectResult.recursiveMove,
         actor,
         action.side,
         defender,
@@ -2394,7 +2466,7 @@ export class BattleEngine implements BattleEventEmitter {
     }
 
     // Recharge: if the move requires recharge and noRecharge was not set, mark the attacker
-    if (effectiveMoveData.flags.recharge && !effectResult.noRecharge) {
+    if (effectiveMoveData.flags.recharge && !resolvedEffectResult.noRecharge) {
       actor.volatileStatuses.set("recharge", { turnsLeft: 1 });
     }
 

--- a/packages/battle/src/ruleset/GenerationRuleset.ts
+++ b/packages/battle/src/ruleset/GenerationRuleset.ts
@@ -213,8 +213,10 @@ export interface MoveSystem {
    */
   doesMoveHit(context: AccuracyContext): boolean;
   /**
-   * Execute a move's effect after damage calculation.
-   * Handles secondary effects, stat changes, status infliction.
+   * Execute a move's effect during move resolution.
+   * Usually runs after damage calculation, but charge-turn handlers may be
+   * consulted before accuracy/damage so they can request a forced follow-up move
+   * or consume Power Herb without taking the normal damage path.
    */
   executeMoveEffect(context: MoveEffectContext): MoveEffectResult;
   /**

--- a/packages/battle/tests/engine/two-turn-moves.test.ts
+++ b/packages/battle/tests/engine/two-turn-moves.test.ts
@@ -73,9 +73,25 @@ function createEngine(overrides?: {
 
 describe("two-turn move engine infrastructure", () => {
   describe("given a Pokemon using a charge move, when the charge turn executes, then forcedMove is set and volatile applied", () => {
-    it("sets forcedMove on the attacker and applies the volatile status from forcedMoveSet", () => {
+    it("sets forcedMove on the attacker, applies the volatile status from forcedMoveSet, and deals no damage", () => {
       // Arrange: configure executeMoveEffect to return forcedMoveSet on the first call
       const ruleset = new MockRuleset();
+      const team1 = [
+        createTestPokemon(6, 50, {
+          uid: "charizard-1",
+          nickname: "Charizard",
+          moves: [{ moveId: "fly", currentPP: 15, maxPP: 15, ppUps: 0 }],
+          calculatedStats: {
+            hp: 200,
+            attack: 100,
+            defense: 100,
+            spAttack: 100,
+            spDefense: 100,
+            speed: 120,
+          },
+          currentHp: 200,
+        }),
+      ];
       let callCount = 0;
       const origExecute = ruleset.executeMoveEffect.bind(ruleset);
       ruleset.executeMoveEffect = (context: MoveEffectContext): MoveEffectResult => {
@@ -91,7 +107,7 @@ describe("two-turn move engine infrastructure", () => {
             messages: [],
             forcedMoveSet: {
               moveIndex: 0,
-              moveId: "tackle",
+              moveId: "fly",
               volatileStatus: "flying" as VolatileStatus,
             },
           };
@@ -99,8 +115,10 @@ describe("two-turn move engine infrastructure", () => {
         return origExecute(context);
       };
 
-      const { engine, events } = createEngine({ ruleset });
+      const { engine, events } = createEngine({ ruleset, team1 });
       engine.start();
+      const defenderStartHp = engine.getActive(1)?.pokemon.currentHp;
+      expect(defenderStartHp).toBeDefined();
 
       // Act: submit moves for both sides
       engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
@@ -109,7 +127,7 @@ describe("two-turn move engine infrastructure", () => {
       // Assert: forcedMove should be set on side 0's active Pokemon
       const active0 = engine.state.sides[0].active[0];
       expect(active0).not.toBeNull();
-      expect(active0!.forcedMove).toEqual({ moveIndex: 0, moveId: "tackle" });
+      expect(active0!.forcedMove).toEqual({ moveIndex: 0, moveId: "fly" });
 
       // Assert: flying volatile should be applied
       expect(active0!.volatileStatuses.has("flying")).toBe(true);
@@ -119,6 +137,91 @@ describe("two-turn move engine infrastructure", () => {
         (e) => e.type === "volatile-start" && "volatile" in e && e.volatile === "flying",
       );
       expect(volatileStartEvents.length).toBe(1);
+
+      // Assert: charge turn does not deal damage before the forced move executes.
+      const defender = engine.getActive(1);
+      expect(defender).not.toBeNull();
+      expect(defender!.pokemon.currentHp).toBe(defenderStartHp);
+      const damageEvents = events.filter(
+        (e) => e.type === "damage" && "pokemon" in e && e.pokemon === "Blastoise",
+      );
+      expect(damageEvents.length).toBe(0);
+    });
+
+    it("clears the charge state and deals damage on the forced follow-up turn", () => {
+      const ruleset = new MockRuleset();
+      const team1 = [
+        createTestPokemon(6, 50, {
+          uid: "charizard-1",
+          nickname: "Charizard",
+          moves: [{ moveId: "fly", currentPP: 15, maxPP: 15, ppUps: 0 }],
+          calculatedStats: {
+            hp: 200,
+            attack: 100,
+            defense: 100,
+            spAttack: 100,
+            spDefense: 100,
+            speed: 120,
+          },
+          currentHp: 200,
+        }),
+      ];
+      let callCount = 0;
+      const origExecute = ruleset.executeMoveEffect.bind(ruleset);
+      ruleset.executeMoveEffect = (context: MoveEffectContext): MoveEffectResult => {
+        callCount++;
+        if (
+          context.attacker.pokemon.uid === "charizard-1" &&
+          context.move.id === "fly" &&
+          !context.attacker.volatileStatuses.has("flying")
+        ) {
+          return {
+            statusInflicted: null,
+            volatileInflicted: null,
+            statChanges: [],
+            recoilDamage: 0,
+            healAmount: 0,
+            switchOut: false,
+            messages: [],
+            forcedMoveSet: {
+              moveIndex: 0,
+              moveId: "fly",
+              volatileStatus: "flying" as VolatileStatus,
+            },
+          };
+        }
+        return origExecute(context);
+      };
+
+      const { engine, events } = createEngine({ ruleset, team1 });
+      engine.start();
+      const defenderStartHp = engine.getActive(1)?.pokemon.currentHp;
+      expect(defenderStartHp).toBeDefined();
+
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      const chargingAttacker = engine.getActive(0);
+      expect(chargingAttacker).not.toBeNull();
+      expect(chargingAttacker!.forcedMove).toEqual({ moveIndex: 0, moveId: "fly" });
+      expect(chargingAttacker!.volatileStatuses.has("flying")).toBe(true);
+
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      const resolvedAttacker = engine.getActive(0);
+      const defender = engine.getActive(1);
+      expect(resolvedAttacker).not.toBeNull();
+      expect(defender).not.toBeNull();
+      expect(defender!.pokemon.currentHp).toBe(defenderStartHp! - 10);
+      expect(resolvedAttacker!.forcedMove).toBeNull();
+      expect(resolvedAttacker!.volatileStatuses.has("flying")).toBe(false);
+
+      const volatileStartEvents = events.filter(
+        (e) => e.type === "volatile-start" && "volatile" in e && e.volatile === "flying",
+      );
+      expect(volatileStartEvents.length).toBe(1);
+      expect(callCount).toBe(2);
     });
   });
 


### PR DESCRIPTION
## Summary
- run charge-move setup effects before accuracy and damage so charge turns do not hit immediately
- skip re-running the charge setup hook on the forced follow-up turn after the volatile is cleared
- add engine regressions covering both the zero-damage setup turn and the normal follow-up hit

## Related Issue
Closes #795

## Verification
- `npx vitest run packages/battle/tests/engine/two-turn-moves.test.ts --reporter=dot`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/src/context/types.ts packages/battle/src/ruleset/GenerationRuleset.ts packages/battle/tests/engine/two-turn-moves.test.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/battle`
- `npm run test --workspace @pokemon-lib-ts/battle` *(blocked by unrelated existing workspace resolution failure in `tests/engine/ice-face-regression.test.ts` when `@pokemon-lib-ts/gen8` is not built in this worktree)*
