### PR TITLE
fix(battle): add pre-turn go-first item activation

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -26,6 +26,7 @@ import type {
   GenerationRuleset,
 } from "../ruleset";
 import { generations } from "../ruleset";
+import { markGoFirstItemActivated } from "../ruleset/GoFirstItemActivation";
 import type {
   ActivePokemon,
   BattlePhase,
@@ -1454,6 +1455,8 @@ export class BattleEngine implements BattleEventEmitter {
 
     // --- turn-resolve ---
     this.transitionTo("turn-resolve");
+
+    this.prepareGoFirstItemActivations(actions);
 
     // Sort actions by priority / speed / random
     const orderedActions = this.ruleset.resolveTurnOrder(actions, this.state, this.state.rng);
@@ -5306,6 +5309,49 @@ export class BattleEngine implements BattleEventEmitter {
             }
           }
         }
+      }
+    }
+  }
+
+  private prepareGoFirstItemActivations(actions: BattleAction[]): void {
+    if (!this.ruleset.hasHeldItems()) return;
+
+    for (const action of actions) {
+      if (action.type !== "move") continue;
+
+      const active = this.getActiveMutable(action.side);
+      if (!active || active.pokemon.currentHp <= 0 || !active.pokemon.heldItem) continue;
+
+      const moveSlot = active.pokemon.moves[action.moveIndex];
+      if (!moveSlot) continue;
+
+      let moveData: MoveData;
+      try {
+        moveData = this.dataManager.getMove(moveSlot.moveId);
+      } catch {
+        this.emit({
+          type: "engine-warning",
+          message: `Go-first item check skipped because move data for slot ${action.moveIndex} was not found.`,
+        });
+        continue;
+      }
+
+      const opponent = this.getOpponentActive(action.side) ?? undefined;
+      const itemResult = this.ruleset.applyHeldItem("before-turn-order", {
+        pokemon: active,
+        opponent,
+        state: this.state,
+        rng: this.state.rng,
+        move: moveData,
+      });
+
+      if (!itemResult.activated) continue;
+
+      markGoFirstItemActivated(action);
+      if (opponent) {
+        this.processItemResult(itemResult, active, opponent, action.side);
+      } else {
+        this.processItemResult(itemResult, active, action.side);
       }
     }
   }

--- a/packages/battle/src/ruleset/BaseRuleset.ts
+++ b/packages/battle/src/ruleset/BaseRuleset.ts
@@ -50,6 +50,7 @@ import type {
   ExpRecipientSelectionContext,
   GenerationRuleset,
 } from "./GenerationRuleset";
