### PR TITLE
refactor: extract shared offensive damage-calc lookup tables

### DIFF
--- a/packages/battle/tests/data/damage-calc-constants.test.ts
+++ b/packages/battle/tests/data/damage-calc-constants.test.ts
@@ -2,18 +2,28 @@ import { describe, expect, it } from "vitest";
 import { BASE_PINCH_ABILITY_TYPES, BASE_PLATE_ITEMS, BASE_TYPE_BOOST_ITEMS } from "../../src/data";
 
 describe("battle damage-calc shared constants", () => {
-  it("exposes the stable offensive boost tables", () => {
+  it("given the shared offensive lookup tables, when they are imported, then they match the documented cartridge-era item and ability sets", () => {
+    // Source: Bulbapedia "Type-enhancing item" list for the 17 held items shared across gens 4-9.
     expect(Object.keys(BASE_TYPE_BOOST_ITEMS)).toHaveLength(17);
+    // Source: Showdown data/items.ts Charcoal entry + Bulbapedia "Charcoal".
     expect(BASE_TYPE_BOOST_ITEMS.charcoal).toBe("fire");
+    // Source: Showdown data/items.ts Silk Scarf entry + Bulbapedia "Silk Scarf".
     expect(BASE_TYPE_BOOST_ITEMS["silk-scarf"]).toBe("normal");
 
+    // Source: Bulbapedia "Plate" list for the 16 Arceus plates introduced in Gen 4.
     expect(Object.keys(BASE_PLATE_ITEMS)).toHaveLength(16);
+    // Source: Showdown data/items.ts Flame Plate entry + Bulbapedia "Flame Plate".
     expect(BASE_PLATE_ITEMS["flame-plate"]).toBe("fire");
+    // Source: Showdown data/items.ts Iron Plate entry + Bulbapedia "Iron Plate".
     expect(BASE_PLATE_ITEMS["iron-plate"]).toBe("steel");
+    // Source: Bulbapedia "Pixie Plate" documents it as Gen 6+, so it is absent from the shared base Gen 4+ table.
     expect(BASE_PLATE_ITEMS["pixie-plate"]).toBeUndefined();
 
+    // Source: Bulbapedia ability pages + Showdown pinch-ability handling for Overgrow/Blaze/Torrent/Swarm only.
     expect(Object.keys(BASE_PINCH_ABILITY_TYPES)).toHaveLength(4);
+    // Source: Bulbapedia "Overgrow" + Showdown data/abilities.ts.
     expect(BASE_PINCH_ABILITY_TYPES.overgrow).toBe("grass");
+    // Source: Bulbapedia "Swarm" + Showdown data/abilities.ts.
     expect(BASE_PINCH_ABILITY_TYPES.swarm).toBe("bug");
   });
 });

--- a/packages/gen4/src/Gen4DamageCalc.ts
+++ b/packages/gen4/src/Gen4DamageCalc.ts
@@ -4,6 +4,11 @@ import type {
   DamageContext,
   DamageResult,
 } from "@pokemon-lib-ts/battle";
+import {
+  BASE_PINCH_ABILITY_TYPES,
+  BASE_PLATE_ITEMS,
+  BASE_TYPE_BOOST_ITEMS,
+} from "@pokemon-lib-ts/battle/data";
 import type { MoveEffect, PokemonType, TypeChart } from "@pokemon-lib-ts/core";
 import {
   getStabModifier,
@@ -12,11 +17,6 @@ import {
   getTypeMultiplier,
   getWeatherDamageModifier,
 } from "@pokemon-lib-ts/core";
-import {
-  BASE_PINCH_ABILITY_TYPES,
-  BASE_PLATE_ITEMS,
-  BASE_TYPE_BOOST_ITEMS,
-} from "../../battle/src/data/index.js";
 import { isWeatherSuppressedGen4 } from "./Gen4Abilities";
 
 // ─── Type-Boosting Items ────────────────────────────────────────────────────

--- a/packages/gen4/tsconfig.json
+++ b/packages/gen4/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "../..",
+    "rootDir": "src",
     "composite": false,
     "resolveJsonModule": true
   },

--- a/packages/gen5/src/Gen5DamageCalc.ts
+++ b/packages/gen5/src/Gen5DamageCalc.ts
@@ -5,17 +5,17 @@ import type {
   DamageResult,
 } from "@pokemon-lib-ts/battle";
 import { getEffectiveStatStage } from "@pokemon-lib-ts/battle";
+import {
+  BASE_PINCH_ABILITY_TYPES,
+  BASE_PLATE_ITEMS,
+  BASE_TYPE_BOOST_ITEMS,
+} from "@pokemon-lib-ts/battle/data";
 import type { MoveEffect, PokemonType, TypeChart } from "@pokemon-lib-ts/core";
 import {
   getStabModifier,
   getStatStageMultiplier,
   getTypeEffectiveness,
 } from "@pokemon-lib-ts/core";
-import {
-  BASE_PINCH_ABILITY_TYPES,
-  BASE_PLATE_ITEMS,
-  BASE_TYPE_BOOST_ITEMS,
-} from "../../battle/src/data/index.js";
 import { isSheerForceEligibleMove } from "./Gen5AbilitiesDamage";
 import { isWeatherSuppressedGen5 } from "./Gen5Weather";
 

--- a/packages/gen5/tsconfig.json
+++ b/packages/gen5/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "../..",
+    "rootDir": "src",
     "composite": false,
     "resolveJsonModule": true
   },

--- a/packages/gen6/src/Gen6DamageCalc.ts
+++ b/packages/gen6/src/Gen6DamageCalc.ts
@@ -5,17 +5,17 @@ import type {
   DamageResult,
 } from "@pokemon-lib-ts/battle";
 import { getEffectiveStatStage } from "@pokemon-lib-ts/battle";
+import {
+  BASE_PINCH_ABILITY_TYPES,
+  BASE_PLATE_ITEMS,
+  BASE_TYPE_BOOST_ITEMS,
+} from "@pokemon-lib-ts/battle/data";
 import type { MoveEffect, PokemonType, TypeChart } from "@pokemon-lib-ts/core";
 import {
   getStabModifier,
   getStatStageMultiplier,
   getTypeEffectiveness,
 } from "@pokemon-lib-ts/core";
-import {
-  BASE_PINCH_ABILITY_TYPES,
-  BASE_PLATE_ITEMS,
-  BASE_TYPE_BOOST_ITEMS,
-} from "../../battle/src/data/index.js";
 import { isGen6Grounded } from "./Gen6EntryHazards.js";
 import { getTerrainDamageModifier } from "./Gen6Terrain.js";
 import { isWeatherSuppressedGen6 } from "./Gen6Weather.js";

--- a/packages/gen6/tsconfig.json
+++ b/packages/gen6/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "../..",
+    "rootDir": "src",
     "composite": false,
     "resolveJsonModule": true
   },

