### PR TITLE
fix(core): add explicit gen1toN helper names

### DIFF
--- a/.changeset/core-gen-range-helper-names.md
+++ b/.changeset/core-gen-range-helper-names.md
@@ -1,0 +1,9 @@
+---
+"@pokemon-lib-ts/core": patch
+---
+
+Add explicit `gen1toN*` helper names for the shared Gen 1-2, Gen 1-4, and
+Gen 1-6 battle logic helpers in `@pokemon-lib-ts/core`.
+
+The old `gen12*`, `gen14*`, and `gen16*` exports remain as deprecated aliases
+for compatibility while internal callers move to the clearer public names.

--- a/packages/core/src/logic/gen12-shared.ts
+++ b/packages/core/src/logic/gen12-shared.ts
@@ -9,9 +9,14 @@ import type { SeededRandom } from "../prng/seeded-random.js";
  * @param rng - The battle's seeded PRNG
  * @returns `true` if the Pokémon is fully paralyzed this turn
  */
-export function gen12FullParalysisCheck(rng: SeededRandom): boolean {
+export function gen1to2FullParalysisCheck(rng: SeededRandom): boolean {
   return rng.int(0, 255) < 63;
 }
+
+/**
+ * @deprecated Use gen1to2FullParalysisCheck for the explicit generation range.
+ */
+export const gen12FullParalysisCheck = gen1to2FullParalysisCheck;
 
 /**
  * Gen 1–4: Weighted multi-hit distribution [2,2,2,3,3,3,4,5].
@@ -24,9 +29,14 @@ export function gen12FullParalysisCheck(rng: SeededRandom): boolean {
  * @param rng - The battle's seeded PRNG
  * @returns Number of hits: 2, 3, 4, or 5
  */
-export function gen14MultiHitRoll(rng: SeededRandom): number {
+export function gen1to4MultiHitRoll(rng: SeededRandom): number {
   return rng.pick([2, 2, 2, 3, 3, 3, 4, 5] as const);
 }
+
+/**
+ * @deprecated Use gen1to4MultiHitRoll for the explicit generation range.
+ */
+export const gen14MultiHitRoll = gen1to4MultiHitRoll;
 
 /**
  * Gen 1–6: 50% chance to hit self in confusion.
@@ -37,9 +47,14 @@ export function gen14MultiHitRoll(rng: SeededRandom): number {
  * @param rng - The battle's seeded PRNG
  * @returns `true` if the Pokémon hits itself in confusion
  */
-export function gen16ConfusionSelfHitRoll(rng: SeededRandom): boolean {
+export function gen1to6ConfusionSelfHitRoll(rng: SeededRandom): boolean {
   return rng.chance(0.5);
 }
+
+/**
+ * @deprecated Use gen1to6ConfusionSelfHitRoll for the explicit generation range.
+ */
+export const gen16ConfusionSelfHitRoll = gen1to6ConfusionSelfHitRoll;
 
 /**
  * Gen 1–2: Stat EXP contribution = floor(ceil(sqrt(statExp)) / 4).

--- a/packages/core/src/logic/index.ts
+++ b/packages/core/src/logic/index.ts
@@ -27,6 +27,9 @@ export {
 } from "./experience";
 export {
   calculateStatExpContribution,
+  gen1to2FullParalysisCheck,
+  gen1to4MultiHitRoll,
+  gen1to6ConfusionSelfHitRoll,
   gen12FullParalysisCheck,
   gen14MultiHitRoll,
   gen16ConfusionSelfHitRoll,

--- a/packages/core/tests/logic/gen12-shared.test.ts
+++ b/packages/core/tests/logic/gen12-shared.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   calculateStatExpContribution,
+  gen1to2FullParalysisCheck,
+  gen1to4MultiHitRoll,
+  gen1to6ConfusionSelfHitRoll,
   gen12FullParalysisCheck,
   gen14MultiHitRoll,
   gen16ConfusionSelfHitRoll,
@@ -8,10 +11,10 @@ import {
 import { SeededRandom } from "../../src/prng/seeded-random.js";
 
 // ============================================================
-// gen12FullParalysisCheck
+// gen1to2FullParalysisCheck
 // ============================================================
 
-describe("gen12FullParalysisCheck", () => {
+describe("gen1to2FullParalysisCheck", () => {
   // Source: pret/pokered engine/battle/core.asm:3454 — cp 25 percent (= 63/256)
   // The check returns true when rng.int(0,255) < 63.
 
@@ -19,21 +22,21 @@ describe("gen12FullParalysisCheck", () => {
     // Seed 7 → int(0,255) = 2 → 2 < 63 → paralyzed
     // Verified: new SeededRandom(7).int(0,255) === 2
     const rng = new SeededRandom(7);
-    expect(gen12FullParalysisCheck(rng)).toBe(true);
+    expect(gen1to2FullParalysisCheck(rng)).toBe(true);
   });
 
   it("given seed 0, when checking full paralysis, then returns false (rng.int(0,255) = 68 >= 63)", () => {
     // Seed 0 → int(0,255) = 68 → 68 >= 63 → not paralyzed
     // Verified: new SeededRandom(0).int(0,255) === 68
     const rng = new SeededRandom(0);
-    expect(gen12FullParalysisCheck(rng)).toBe(false);
+    expect(gen1to2FullParalysisCheck(rng)).toBe(false);
   });
 
   it("given same seed 7, when checking full paralysis twice, then both calls return the same result", () => {
     // Source: pret/pokered engine/battle/core.asm:3454 — deterministic PRNG
     const rng1 = new SeededRandom(7);
     const rng2 = new SeededRandom(7);
-    expect(gen12FullParalysisCheck(rng1)).toBe(gen12FullParalysisCheck(rng2));
+    expect(gen1to2FullParalysisCheck(rng1)).toBe(gen1to2FullParalysisCheck(rng2));
   });
 
   it("given 10,000 trials with seed 42, when counting paralysis triggers, then rate is between 22% and 27%", () => {
@@ -43,7 +46,7 @@ describe("gen12FullParalysisCheck", () => {
     let trueCount = 0;
     const trials = 10000;
     for (let i = 0; i < trials; i++) {
-      if (gen12FullParalysisCheck(rng)) trueCount++;
+      if (gen1to2FullParalysisCheck(rng)) trueCount++;
     }
     const rate = trueCount / trials;
     expect(rate).toBeGreaterThan(0.22);
@@ -54,15 +57,19 @@ describe("gen12FullParalysisCheck", () => {
     // Seed 15 → int(0,255) = 60 → 60 < 63 → paralyzed (triangulation: second true case)
     // Verified: new SeededRandom(15).int(0,255) === 60
     const rng = new SeededRandom(15);
-    expect(gen12FullParalysisCheck(rng)).toBe(true);
+    expect(gen1to2FullParalysisCheck(rng)).toBe(true);
+  });
+
+  it("keeps gen12FullParalysisCheck as a compatibility alias", () => {
+    expect(gen12FullParalysisCheck).toBe(gen1to2FullParalysisCheck);
   });
 });
 
 // ============================================================
-// gen14MultiHitRoll
+// gen1to4MultiHitRoll
 // ============================================================
 
-describe("gen14MultiHitRoll", () => {
+describe("gen1to4MultiHitRoll", () => {
   // Source: pret/pokered engine/battle/core.asm — multi-hit distribution [2,2,2,3,3,3,4,5]
   // Source: Bulbapedia — Multi-hit move — counts 2 (37.5%), 3 (37.5%), 4 (12.5%), 5 (12.5%)
 
@@ -70,28 +77,28 @@ describe("gen14MultiHitRoll", () => {
     // Seed 0 → pick index 0 → value 2
     // Verified: new SeededRandom(0).pick([2,2,2,3,3,3,4,5]) === 2
     const rng = new SeededRandom(0);
-    expect(gen14MultiHitRoll(rng)).toBe(2);
+    expect(gen1to4MultiHitRoll(rng)).toBe(2);
   });
 
   it("given seed 1, when rolling multi-hit, then returns 3 (picks from the 3-hit slots)", () => {
     // Seed 1 → pick index in [3,4,5] → value 3
     // Verified: new SeededRandom(1).pick([2,2,2,3,3,3,4,5]) === 3
     const rng = new SeededRandom(1);
-    expect(gen14MultiHitRoll(rng)).toBe(3);
+    expect(gen1to4MultiHitRoll(rng)).toBe(3);
   });
 
   it("given seed 20, when rolling multi-hit, then returns 4 (picks index 6 of [2,2,2,3,3,3,4,5])", () => {
     // Seed 20 → pick index 6 → value 4
     // Verified: new SeededRandom(20).pick([2,2,2,3,3,3,4,5]) === 4
     const rng = new SeededRandom(20);
-    expect(gen14MultiHitRoll(rng)).toBe(4);
+    expect(gen1to4MultiHitRoll(rng)).toBe(4);
   });
 
   it("given seed 4, when rolling multi-hit, then returns 5 (picks index 7 of [2,2,2,3,3,3,4,5])", () => {
     // Seed 4 → pick index 7 → value 5
     // Verified: new SeededRandom(4).pick([2,2,2,3,3,3,4,5]) === 5
     const rng = new SeededRandom(4);
-    expect(gen14MultiHitRoll(rng)).toBe(5);
+    expect(gen1to4MultiHitRoll(rng)).toBe(5);
   });
 
   it("given seeds 0-99, when rolling multi-hit, then every result is in {2, 3, 4, 5}", () => {
@@ -99,7 +106,7 @@ describe("gen14MultiHitRoll", () => {
     const validHits = new Set([2, 3, 4, 5]);
     for (let seed = 0; seed < 100; seed++) {
       const rng = new SeededRandom(seed);
-      const result = gen14MultiHitRoll(rng);
+      const result = gen1to4MultiHitRoll(rng);
       expect(validHits.has(result)).toBe(true);
     }
   });
@@ -112,7 +119,7 @@ describe("gen14MultiHitRoll", () => {
     const counts: Record<number, number> = { 2: 0, 3: 0, 4: 0, 5: 0 };
     const trials = 10000;
     for (let i = 0; i < trials; i++) {
-      const result = gen14MultiHitRoll(rng);
+      const result = gen1to4MultiHitRoll(rng);
       counts[result]++;
     }
     // 2-hits: expected 37.5%, acceptable 33–42%
@@ -128,13 +135,17 @@ describe("gen14MultiHitRoll", () => {
     expect(counts[5] / trials).toBeGreaterThan(0.08);
     expect(counts[5] / trials).toBeLessThan(0.17);
   });
+
+  it("keeps gen14MultiHitRoll as a compatibility alias", () => {
+    expect(gen14MultiHitRoll).toBe(gen1to4MultiHitRoll);
+  });
 });
 
 // ============================================================
-// gen16ConfusionSelfHitRoll
+// gen1to6ConfusionSelfHitRoll
 // ============================================================
 
-describe("gen16ConfusionSelfHitRoll", () => {
+describe("gen1to6ConfusionSelfHitRoll", () => {
   // Source: pret/pokered engine/battle/core.asm — confusion self-hit check (50%)
   // Source: pret/pokecrystal engine/battle/effect_commands.asm:602 HitConfusion
 
@@ -142,21 +153,21 @@ describe("gen16ConfusionSelfHitRoll", () => {
     // Seed 0 → next() < 0.5 → true
     // Verified: new SeededRandom(0).chance(0.5) === true
     const rng = new SeededRandom(0);
-    expect(gen16ConfusionSelfHitRoll(rng)).toBe(true);
+    expect(gen1to6ConfusionSelfHitRoll(rng)).toBe(true);
   });
 
   it("given seed 1, when rolling confusion self-hit, then returns false (rng.chance(0.5) misses)", () => {
     // Seed 1 → next() >= 0.5 → false
     // Verified: new SeededRandom(1).chance(0.5) === false
     const rng = new SeededRandom(1);
-    expect(gen16ConfusionSelfHitRoll(rng)).toBe(false);
+    expect(gen1to6ConfusionSelfHitRoll(rng)).toBe(false);
   });
 
   it("given same seed 0, when rolling confusion self-hit twice, then both calls return the same result", () => {
     // Source: Mulberry32 PRNG — same seed always produces same sequence
     const rng1 = new SeededRandom(0);
     const rng2 = new SeededRandom(0);
-    expect(gen16ConfusionSelfHitRoll(rng1)).toBe(gen16ConfusionSelfHitRoll(rng2));
+    expect(gen1to6ConfusionSelfHitRoll(rng1)).toBe(gen1to6ConfusionSelfHitRoll(rng2));
   });
 
   it("given 10,000 trials with seed 42, when counting self-hits, then rate is between 47% and 53%", () => {
@@ -166,11 +177,15 @@ describe("gen16ConfusionSelfHitRoll", () => {
     let trueCount = 0;
     const trials = 10000;
     for (let i = 0; i < trials; i++) {
-      if (gen16ConfusionSelfHitRoll(rng)) trueCount++;
+      if (gen1to6ConfusionSelfHitRoll(rng)) trueCount++;
     }
     const rate = trueCount / trials;
     expect(rate).toBeGreaterThan(0.47);
     expect(rate).toBeLessThan(0.53);
+  });
+
+  it("keeps gen16ConfusionSelfHitRoll as a compatibility alias", () => {
+    expect(gen16ConfusionSelfHitRoll).toBe(gen1to6ConfusionSelfHitRoll);
   });
 });
 

--- a/packages/core/tests/public-api.test.ts
+++ b/packages/core/tests/public-api.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import * as core from "../src/index.js";
+
+describe("@pokemon-lib-ts/core public API", () => {
+  it("exports explicit gen1toN helper names from the root barrel", () => {
+    expect(core.gen1to2FullParalysisCheck).toBeTypeOf("function");
+    expect(core.gen1to4MultiHitRoll).toBeTypeOf("function");
+    expect(core.gen1to6ConfusionSelfHitRoll).toBeTypeOf("function");
+  });
+
+  it("keeps the legacy aliases wired to the canonical helpers", () => {
+    expect(core.gen12FullParalysisCheck).toBe(core.gen1to2FullParalysisCheck);
+    expect(core.gen14MultiHitRoll).toBe(core.gen1to4MultiHitRoll);
+    expect(core.gen16ConfusionSelfHitRoll).toBe(core.gen1to6ConfusionSelfHitRoll);
+  });
+});

--- a/packages/gen1/src/Gen1Ruleset.ts
+++ b/packages/gen1/src/Gen1Ruleset.ts
@@ -42,9 +42,9 @@ import type {
 } from "@pokemon-lib-ts/core";
 import {
   calculateExpGainClassic,
-  gen12FullParalysisCheck,
-  gen14MultiHitRoll,
-  gen16ConfusionSelfHitRoll,
+  gen1to2FullParalysisCheck,
+  gen1to4MultiHitRoll,
+  gen1to6ConfusionSelfHitRoll,
   getGen12StatStageRatio,
   NEUTRAL_NATURES,
   type SeededRandom,
@@ -1276,11 +1276,11 @@ export class Gen1Ruleset implements GenerationRuleset {
   }
 
   checkFullParalysis(_pokemon: ActivePokemon, rng: SeededRandom): boolean {
-    return gen12FullParalysisCheck(rng);
+    return gen1to2FullParalysisCheck(rng);
   }
 
   rollConfusionSelfHit(rng: SeededRandom): boolean {
-    return gen16ConfusionSelfHitRoll(rng);
+    return gen1to6ConfusionSelfHitRoll(rng);
   }
 
   processSleepTurn(pokemon: ActivePokemon, _state: BattleState): boolean {
@@ -1941,7 +1941,7 @@ export class Gen1Ruleset implements GenerationRuleset {
   }
 
   rollMultiHitCount(_attacker: ActivePokemon, rng: SeededRandom): number {
-    return gen14MultiHitRoll(rng);
+    return gen1to4MultiHitRoll(rng);
   }
 
   rollProtectSuccess(_consecutiveProtects: number, _rng: SeededRandom): boolean {

--- a/packages/gen2/src/Gen2Ruleset.ts
+++ b/packages/gen2/src/Gen2Ruleset.ts
@@ -43,9 +43,9 @@ import type {
 import {
   CRIT_MULTIPLIER_CLASSIC,
   calculateExpGainClassic,
-  gen12FullParalysisCheck,
-  gen14MultiHitRoll,
-  gen16ConfusionSelfHitRoll,
+  gen1to2FullParalysisCheck,
+  gen1to4MultiHitRoll,
+  gen1to6ConfusionSelfHitRoll,
   getAccuracyStageRatio,
   getGen12StatStageRatio,
 } from "@pokemon-lib-ts/core";
@@ -585,11 +585,11 @@ export class Gen2Ruleset implements GenerationRuleset {
   }
 
   checkFullParalysis(_pokemon: ActivePokemon, rng: SeededRandom): boolean {
-    return gen12FullParalysisCheck(rng);
+    return gen1to2FullParalysisCheck(rng);
   }
 
   rollConfusionSelfHit(rng: SeededRandom): boolean {
-    return gen16ConfusionSelfHitRoll(rng);
+    return gen1to6ConfusionSelfHitRoll(rng);
   }
 
   processSleepTurn(pokemon: ActivePokemon, _state: BattleState): boolean {
@@ -1045,7 +1045,7 @@ export class Gen2Ruleset implements GenerationRuleset {
   }
 
   rollMultiHitCount(_attacker: ActivePokemon, rng: SeededRandom): number {
-    return gen14MultiHitRoll(rng);
+    return gen1to4MultiHitRoll(rng);
   }
 
   rollProtectSuccess(consecutiveProtects: number, rng: SeededRandom): boolean {

--- a/packages/gen3/src/Gen3Ruleset.ts
+++ b/packages/gen3/src/Gen3Ruleset.ts
@@ -34,7 +34,7 @@ import type {
 import {
   calculateExpGainClassic,
   DataManager,
-  gen14MultiHitRoll,
+  gen1to4MultiHitRoll,
   getStatStageMultiplier,
 } from "@pokemon-lib-ts/core";
 import {
@@ -60,7 +60,7 @@ import { applyGen3WeatherEffects } from "./Gen3Weather";
  *   - getAvailableHazards — Gen 3 only has Spikes (no Stealth Rock until Gen 4)
  *   - calculateBindDamage — 1/16 max HP (Gen 2-4; Gen 5+ uses 1/8)
  *   - calculateStruggleRecoil — 1/4 damage dealt (Gen 3 RECOIL_25; Gen 4+ uses 1/4 max HP)
- *   - rollMultiHitCount — Gen 1-4 weighted distribution via gen14MultiHitRoll
+ *   - rollMultiHitCount — Gen 1-4 weighted distribution via gen1to4MultiHitRoll
  *   - rollSleepTurns — 2-5 turns (Gen 3-4; Gen 5+ uses 1-3)
  *   - calculateExpGain — classic formula (no level scaling)
  *   - getCritMultiplier — 2.0x (Gen 3-5; Gen 6+ uses 1.5x)
@@ -276,10 +276,10 @@ export class Gen3Ruleset extends BaseRuleset {
    * Gen 5+ uses a different distribution (BaseRuleset default).
    *
    * Source: pret/pokeemerald src/battle_util.c — multi-hit uses 8-entry lookup table
-   * Also: packages/core/src/logic/gen12-shared.ts gen14MultiHitRoll
+   * Also: packages/core/src/logic/gen12-shared.ts gen1to4MultiHitRoll
    */
   rollMultiHitCount(_attacker: ActivePokemon, rng: SeededRandom): number {
-    return gen14MultiHitRoll(rng);
+    return gen1to4MultiHitRoll(rng);
   }
 
   // --- Status System ---

--- a/packages/gen4/src/Gen4Ruleset.ts
+++ b/packages/gen4/src/Gen4Ruleset.ts
@@ -32,7 +32,7 @@ import type {
 import {
   calculateExpGainClassic,
   DataManager,
-  gen14MultiHitRoll,
+  gen1to4MultiHitRoll,
   getStatStageMultiplier,
 } from "@pokemon-lib-ts/core";
 import {
@@ -63,7 +63,7 @@ import { applyGen4WeatherEffects } from "./Gen4Weather";
  *
  * Overrides implemented here:
  *   - calculateBindDamage — 1/16 max HP (Gen 2-4; Gen 5+ uses 1/8)
- *   - rollMultiHitCount — Gen 1-4 weighted distribution via gen14MultiHitRoll
+ *   - rollMultiHitCount — Gen 1-4 weighted distribution via gen1to4MultiHitRoll
  *   - rollSleepTurns — 1-5 turns (international Gen 4; Gen 5+ uses 1-3)
  *   - calculateExpGain — classic formula (no level scaling)
  *   - getCritMultiplier — 2.0x (Gen 3-5; Gen 6+ uses 1.5x)
@@ -508,12 +508,12 @@ export class Gen4Ruleset extends BaseRuleset {
    * Gen 5+ uses a different distribution (BaseRuleset default).
    *
    * Source: pret/pokeplatinum — multi-hit uses same 8-entry lookup table as Gen 1-3
-   * Also: packages/core/src/logic/gen12-shared.ts gen14MultiHitRoll
+   * Also: packages/core/src/logic/gen12-shared.ts gen1to4MultiHitRoll
    */
   rollMultiHitCount(attacker: ActivePokemon, rng: SeededRandom): number {
     // Source: Showdown — Skill Link (introduced Gen 4) always hits 5 times
     if (attacker.ability === "skill-link") return 5;
-    return gen14MultiHitRoll(rng);
+    return gen1to4MultiHitRoll(rng);
   }
 
   // --- Status System ---

--- a/packages/gen4/tests/bughunt-gen4-audit.test.ts
+++ b/packages/gen4/tests/bughunt-gen4-audit.test.ts
@@ -306,7 +306,7 @@ describe("Gen4Ruleset rollMultiHitCount — Skill Link (NEW in Gen 4)", () => {
   });
 
   it("given an attacker WITHOUT Skill Link, when rollMultiHitCount is called, then returns a value in {2, 3, 4, 5}", () => {
-    // Source: Showdown Gen 4 mod — gen14MultiHitRoll returns 2–5
+    // Source: Showdown Gen 4 mod — gen1to4MultiHitRoll returns 2–5
     // Source: Bulbapedia — Multi-hit moves without Skill Link: 2-5 hits (weighted 2:2:1:1)
     // This triangulates that Skill Link's forced-5 path is distinct from the standard path
     const attacker = createActivePokemon({ ability: "blaze" });
@@ -885,7 +885,6 @@ describe("Gen4MoveEffects Trick/Switcheroo — Klutz holder can swap items", () 
     const context = {
       attacker,
       defender,
-      // biome-ignore lint/style/noNonNullAssertion: asserted above via expect()
       move: trickMove!,
       damage: 0,
       state,
@@ -915,7 +914,6 @@ describe("Gen4MoveEffects Trick/Switcheroo — Klutz holder can swap items", () 
     const context = {
       attacker,
       defender,
-      // biome-ignore lint/style/noNonNullAssertion: asserted above via expect()
       move: trickMove!,
       damage: 0,
       state,

--- a/packages/gen4/tests/ruleset.test.ts
+++ b/packages/gen4/tests/ruleset.test.ts
@@ -264,7 +264,7 @@ describe("Gen4Ruleset rollMultiHitCount", () => {
   it("given rollMultiHitCount called 1000 times, then always returns 2, 3, 4, or 5", () => {
     // Source: pret/pokeplatinum — multi-hit uses same 8-entry lookup table as Gen 1-3
     // Distribution: 2 (37.5%), 3 (37.5%), 4 (12.5%), 5 (12.5%)
-    // Source: packages/core/src/logic/gen12-shared.ts gen14MultiHitRoll
+    // Source: packages/core/src/logic/gen12-shared.ts gen1to4MultiHitRoll
     const ruleset = makeRuleset();
     const attacker = makeActivePokemon({});
 
@@ -277,7 +277,7 @@ describe("Gen4Ruleset rollMultiHitCount", () => {
   });
 
   it("given rollMultiHitCount called 1000 times, then never returns 1 or 6+", () => {
-    // Source: pret/pokeplatinum — gen14MultiHitRoll only produces 2, 3, 4, or 5
+    // Source: pret/pokeplatinum — gen1to4MultiHitRoll only produces 2, 3, 4, or 5
     const ruleset = makeRuleset();
     const attacker = makeActivePokemon({});
 


### PR DESCRIPTION
## Summary
- resolve `#769` by adding explicit `gen1toN*` helper names in `@pokemon-lib-ts/core` instead of relying on concatenated digit suffixes that read like later generation numbers
- migrate internal Gen1-4 callers and related tests/comments to the new canonical names
- keep the old `gen12*`, `gen14*`, and `gen16*` exports as deprecated aliases for compatibility, with follow-up breaking cleanup tracked in `#1011`

## Evidence
- `packages/core/src/logic/gen12-shared.ts` exported `gen12FullParalysisCheck`, `gen14MultiHitRoll`, and `gen16ConfusionSelfHitRoll`, which read like Gen 12 / 14 / 16 rather than explicit generation ranges
- those helpers are part of the public `@pokemon-lib-ts/core` surface through `packages/core/src/logic/index.ts` and `packages/core/src/index.ts`
- the implementations are genuinely range-shared mechanics used by Gen1-4 rulesets, so explicit `gen1toN*` names are the clearest API without changing behavior

## Test plan
- [x] `npx vitest run tests/logic/gen12-shared.test.ts tests/public-api.test.ts`
- [x] `npm run typecheck --workspace @pokemon-lib-ts/core`
- [x] `npx @biomejs/biome check .changeset/core-gen-range-helper-names.md packages/core/src/logic/gen12-shared.ts packages/core/src/logic/index.ts packages/core/tests/logic/gen12-shared.test.ts packages/core/tests/public-api.test.ts packages/gen1/src/Gen1Ruleset.ts packages/gen2/src/Gen2Ruleset.ts packages/gen3/src/Gen3Ruleset.ts packages/gen4/src/Gen4Ruleset.ts packages/gen4/tests/bughunt-gen4-audit.test.ts packages/gen4/tests/ruleset.test.ts`
- [ ] `npx vitest run tests/ruleset.test.ts` in `packages/gen4`  
      blocked by the existing `@pokemon-lib-ts/battle` `./data` export issue already tracked in `#1005`

Closes #769
Refs #1005
Refs #1011


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit generation-range battle logic helpers with clearer naming conventions for full paralysis checks, multi-hit rolls, and confusion mechanics.

* **Chores**
  * Maintained backward compatibility with deprecated aliases for existing helper names.
  * Updated generation rulesets to use new helper naming standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->