+import { hasGoFirstItemActivated } from "./GoFirstItemActivation";
 
 /**
  * Abstract base class implementing GenerationRuleset with Gen 6+/7+ defaults.
@@ -269,16 +270,19 @@ export abstract class BaseRuleset implements GenerationRuleset {
    * the tiebreak rng.next() calls, preserving PRNG consumption order.
    *
    * Returns a Set of action indices that have a "go first" item activated.
-   * Default: no items activated (Gen 4+ Quick Claw uses different mechanics).
+   * Default: honor move actions that the engine marked during the pre-turn held-item pass.
+   * Generations with custom pre-roll mechanics can still override this hook.
    *
    * Source: pret/pokeemerald HOLD_EFFECT_QUICK_CLAW — Gen 3 Quick Claw pre-roll
    */
   protected getQuickClawActivated(
-    _actions: BattleAction[],
+    actions: BattleAction[],
     _state: BattleState,
     _rng: SeededRandom,
   ): Set<number> {
-    return new Set();
+    return new Set(
+      actions.flatMap((action, index) => (hasGoFirstItemActivated(action) ? [index] : [])),
+    );
   }
 
   /**

--- a/packages/battle/src/ruleset/GenerationRuleset.ts
+++ b/packages/battle/src/ruleset/GenerationRuleset.ts
@@ -382,6 +382,7 @@ export interface ItemSystem {
   /**
    * Apply held item effects for the given trigger.
    * @param trigger Known trigger points:
+   *   - `"before-turn-order"` -- triggered before move-order sorting for same-priority go-first items
    *   - `"end-of-turn"` -- standard end-of-turn item effects (Leftovers, Black Sludge, etc.)
    *   - `"on-damage-taken"` -- triggered when the holder takes damage (context.opponent = attacker)
    *   - `"on-hit"` -- triggered when the holder lands a hit (context.opponent = defender)

--- a/packages/battle/src/ruleset/GoFirstItemActivation.ts
+++ b/packages/battle/src/ruleset/GoFirstItemActivation.ts
@@ -1,0 +1,15 @@
+import type { BattleAction } from "../events";
+
+const GO_FIRST_ITEM_ACTIVATED = Symbol("goFirstItemActivated");
+
+type GoFirstPreparedAction = BattleAction & {
+  [GO_FIRST_ITEM_ACTIVATED]?: true;
+};
+
+export function markGoFirstItemActivated(action: BattleAction): void {
+  (action as GoFirstPreparedAction)[GO_FIRST_ITEM_ACTIVATED] = true;
+}
+
+export function hasGoFirstItemActivated(action: BattleAction): boolean {
+  return (action as GoFirstPreparedAction)[GO_FIRST_ITEM_ACTIVATED] === true;
+}

--- a/packages/battle/tests/engine/go-first-item-activation.test.ts
+++ b/packages/battle/tests/engine/go-first-item-activation.test.ts
@@ -1,0 +1,188 @@
+import type { PokemonInstance } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import type { BattleConfig, ItemContext, ItemResult } from "../../src/context";
+import { BattleEngine } from "../../src/engine";
+import type { BattleEvent } from "../../src/events";
+import { hasGoFirstItemActivated } from "../../src/ruleset/GoFirstItemActivation";
+import { createTestPokemon } from "../../src/utils";
+import { createMockDataManager } from "../helpers/mock-data-manager";
+import { MockRuleset } from "../helpers/mock-ruleset";
+
+class GoFirstItemRuleset extends MockRuleset {
+  constructor(
+    private readonly activationMode: "none" | "consume" | "item-activate",
+    private readonly activatingPokemonUid: string,
+  ) {
+    super();
+    this.setGenerationForTest(9);
+  }
+
+  override hasHeldItems(): boolean {
+    return true;
+  }
+
+  override applyHeldItem(trigger: string, context: ItemContext): ItemResult {
+    if (
+      trigger !== "before-turn-order" ||
+      context.pokemon.pokemon.uid !== this.activatingPokemonUid ||
+      this.activationMode === "none"
+    ) {
+      return { activated: false, effects: [], messages: [] };
+    }
+
+    if (this.activationMode === "consume") {
+      return {
+        activated: true,
+        effects: [
+          {
+            type: "consume",
+            target: "self",
+            value: context.pokemon.pokemon.heldItem ?? "custap-berry",
+          },
+        ],
+        messages: [`${context.pokemon.pokemon.nickname}'s item let it move first!`],
+      };
+    }
+
+    return {
+      activated: true,
+      effects: [],
+      messages: [`${context.pokemon.pokemon.nickname}'s item let it move first!`],
+    };
+  }
+
+  override resolveTurnOrder(
+    actions: Parameters<MockRuleset["resolveTurnOrder"]>[0],
+    state: Parameters<MockRuleset["resolveTurnOrder"]>[1],
+    rng: Parameters<MockRuleset["resolveTurnOrder"]>[2],
+  ) {
+    return [...actions].sort((actionA, actionB) => {
+      const goFirstA = hasGoFirstItemActivated(actionA);
+      const goFirstB = hasGoFirstItemActivated(actionB);
+      if (goFirstA && !goFirstB) return -1;
+      if (goFirstB && !goFirstA) return 1;
+
+      const speedA = state.sides[actionA.side]?.active[0]?.pokemon.calculatedStats?.speed ?? 0;
+      const speedB = state.sides[actionB.side]?.active[0]?.pokemon.calculatedStats?.speed ?? 0;
+      if (speedA !== speedB) return speedB - speedA;
+
+      return rng.chance(0.5) ? -1 : 1;
+    });
+  }
+}
+
+function createEngine(ruleset: MockRuleset, team1: PokemonInstance[], team2: PokemonInstance[]) {
+  const dataManager = createMockDataManager();
+  const events: BattleEvent[] = [];
+  const config: BattleConfig = {
+    generation: 9,
+    format: "singles",
+    teams: [team1, team2],
+    seed: 12345,
+  };
+
+  const engine = new BattleEngine(config, ruleset, dataManager);
+  engine.on((event) => events.push(event));
+  engine.start();
+
+  return { engine, events };
+}
+
+function createTeams(heldItem: string | null) {
+  const slowerHolder = createTestPokemon(9, 50, {
+    uid: "blastoise-1",
+    nickname: "Blastoise",
+    heldItem,
+    currentHp: 200,
+    calculatedStats: {
+      hp: 200,
+      attack: 110,
+      defense: 100,
+      spAttack: 65,
+      spDefense: 110,
+      speed: 30,
+    },
+    moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+  });
+
+  const fasterOpponent = createTestPokemon(6, 50, {
+    uid: "charizard-1",
+    nickname: "Charizard",
+    currentHp: 200,
+    calculatedStats: {
+      hp: 200,
+      attack: 65,
+      defense: 60,
+      spAttack: 110,
+      spDefense: 95,
+      speed: 130,
+    },
+    moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+  });
+
+  return { team1: [slowerHolder], team2: [fasterOpponent] };
+}
+
+describe("go-first item activation", () => {
+  it("consumes an activated go-first item before turn order is resolved", () => {
+    const ruleset = new GoFirstItemRuleset("consume", "blastoise-1");
+    const { team1, team2 } = createTeams("custap-berry");
+    const { engine, events } = createEngine(ruleset, team1, team2);
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    const moveStarts = events.filter((event) => event.type === "move-start");
+    expect(moveStarts).toHaveLength(2);
+    expect(moveStarts[0]).toMatchObject({ pokemon: "Blastoise" });
+    expect(engine.getActive(0)?.pokemon.heldItem).toBeNull();
+
+    const itemConsumed = events.find(
+      (event) =>
+        event.type === "item-consumed" && "pokemon" in event && event.pokemon === "Blastoise",
+    );
+    expect(itemConsumed).toBeDefined();
+  });
+
+  it("supports non-consuming go-first items in the same pre-turn path", () => {
+    const ruleset = new GoFirstItemRuleset("item-activate", "blastoise-1");
+    const { team1, team2 } = createTeams("quick-claw");
+    const { engine, events } = createEngine(ruleset, team1, team2);
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    const moveStarts = events.filter((event) => event.type === "move-start");
+    expect(moveStarts).toHaveLength(2);
+    expect(moveStarts[0]).toMatchObject({ pokemon: "Blastoise" });
+    expect(engine.getActive(0)?.pokemon.heldItem).toBe("quick-claw");
+
+    const itemActivated = events.find(
+      (event) =>
+        event.type === "item-activate" && "pokemon" in event && event.pokemon === "Blastoise",
+    );
+    expect(itemActivated).toBeDefined();
+  });
+
+  it("leaves turn order unchanged when no go-first item activates", () => {
+    const ruleset = new GoFirstItemRuleset("none", "blastoise-1");
+    const { team1, team2 } = createTeams("custap-berry");
+    const { engine, events } = createEngine(ruleset, team1, team2);
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    const moveStarts = events.filter((event) => event.type === "move-start");
+    expect(moveStarts).toHaveLength(2);
+    expect(moveStarts[0]).toMatchObject({ pokemon: "Charizard" });
+    expect(engine.getActive(0)?.pokemon.heldItem).toBe("custap-berry");
+
+    const itemEvent = events.find(
+      (event) =>
+        (event.type === "item-consumed" || event.type === "item-activate") &&
+        "pokemon" in event &&
+        event.pokemon === "Blastoise",
+    );
+    expect(itemEvent).toBeUndefined();
+  });
+});

--- a/packages/gen9/src/Gen9Items.ts
+++ b/packages/gen9/src/Gen9Items.ts
@@ -770,6 +770,9 @@ export function applyGen9HeldItem(trigger: string, context: ItemContext): ItemRe
 
   let result: ItemResult;
   switch (trigger) {
+    case "before-turn-order":
+      result = handleBeforeTurnOrder(item, context);
+      break;
     case "before-move":
       result = handleBeforeMove(item, context);
       break;
@@ -805,6 +808,44 @@ export function applyGen9HeldItem(trigger: string, context: ItemContext): ItemRe
   }
 
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// before-turn-order
+// ---------------------------------------------------------------------------
+
+function handleBeforeTurnOrder(item: string, context: ItemContext): ItemResult {
+  const { pokemon } = context;
+  const pokemonName = pokemon.pokemon.nickname ?? "The Pokemon";
+  const maxHp = pokemon.pokemon.calculatedStats?.hp ?? pokemon.pokemon.currentHp;
+  const currentHp = pokemon.pokemon.currentHp;
+
+  switch (item) {
+    case "quick-claw":
+      if (context.rng.chance(0.2)) {
+        return {
+          activated: true,
+          effects: [],
+          messages: [`${pokemonName}'s Quick Claw let it move first!`],
+        };
+      }
+      return NO_ACTIVATION;
+
+    case "custap-berry": {
+      const threshold = getPinchBerryThreshold(pokemon, 0.25);
+      if (currentHp > 0 && currentHp <= Math.floor(maxHp * threshold)) {
+        return {
+          activated: true,
+          effects: [{ type: "consume", target: "self", value: "custap-berry" }],
+          messages: [`${pokemonName}'s Custap Berry let it move first!`],
+        };
+      }
+      return NO_ACTIVATION;
+    }
+
+    default:
+      return NO_ACTIVATION;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1332,24 +1373,6 @@ function handleOnDamageTaken(item: string, context: ItemContext): ItemResult {
             { type: "consume", target: "self", value: "starf-berry" },
           ],
           messages: [`${pokemonName}'s Starf Berry sharply raised its ${chosenStat}!`],
-        };
-      }
-      return NO_ACTIVATION;
-    }
-
-    // Custap Berry: gives priority to the holder's next move at <= 25% HP (consumed)
-    // Source: Showdown data/items.ts -- Custap Berry onBeforeTurn
-    // Source: Bulbapedia "Custap Berry" -- lets the holder move first once
-    case "custap-berry": {
-      const threshold = getPinchBerryThreshold(pokemon, 0.25);
-      if (currentHp > 0 && currentHp <= Math.floor(maxHp * threshold)) {
-        return {
-          activated: true,
-          effects: [
-            { type: "speed-boost", target: "self", value: 1 },
-            { type: "consume", target: "self", value: "custap-berry" },
-          ],
-          messages: [`${pokemonName}'s Custap Berry let it move first!`],
         };
       }
       return NO_ACTIVATION;

--- a/packages/gen9/src/Gen9Ruleset.ts
+++ b/packages/gen9/src/Gen9Ruleset.ts
@@ -392,7 +392,7 @@ export class Gen9Ruleset extends BaseRuleset {
    * Gen 9 held item handler.
    *
    * Delegates to applyGen9HeldItem which handles all item triggers:
-   * before-move, end-of-turn, on-damage-taken, on-contact, on-hit.
+   * before-turn-order, before-move, end-of-turn, on-damage-taken, on-contact, on-hit.
    *
    * Gen 9 changes from Gen 8:
    *   - No Z-Crystals or Mega Stones (already removed in Gen 8)

--- a/packages/gen9/tests/items.test.ts
+++ b/packages/gen9/tests/items.test.ts
@@ -440,6 +440,63 @@ describe("Life Orb", () => {
   });
 });
 
+describe("go-first held items", () => {
+  it("given Custap Berry in pinch range, when before-turn-order triggers, then it activates and consumes", () => {
+    const pokemon = makeActive({ heldItem: "custap-berry", hp: 200, currentHp: 50 });
+    const ctx = makeContext({
+      pokemon,
+      move: { id: "tackle", type: "normal", category: "physical" },
+    });
+
+    const result = applyGen9HeldItem("before-turn-order", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toEqual([{ type: "consume", target: "self", value: "custap-berry" }]);
+    expect(result.messages).toEqual(["The Pokemon's Custap Berry let it move first!"]);
+  });
+
+  it("given Custap Berry outside pinch range, when before-turn-order triggers, then it does not activate", () => {
+    const pokemon = makeActive({ heldItem: "custap-berry", hp: 200, currentHp: 51 });
+    const ctx = makeContext({
+      pokemon,
+      move: { id: "tackle", type: "normal", category: "physical" },
+    });
+
+    const result = applyGen9HeldItem("before-turn-order", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+
+  it("given Quick Claw and a successful roll, when before-turn-order triggers, then it activates without consuming", () => {
+    const pokemon = makeActive({ heldItem: "quick-claw" });
+    const ctx = makeContext({
+      pokemon,
+      move: { id: "tackle", type: "normal", category: "physical" },
+      rng: makeRng({ chance: () => true }),
+    });
+
+    const result = applyGen9HeldItem("before-turn-order", ctx);
+
+    expect(result.activated).toBe(true);
+    expect(result.effects).toEqual([]);
+    expect(result.messages).toEqual(["The Pokemon's Quick Claw let it move first!"]);
+  });
+
+  it("given Magic Room, when before-turn-order triggers, then go-first items stay suppressed", () => {
+    const pokemon = makeActive({ heldItem: "quick-claw" });
+    const ctx = makeContext({
+      pokemon,
+      move: { id: "tackle", type: "normal", category: "physical" },
+      rng: makeRng({ chance: () => true }),
+      state: makeState({ magicRoom: { active: true, turnsLeft: 3 } }),
+    });
+
+    const result = applyGen9HeldItem("before-turn-order", ctx);
+
+    expect(result.activated).toBe(false);
+  });
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Leftovers
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add a pre-turn go-first item activation pass before turn-order sorting
- route Gen 9 Custap Berry and Quick Claw through the new `before-turn-order` item trigger
- add regression coverage for engine ordering and Gen 9 item handlers

## Verification
- `npx vitest run packages/battle/tests/engine/go-first-item-activation.test.ts packages/gen9/tests/items.test.ts --reporter=dot`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/src/ruleset/BaseRuleset.ts packages/battle/src/ruleset/GenerationRuleset.ts packages/battle/src/ruleset/GoFirstItemActivation.ts packages/battle/tests/engine/go-first-item-activation.test.ts packages/gen9/src/Gen9Items.ts packages/gen9/src/Gen9Ruleset.ts packages/gen9/tests/items.test.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/battle --workspace @pokemon-lib-ts/gen9`
- `npm run build --workspace @pokemon-lib-ts/battle --workspace @pokemon-lib-ts/gen9`
- `npm run test --workspace @pokemon-lib-ts/battle --workspace @pokemon-lib-ts/gen9` *(still hits the pre-existing `@pokemon-lib-ts/gen8` package-entry failure in `packages/battle/tests/engine/ice-face-regression.test.ts`; all other battle tests passed and the full gen9 suite passed)*

Closes #939


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed go-first held items (Quick Claw, Custap Berry) to activate at the correct timing during battle turn order resolution.
  * Custap Berry now properly activates when a Pokémon's HP drops into critical range.
  * Magic Room status now correctly suppresses go-first item activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->