--- a/packages/gen7/src/Gen7DamageCalc.ts
+++ b/packages/gen7/src/Gen7DamageCalc.ts
@@ -37,17 +37,17 @@ import type {
   DamageResult,
 } from "@pokemon-lib-ts/battle";
 import { getEffectiveStatStage } from "@pokemon-lib-ts/battle";
+import {
+  BASE_PINCH_ABILITY_TYPES,
+  BASE_PLATE_ITEMS,
+  BASE_TYPE_BOOST_ITEMS,
+} from "@pokemon-lib-ts/battle/data";
 import type { MoveEffect, PokemonType, TypeChart, VolatileStatus } from "@pokemon-lib-ts/core";
 import {
   getStabModifier,
   getStatStageMultiplier,
   getTypeEffectiveness,
 } from "@pokemon-lib-ts/core";
-import {
-  BASE_PINCH_ABILITY_TYPES,
-  BASE_PLATE_ITEMS,
-  BASE_TYPE_BOOST_ITEMS,
-} from "../../battle/src/data/index.js";
 import { isWeatherSuppressedGen7 } from "./Gen7Weather.js";
 
 // ---- pokeRound: the 4096-based rounding function ----

--- a/packages/gen7/tsconfig.json
+++ b/packages/gen7/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "../..",
+    "rootDir": "src",
     "composite": false,
     "resolveJsonModule": true
   },

--- a/packages/gen8/src/Gen8DamageCalc.ts
+++ b/packages/gen8/src/Gen8DamageCalc.ts
@@ -41,17 +41,17 @@ import type {
   DamageResult,
 } from "@pokemon-lib-ts/battle";
 import { getEffectiveStatStage } from "@pokemon-lib-ts/battle";
+import {
+  BASE_PINCH_ABILITY_TYPES,
+  BASE_PLATE_ITEMS,
+  BASE_TYPE_BOOST_ITEMS,
+} from "@pokemon-lib-ts/battle/data";
 import type { MoveEffect, PokemonType, TypeChart, VolatileStatus } from "@pokemon-lib-ts/core";
 import {
   getStabModifier,
   getStatStageMultiplier,
   getTypeEffectiveness,
 } from "@pokemon-lib-ts/core";
