### PR TITLE
feat(battle): add source-linked volatile lifecycle hooks

### DIFF
--- a/packages/battle/src/context/types.ts
+++ b/packages/battle/src/context/types.ts
@@ -178,6 +178,18 @@ export interface MoveEffectResult {
   readonly statusInflicted: PrimaryStatus | null;
   /** Volatile status to inflict on the defender, or `null` */
   readonly volatileInflicted: VolatileStatus | null;
+  /**
+   * Volatile status to inflict on the defender with source-link metadata.
+   * Use this for effects that immobilize the target until the source leaves
+   * the field or the effect is explicitly cleared.
+   */
+  readonly targetVolatileInflicted?: {
+    volatile: VolatileStatus;
+    turnsLeft?: number;
+    data?: Record<string, unknown>;
+    sourcePokemonUid?: string;
+    blocksAction?: boolean;
+  } | null;
   /** Stat stage changes to apply; empty array means no stat changes */
   readonly statChanges: ReadonlyArray<{
     target: "attacker" | "defender";

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -878,6 +878,35 @@ export class BattleEngine implements BattleEventEmitter {
     const active = this.state.sides[side].active[0];
     if (!active) return [];
 
+    const actionBlockingVolatile = this.getSourceLinkedActionBlocker(active);
+    if (actionBlockingVolatile) {
+      return active.pokemon.moves.flatMap((slot, index) => {
+        let moveData: MoveData | undefined;
+        try {
+          moveData = this.dataManager.getMove(slot.moveId);
+        } catch {
+          this.emit({
+            type: "engine-warning",
+            message: `Move "${slot.moveId}" not found in data for Pokémon "${active.pokemon.speciesId}". Slot skipped.`,
+          });
+          return [];
+        }
+        return [
+          {
+            index,
+            moveId: slot.moveId,
+            displayName: moveData.displayName,
+            type: moveData.type,
+            category: moveData.category,
+            pp: slot.currentPP,
+            maxPp: slot.maxPP,
+            disabled: true,
+            disabledReason: "Can't move",
+          },
+        ];
+      });
+    }
+
     // If the Pokemon has a forced move (two-turn move second turn), only that move is available
     // Source: Showdown — during the execution turn of a two-turn move, only that move can be selected
     if (active.forcedMove) {
@@ -1074,6 +1103,67 @@ export class BattleEngine implements BattleEventEmitter {
 
   private getActiveMutable(side: 0 | 1): ActivePokemon | null {
     return this.state.sides[side].active[0] ?? null;
+  }
+
+  /**
+   * Returns the first source-linked volatile that should prevent the Pokemon
+   * from acting. If the source is no longer active, the stale volatile is
+   * cleared immediately and `null` is returned.
+   */
+  private getSourceLinkedActionBlocker(
+    actor: ActivePokemon,
+  ): { volatile: VolatileStatus; state: VolatileStatusState } | null {
+    for (const [volatile, volatileState] of actor.volatileStatuses.entries()) {
+      if (!volatileState.blocksAction) continue;
+
+      const sourcePokemonUid = volatileState.sourcePokemonUid;
+      if (sourcePokemonUid && !this.isPokemonActive(sourcePokemonUid)) {
+        const side = this.getSideIndex(actor);
+        actor.volatileStatuses.delete(volatile);
+        this.emit({
+          type: "volatile-end",
+          side,
+          pokemon: getPokemonName(actor),
+          volatile,
+        });
+        continue;
+      }
+
+      return { volatile, state: volatileState };
+    }
+
+    return null;
+  }
+
+  /**
+   * Removes any source-linked volatiles created by the given source Pokemon.
+   * Used when the source leaves the field so linked targets are released.
+   */
+  private clearSourceLinkedVolatiles(sourcePokemonUid: string): void {
+    for (const side of this.state.sides) {
+      for (const active of side.active) {
+        if (!active) continue;
+
+        for (const [volatile, volatileState] of [...active.volatileStatuses.entries()]) {
+          if (volatileState.sourcePokemonUid !== sourcePokemonUid) continue;
+
+          active.volatileStatuses.delete(volatile);
+          this.emit({
+            type: "volatile-end",
+            side: side.index,
+            pokemon: getPokemonName(active),
+            volatile,
+          });
+        }
+      }
+    }
+  }
+
+  /** Returns `true` if the given Pokemon UID is still active on the field. */
+  private isPokemonActive(pokemonUid: string): boolean {
+    return this.state.sides.some((side) =>
+      side.active.some((active) => active?.pokemon.uid === pokemonUid),
+    );
   }
 
   // --- Serialization ---
@@ -2724,6 +2814,7 @@ export class BattleEngine implements BattleEventEmitter {
     if (outgoing) {
       // Let the ruleset handle any gen-specific switch-out cleanup first
       this.ruleset.onSwitchOut(outgoing, this.state);
+      this.clearSourceLinkedVolatiles(outgoing.pokemon.uid);
 
       this.emit({
         type: "switch-out",
@@ -2779,6 +2870,7 @@ export class BattleEngine implements BattleEventEmitter {
     const outgoing = side.active[0];
     if (outgoing) {
       this.ruleset.onSwitchOut(outgoing, this.state);
+      this.clearSourceLinkedVolatiles(outgoing.pokemon.uid);
       this.emit({
         type: "switch-out",
         side: sideIndex,
@@ -3453,6 +3545,17 @@ export class BattleEngine implements BattleEventEmitter {
       }
     }
 
+    // Source-linked target-volatiles (e.g., Sky Drop-style immobilization) can
+    // block the Pokemon from acting while the source remains active.
+    const sourceLinkedBlocker = this.getSourceLinkedActionBlocker(actor);
+    if (sourceLinkedBlocker) {
+      this.emit({
+        type: "message",
+        text: `${getPokemonName(actor)} can't move!`,
+      });
+      return false;
+    }
+
     // Gravity check — prevents moves with the gravity flag (Fly, Bounce, etc.)
     // Source: Showdown Gen 4 mod — Gravity disables gravity-flagged moves
     if (this.state.gravity.active && move.flags.gravity) {
@@ -3629,6 +3732,29 @@ export class BattleEngine implements BattleEventEmitter {
           side: defenderSide,
           pokemon: getPokemonName(defender),
           volatile: result.volatileInflicted,
+        });
+      }
+    }
+
+    // Source-linked target volatile infliction — used by effects that immobilize
+    // the defender while the source Pokemon remains on the field.
+    if (
+      result.targetVolatileInflicted &&
+      !defender.volatileStatuses.has(result.targetVolatileInflicted.volatile)
+    ) {
+      const linkedVolatile = result.targetVolatileInflicted;
+      if (!this.ruleset.shouldBlockVolatile?.(linkedVolatile.volatile, defender, this.state)) {
+        defender.volatileStatuses.set(linkedVolatile.volatile, {
+          turnsLeft: linkedVolatile.turnsLeft ?? -1,
+          data: linkedVolatile.data,
+          sourcePokemonUid: linkedVolatile.sourcePokemonUid ?? attacker.pokemon.uid,
+          blocksAction: linkedVolatile.blocksAction ?? false,
+        });
+        this.emit({
+          type: "volatile-start",
+          side: defenderSide,
+          pokemon: getPokemonName(defender),
+          volatile: linkedVolatile.volatile,
         });
       }
     }
@@ -5274,6 +5400,7 @@ export class BattleEngine implements BattleEventEmitter {
           pokemon: getPokemonName(active),
         });
         side.faintCount++;
+        this.clearSourceLinkedVolatiles(active.pokemon.uid);
 
         // Award EXP to the winning side's participants for this faint
         this.awardExpForFaint(side.index as 0 | 1, active.pokemon.uid);

--- a/packages/battle/src/state/BattleSide.ts
+++ b/packages/battle/src/state/BattleSide.ts
@@ -155,6 +155,13 @@ export interface VolatileStatusState {
   turnsLeft: number;
   /** Identifier of whatever caused this volatile status (move ID, ability ID, etc.) */
   source?: string;
+  /**
+   * UID of the active Pokemon that created this volatile, when the effect is
+   * source-linked and should disappear if the source leaves the field.
+   */
+  sourcePokemonUid?: string;
+  /** When true, the volatile blocks the Pokemon from acting while it remains active. */
+  blocksAction?: boolean;
   /** Arbitrary extra data for complex volatiles (e.g., confusion damage threshold) */
   data?: Record<string, unknown>;
 }

--- a/packages/battle/tests/engine/source-linked-target-volatiles.test.ts
+++ b/packages/battle/tests/engine/source-linked-target-volatiles.test.ts
@@ -1,0 +1,258 @@
+import type { PokemonInstance } from "@pokemon-lib-ts/core";
+import { describe, expect, it } from "vitest";
+import type { BattleConfig, MoveEffectContext, MoveEffectResult } from "../../src/context";
+import { BattleEngine } from "../../src/engine";
+import type { BattleEvent } from "../../src/events";
+import type { VolatileStatusState } from "../../src/state";
+import { createTestPokemon } from "../../src/utils";
+import { createMockDataManager } from "../helpers/mock-data-manager";
+import { MockRuleset } from "../helpers/mock-ruleset";
+
+function createEngine(overrides?: {
+  seed?: number;
+  team1?: PokemonInstance[];
+  team2?: PokemonInstance[];
+  ruleset?: MockRuleset;
+}) {
+  const ruleset = overrides?.ruleset ?? new MockRuleset();
+  const dataManager = createMockDataManager();
+  const events: BattleEvent[] = [];
+
+  const team1 = overrides?.team1 ?? [
+    createTestPokemon(6, 50, {
+      uid: "charizard-1",
+      nickname: "Charizard",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 120,
+      },
+      currentHp: 200,
+    }),
+    createTestPokemon(25, 50, {
+      uid: "pikachu-1",
+      nickname: "Pikachu",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 100,
+        attack: 80,
+        defense: 60,
+        spAttack: 80,
+        spDefense: 60,
+        speed: 110,
+      },
+      currentHp: 100,
+    }),
+  ];
+
+  const team2 = overrides?.team2 ?? [
+    createTestPokemon(9, 50, {
+      uid: "blastoise-1",
+      nickname: "Blastoise",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 80,
+      },
+      currentHp: 200,
+    }),
+    createTestPokemon(6, 50, {
+      uid: "charizard-2",
+      nickname: "Charizard2",
+      moves: [{ moveId: "tackle", currentPP: 35, maxPP: 35, ppUps: 0 }],
+      calculatedStats: {
+        hp: 200,
+        attack: 100,
+        defense: 100,
+        spAttack: 100,
+        spDefense: 100,
+        speed: 70,
+      },
+      currentHp: 200,
+    }),
+  ];
+
+  const config: BattleConfig = {
+    generation: 1,
+    format: "singles",
+    teams: [team1, team2],
+    seed: overrides?.seed ?? 12345,
+  };
+
+  const engine = new BattleEngine(config, ruleset, dataManager);
+  engine.on((e) => events.push(e));
+
+  return { engine, ruleset, events };
+}
+
+function createLinkedVolatile(sourcePokemonUid: string): VolatileStatusState {
+  return {
+    turnsLeft: 2,
+    sourcePokemonUid,
+    blocksAction: true,
+  } as unknown as VolatileStatusState;
+}
+
+describe("BattleEngine - source-linked target volatile lifecycle", () => {
+  it("given executeMoveEffect applies a source-linked blocking volatile, when the source resolves it on the next turn, then the target is blocked until the resolution clears the volatile", () => {
+    // Source: Showdown Sky Drop / trapping-style move flow — the target becomes immobilized
+    // while the user keeps the effect active, then the effect is cleared by the resolving move.
+    const ruleset = new MockRuleset();
+    let callCount = 0;
+    const originalExecute = ruleset.executeMoveEffect.bind(ruleset);
+    ruleset.executeMoveEffect = (context: MoveEffectContext): MoveEffectResult => {
+      callCount += 1;
+      if (context.attacker.pokemon.uid === "charizard-1" && callCount === 1) {
+        return {
+          statusInflicted: null,
+          volatileInflicted: null,
+          statChanges: [],
+          recoilDamage: 0,
+          healAmount: 0,
+          switchOut: false,
+          messages: [],
+          targetVolatileInflicted: {
+            volatile: "trapped",
+            turnsLeft: 2,
+            sourcePokemonUid: context.attacker.pokemon.uid,
+            blocksAction: true,
+          } as never,
+        } as MoveEffectResult;
+      }
+      if (context.attacker.pokemon.uid === "charizard-1" && callCount === 2) {
+        return {
+          statusInflicted: null,
+          volatileInflicted: null,
+          statChanges: [],
+          recoilDamage: 0,
+          healAmount: 0,
+          switchOut: false,
+          messages: [],
+          volatilesToClear: [{ target: "defender", volatile: "trapped" }],
+        } as MoveEffectResult;
+      }
+      return originalExecute(context);
+    };
+
+    const { engine, events } = createEngine({ ruleset });
+    engine.start();
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    const linkedVolatile = engine.state.sides[1].active[0]?.volatileStatuses.get("trapped");
+    expect(linkedVolatile).toEqual({
+      turnsLeft: 2,
+      sourcePokemonUid: "charizard-1",
+      blocksAction: true,
+    });
+
+    const turn1MoveStarts = events.filter((event) => event.type === "move-start");
+    expect(turn1MoveStarts).toHaveLength(1);
+    expect(
+      (turn1MoveStarts[0] as Extract<BattleEvent, { type: "move-start" }> | undefined)?.side,
+    ).toBe(0);
+    expect(engine.state.sides[0].active[0]?.pokemon.currentHp).toBe(
+      engine.state.sides[0].active[0]?.pokemon.calculatedStats?.hp,
+    );
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    const clearedVolatile = engine.state.sides[1].active[0]?.volatileStatuses.get("trapped");
+    expect(clearedVolatile).toBeUndefined();
+
+    const targetMoveStarts = events.filter(
+      (event) => event.type === "move-start" && event.side === 1,
+    );
+    expect(targetMoveStarts).toHaveLength(1);
+
+    const volatileEndEvents = events.filter(
+      (event) => event.type === "volatile-end" && event.side === 1 && event.volatile === "trapped",
+    );
+    expect(volatileEndEvents).toHaveLength(1);
+  });
+
+  it("given a target with a source-linked blocking volatile, when the source switches out, then the volatile is cleared and the target can act", () => {
+    // Source: Sky Drop-style source-leaves-field cleanup — switching out should release
+    // the linked target before the opponent's move resolves.
+    const { engine, events } = createEngine();
+    engine.start();
+
+    engine.state.sides[1].active[0]!.volatileStatuses.set(
+      "trapped",
+      createLinkedVolatile("charizard-1"),
+    );
+
+    engine.submitAction(0, { type: "switch", side: 0, switchTo: 1 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    expect(engine.state.sides[1].active[0]?.volatileStatuses.has("trapped")).toBe(false);
+
+    const volatileEndEvents = events.filter(
+      (event) => event.type === "volatile-end" && event.side === 1 && event.volatile === "trapped",
+    );
+    expect(volatileEndEvents).toHaveLength(1);
+
+    const targetMoveStarts = events.filter(
+      (event) => event.type === "move-start" && event.side === 1,
+    );
+    expect(targetMoveStarts).toHaveLength(1);
+  });
+
+  it("given a target with a source-linked blocking volatile, when the source faints, then the volatile is cleared and the target can act", () => {
+    // Source: Sky Drop-style source-faint cleanup — if the user faints, the target is released
+    // before the opponent's move resolves.
+    const ruleset = new MockRuleset();
+    const originalExecute = ruleset.executeMoveEffect.bind(ruleset);
+    ruleset.executeMoveEffect = (context: MoveEffectContext): MoveEffectResult => {
+      if (context.attacker.pokemon.uid === "charizard-1") {
+        return {
+          statusInflicted: null,
+          volatileInflicted: null,
+          statChanges: [],
+          recoilDamage: 0,
+          healAmount: 0,
+          switchOut: false,
+          messages: [],
+          selfFaint: true,
+        } as MoveEffectResult;
+      }
+      return originalExecute(context);
+    };
+
+    const { engine, events } = createEngine({ ruleset });
+    engine.start();
+
+    engine.state.sides[1].active[0]!.volatileStatuses.set(
+      "trapped",
+      createLinkedVolatile("charizard-1"),
+    );
+
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    expect(engine.state.sides[1].active[0]?.volatileStatuses.has("trapped")).toBe(false);
+
+    const faintEvents = events.filter((event) => event.type === "faint" && event.side === 0);
+    expect(faintEvents).toHaveLength(1);
+
+    const volatileEndEvents = events.filter(
+      (event) => event.type === "volatile-end" && event.side === 1 && event.volatile === "trapped",
+    );
+    expect(volatileEndEvents).toHaveLength(1);
+
+    const targetMoveStarts = events.filter(
+      (event) => event.type === "move-start" && event.side === 1,
+    );
+    expect(targetMoveStarts).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Add reusable engine support for source-linked target volatiles so rulesets can immobilize a target across turns and release it when the source switches out, faints, or explicitly clears the effect.

## Verification
- npx vitest run packages/battle/tests/engine/source-linked-target-volatiles.test.ts --reporter=dot
- npx vitest run packages/battle/tests/engine/two-turn-moves.test.ts packages/battle/tests/engine/battle-engine.test.ts -t "forced move|getAvailableMoves|Locked into move|source-linked target volatile" --reporter=dot
- npx vitest run packages/battle/tests/engine/source-linked-target-volatiles.test.ts packages/battle/tests/engine/move-availability.test.ts packages/battle/tests/engine/assault-vest.test.ts packages/battle/tests/engine/battle-engine-branches.test.ts -t "getAvailableMoves|Assault Vest|source-linked target volatile|forced move" --reporter=dot
- npx vitest run packages/battle/tests/engine/move-availability.test.ts --reporter=dot
- npx @biomejs/biome check packages/battle/src/context/types.ts packages/battle/src/state/BattleSide.ts packages/battle/src/engine/BattleEngine.ts packages/battle/tests/engine/source-linked-target-volatiles.test.ts
- npx tsc -p packages/battle/tsconfig.json --noEmit

Closes #1002