-import {
-  BASE_PINCH_ABILITY_TYPES,
-  BASE_PLATE_ITEMS,
-  BASE_TYPE_BOOST_ITEMS,
-} from "../../battle/src/data/index.js";
 import { isWeatherSuppressedGen8 } from "./Gen8Weather.js";
 
 // ---- pokeRound: the 4096-based rounding function ----

--- a/packages/gen8/tsconfig.json
+++ b/packages/gen8/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "../..",
+    "rootDir": "src",
     "composite": false,
     "resolveJsonModule": true
   },

--- a/packages/gen9/src/Gen9DamageCalc.ts
+++ b/packages/gen9/src/Gen9DamageCalc.ts
@@ -41,13 +41,13 @@ import type {
   DamageResult,
 } from "@pokemon-lib-ts/battle";
 import { getEffectiveStatStage } from "@pokemon-lib-ts/battle";
-import type { MoveEffect, PokemonType, TypeChart, VolatileStatus } from "@pokemon-lib-ts/core";
-import { getStatStageMultiplier, getTypeEffectiveness } from "@pokemon-lib-ts/core";
 import {
   BASE_PINCH_ABILITY_TYPES,
   BASE_PLATE_ITEMS,
   BASE_TYPE_BOOST_ITEMS,
-} from "../../battle/src/data/index.js";
+} from "@pokemon-lib-ts/battle/data";
+import type { MoveEffect, PokemonType, TypeChart, VolatileStatus } from "@pokemon-lib-ts/core";
+import { getStatStageMultiplier, getTypeEffectiveness } from "@pokemon-lib-ts/core";
 import {
   getFluffyModifier,
   getHadronEngineSpAModifier,

--- a/packages/gen9/tsconfig.json
+++ b/packages/gen9/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "../..",
+    "rootDir": "src",
     "composite": false,
     "resolveJsonModule": true
   },


### PR DESCRIPTION
Closes #997\n\nThis slices out the stable offensive lookup family used by gen4-gen9 damage calculators into battle-local shared source:\n- type-boost items\n- plate items\n- pinch ability types\n\nThe gen damage-calculation suites still cover the runtime behavior, and the new battle data test locks the shared constants in place.\n\nVerification:\n- npx vitest run packages/battle/tests/data/damage-calc-constants.test.ts packages/battle/tests/index.test.ts\n- npx vitest run packages/gen4/tests/damage-calc.test.ts packages/gen5/tests/damage-calc.test.ts packages/gen6/tests/damage-calc.test.ts packages/gen7/tests/damage-calc.test.ts packages/gen8/tests/damage-calc.test.ts packages/gen9/tests/damage-calc.test.ts -t "type-boost|plate|pinch|Charcoal|flame-plate|pixie-plate|overgrow"\n- npx biome check packages/battle/package.json packages/battle/tsup.config.ts packages/battle/src/index.ts packages/battle/src/data/damage-calc-constants.ts packages/battle/src/data/index.ts packages/battle/tests/index.test.ts packages/battle/tests/data/damage-calc-constants.test.ts packages/gen4/src/Gen4DamageCalc.ts packages/gen4/tsconfig.json packages/gen5/src/Gen5DamageCalc.ts packages/gen5/tsconfig.json packages/gen6/src/Gen6DamageCalc.ts packages/gen6/tsconfig.json packages/gen7/src/Gen7DamageCalc.ts packages/gen7/tsconfig.json packages/gen8/src/Gen8DamageCalc.ts packages/gen8/tsconfig.json packages/gen9/src/Gen9DamageCalc.ts packages/gen9/tsconfig.json\n- npm run typecheck -w @pokemon-lib-ts/battle -w @pokemon-lib-ts/gen4 -w @pokemon-lib-ts/gen5 -w @pokemon-lib-ts/gen6 -w @pokemon-lib-ts/gen7 -w @pokemon-lib-ts/gen9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new `./data` export path to the battle package, exposing shared lookup tables for type-boost items, plate items, and pinch ability mappings.
  * These constants are now publicly available for use in damage calculations.

* **Refactor**
  * Consolidated duplicate lookup table definitions across generation-specific calculators to use shared base datasets.

* **Tests**
  * Added tests verifying the new shared data exports and their expected mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->