### PR TITLE
refactor(battle): dedupe end-of-turn countdown handlers

### DIFF
--- a/.changeset/battle-eot-countdown-dedup.md
+++ b/.changeset/battle-eot-countdown-dedup.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/battle": patch
+---
+
+Refactor the end-of-turn countdown pipeline to share repeated volatile and field countdown handlers, and add regression coverage for the affected Gen 4 residual effects.

--- a/packages/battle/src/engine/BattleEndOfTurnPipeline.ts
+++ b/packages/battle/src/engine/BattleEndOfTurnPipeline.ts
@@ -1,4 +1,4 @@
-import type { DataManager, PrimaryStatus } from "@pokemon-lib-ts/core";
+import type { DataManager, PrimaryStatus, VolatileStatus } from "@pokemon-lib-ts/core";
 import type { AbilityResult, EndOfTurnEffect, ItemResult } from "../context";
 import type { BattleEvent } from "../events";
 import type { GenerationRuleset } from "../ruleset";
@@ -90,6 +90,83 @@ function processSpecificHeldItemEndOfTurn(host: BattleEndOfTurnPipelineHost, ite
   }
 }
 
+type CountdownFieldKey = "gravity" | "magicRoom" | "wonderRoom";
+
+function forEachLivingActivePokemon(
+  host: BattleEndOfTurnPipelineHost,
+  callback: (active: ActivePokemon, sideIndex: 0 | 1) => void,
+): void {
+  for (const side of host.state.sides) {
+    const active = side.active[0];
+    if (!active || active.pokemon.currentHp <= 0) continue;
+    callback(active, side.index);
+  }
+}
+
+function endVolatileStatus(
+  host: BattleEndOfTurnPipelineHost,
+  active: ActivePokemon,
+  sideIndex: 0 | 1,
+  volatile: VolatileStatus,
+): void {
+  active.volatileStatuses.delete(volatile);
+  host.emit({
+    type: "volatile-end",
+    side: sideIndex,
+    pokemon: getPokemonName(active),
+    volatile,
+  });
+}
+
+function processSimpleVolatileCountdown(
+  host: BattleEndOfTurnPipelineHost,
+  volatile: VolatileStatus,
+  onExpire?: (active: ActivePokemon, sideIndex: 0 | 1) => void,
+): void {
+  forEachLivingActivePokemon(host, (active, sideIndex) => {
+    const volatileState = active.volatileStatuses.get(volatile);
+    if (!volatileState || volatileState.turnsLeft <= 0) return;
+
+    volatileState.turnsLeft -= 1;
+    if (volatileState.turnsLeft > 0) return;
+
+    endVolatileStatus(host, active, sideIndex, volatile);
+    onExpire?.(active, sideIndex);
+  });
+}
+
+function processYawnCountdown(host: BattleEndOfTurnPipelineHost): void {
+  forEachLivingActivePokemon(host, (active, sideIndex) => {
+    const yawnState = active.volatileStatuses.get("yawn");
+    if (!yawnState) return;
+
+    if (yawnState.turnsLeft > 0) {
+      yawnState.turnsLeft -= 1;
+    }
+    if (yawnState.turnsLeft > 0) return;
+
+    endVolatileStatus(host, active, sideIndex, "yawn");
+    if (active.pokemon.status === null) {
+      host.applyPrimaryStatus(active, "sleep", sideIndex);
+    }
+  });
+}
+
+function processFieldCountdown(
+  host: BattleEndOfTurnPipelineHost,
+  fieldKey: CountdownFieldKey,
+  expirationMessage: string,
+): void {
+  const fieldState = host.state[fieldKey];
+  if (!fieldState.active) return;
+
+  fieldState.turnsLeft -= 1;
+  if (fieldState.turnsLeft > 0) return;
+
+  fieldState.active = false;
+  host.emit({ type: "message", text: expirationMessage });
+}
+
 /**
  * Shared end-of-turn pipeline extracted from BattleEngine.
  *
@@ -174,36 +251,21 @@ export function processEndOfTurnPipeline(host: BattleEndOfTurnPipelineHost): voi
         processOnTurnEndAbilities(host, abilityEndOfTurnFired);
         break;
       case "slow-start-countdown":
-        for (const side of host.state.sides) {
-          const active = side.active[0];
-          if (!active || active.pokemon.currentHp <= 0) continue;
-          // Slow Start: decrement turnsLeft on the slow-start volatile each EoT.
-          // No ability check: the volatile should tick down even if the ability was
-          // temporarily changed (e.g., by Skill Swap). The stat-halving in damage/speed
-          // calcs already requires both the ability AND the volatile to be present.
-          // Source: Pokemon Showdown Gen 4 mod — Slow Start countdown ticks volatile
-          // When turnsLeft reaches 0, remove the volatile so the Attack/Speed halving stops.
-          // Source: Pokemon Showdown Gen 4 mod — Slow Start countdown
-          // Source: Bulbapedia — Slow Start: halves Attack and Speed for 5 turns
-          const slowStart = active.volatileStatuses.get("slow-start");
-          if (slowStart && slowStart.turnsLeft > 0) {
-            slowStart.turnsLeft -= 1;
-            if (slowStart.turnsLeft === 0) {
-              active.volatileStatuses.delete("slow-start");
-              const pokeName = active.pokemon.nickname ?? String(active.pokemon.speciesId);
-              host.emit({
-                type: "volatile-end",
-                side: side.index,
-                pokemon: getPokemonName(active),
-                volatile: "slow-start",
-              });
-              host.emit({
-                type: "message",
-                text: `${pokeName}'s Slow Start wore off!`,
-              });
-            }
-          }
-        }
+        // Slow Start: decrement turnsLeft on the slow-start volatile each EoT.
+        // No ability check: the volatile should tick down even if the ability was
+        // temporarily changed (e.g., by Skill Swap). The stat-halving in damage/speed
+        // calcs already requires both the ability AND the volatile to be present.
+        // Source: Pokemon Showdown Gen 4 mod — Slow Start countdown ticks volatile
+        // When turnsLeft reaches 0, remove the volatile so the Attack/Speed halving stops.
+        // Source: Pokemon Showdown Gen 4 mod — Slow Start countdown
+        // Source: Bulbapedia — Slow Start: halves Attack and Speed for 5 turns
+        processSimpleVolatileCountdown(host, "slow-start", (active) => {
+          const pokeName = active.pokemon.nickname ?? String(active.pokemon.speciesId);
+          host.emit({
+            type: "message",
+            text: `${pokeName}'s Slow Start wore off!`,
+          });
+        });
         break;
       case "toxic-orb-activation":
         processSpecificHeldItemEndOfTurn(host, "toxic-orb");
@@ -350,178 +412,56 @@ export function processEndOfTurnPipeline(host: BattleEndOfTurnPipelineHost): voi
       case "taunt-countdown":
         // Taunt volatile countdown — remove when turnsLeft reaches 0
         // Source: Bulbapedia — "Taunt lasts for 3 turns in Gen 4"
-        for (const side of host.state.sides) {
-          const active = side.active[0];
-          if (!active || active.pokemon.currentHp <= 0) continue;
-          const tauntState = active.volatileStatuses.get("taunt");
-          if (!tauntState) continue;
-          if (tauntState.turnsLeft > 0) {
-            tauntState.turnsLeft--;
-            if (tauntState.turnsLeft <= 0) {
-              active.volatileStatuses.delete("taunt");
-              host.emit({
-                type: "volatile-end",
-                side: side.index,
-                pokemon: getPokemonName(active),
-                volatile: "taunt",
-              });
-            }
-          }
-        }
+        processSimpleVolatileCountdown(host, "taunt");
         break;
       case "disable-countdown":
         // Disable volatile countdown — remove when turnsLeft reaches 0
         // Source: Bulbapedia — "Disable lasts for 4-7 turns in Gen 4"
-        for (const side of host.state.sides) {
-          const active = side.active[0];
-          if (!active || active.pokemon.currentHp <= 0) continue;
-          const disableState = active.volatileStatuses.get("disable");
-          if (!disableState) continue;
-          if (disableState.turnsLeft > 0) {
-            disableState.turnsLeft--;
-            if (disableState.turnsLeft <= 0) {
-              active.volatileStatuses.delete("disable");
-              host.emit({
-                type: "volatile-end",
-                side: side.index,
-                pokemon: getPokemonName(active),
-                volatile: "disable",
-              });
-            }
-          }
-        }
+        processSimpleVolatileCountdown(host, "disable");
         break;
       case "gravity-countdown":
         // Gravity field countdown — deactivate when turnsLeft reaches 0
         // Source: Showdown Gen 4 mod — Gravity lasts 5 turns
-        if (host.state.gravity.active) {
-          host.state.gravity.turnsLeft--;
-          if (host.state.gravity.turnsLeft <= 0) {
-            host.state.gravity.active = false;
-            host.emit({ type: "message", text: "Gravity returned to normal!" });
-          }
-        }
+        processFieldCountdown(host, "gravity", "Gravity returned to normal!");
         break;
       case "magic-room-countdown":
         // Magic Room field countdown — deactivate when turnsLeft reaches 0
         // Source: Showdown magicroom condition — duration: 5
-        if (host.state.magicRoom.active) {
-          host.state.magicRoom.turnsLeft--;
-          if (host.state.magicRoom.turnsLeft <= 0) {
-            host.state.magicRoom.active = false;
-            host.emit({ type: "message", text: "The area returned to normal!" });
-          }
-        }
+        processFieldCountdown(host, "magicRoom", "The area returned to normal!");
         break;
       case "wonder-room-countdown":
         // Wonder Room field countdown — deactivate when turnsLeft reaches 0
         // Source: Showdown wonderroom condition — duration: 5
-        if (host.state.wonderRoom.active) {
-          host.state.wonderRoom.turnsLeft--;
-          if (host.state.wonderRoom.turnsLeft <= 0) {
-            host.state.wonderRoom.active = false;
-            host.emit({
-              type: "message",
-              text: "Wonder Room wore off, and Defense and Sp. Def stats returned to normal!",
-            });
-          }
-        }
+        processFieldCountdown(
+          host,
+          "wonderRoom",
+          "Wonder Room wore off, and Defense and Sp. Def stats returned to normal!",
+        );
         break;
       case "yawn-countdown":
         // Yawn volatile countdown — inflict sleep when turnsLeft reaches 0
         // Source: Bulbapedia — Yawn: "causes drowsiness; the target falls asleep at
         //   the end of the next turn"
         // Source: Showdown Gen 4 mod — Yawn sets a 1-turn drowsy volatile
-        for (const side of host.state.sides) {
-          const active = side.active[0];
-          if (!active || active.pokemon.currentHp <= 0) continue;
-          const yawnState = active.volatileStatuses.get("yawn");
-          if (!yawnState) continue;
-          if (yawnState.turnsLeft > 0) {
-            yawnState.turnsLeft--;
-          }
-          if (yawnState.turnsLeft <= 0) {
-            active.volatileStatuses.delete("yawn");
-            host.emit({
-              type: "volatile-end",
-              side: side.index,
-              pokemon: getPokemonName(active),
-              volatile: "yawn",
-            });
-            if (active.pokemon.status === null) {
-              host.applyPrimaryStatus(active, "sleep", side.index);
-            }
-          }
-        }
+        processYawnCountdown(host);
         break;
       case "heal-block-countdown":
         // Heal Block volatile countdown — remove when turnsLeft reaches 0
         // Source: Bulbapedia — Heal Block prevents HP recovery for 5 turns
         // Source: Showdown Gen 4 mod — Heal Block lasts 5 turns
-        for (const side of host.state.sides) {
-          const active = side.active[0];
-          if (!active || active.pokemon.currentHp <= 0) continue;
-          const hbState = active.volatileStatuses.get("heal-block");
-          if (!hbState) continue;
-          if (hbState.turnsLeft > 0) {
-            hbState.turnsLeft--;
-            if (hbState.turnsLeft <= 0) {
-              active.volatileStatuses.delete("heal-block");
-              host.emit({
-                type: "volatile-end",
-                side: side.index,
-                pokemon: getPokemonName(active),
-                volatile: "heal-block",
-              });
-            }
-          }
-        }
+        processSimpleVolatileCountdown(host, "heal-block");
         break;
       case "embargo-countdown":
         // Embargo volatile countdown — remove when turnsLeft reaches 0
         // Source: Bulbapedia — Embargo prevents use of held items for 5 turns
         // Source: Showdown Gen 4 mod — Embargo lasts 5 turns
-        for (const side of host.state.sides) {
-          const active = side.active[0];
-          if (!active || active.pokemon.currentHp <= 0) continue;
-          const embargoState = active.volatileStatuses.get("embargo");
-          if (!embargoState) continue;
-          if (embargoState.turnsLeft > 0) {
-            embargoState.turnsLeft--;
-            if (embargoState.turnsLeft <= 0) {
-              active.volatileStatuses.delete("embargo");
-              host.emit({
-                type: "volatile-end",
-                side: side.index,
-                pokemon: getPokemonName(active),
-                volatile: "embargo",
-              });
-            }
-          }
-        }
+        processSimpleVolatileCountdown(host, "embargo");
         break;
       case "magnet-rise-countdown":
         // Magnet Rise volatile countdown — remove when turnsLeft reaches 0
         // Source: Bulbapedia — Magnet Rise: "The user levitates for five turns."
         // Source: Showdown Gen 4 mod — Magnet Rise lasts 5 turns
-        for (const side of host.state.sides) {
-          const active = side.active[0];
-          if (!active || active.pokemon.currentHp <= 0) continue;
-          const mrState = active.volatileStatuses.get("magnet-rise");
-          if (!mrState) continue;
-          if (mrState.turnsLeft > 0) {
-            mrState.turnsLeft--;
-            if (mrState.turnsLeft <= 0) {
-              active.volatileStatuses.delete("magnet-rise");
-              host.emit({
-                type: "volatile-end",
-                side: side.index,
-                pokemon: getPokemonName(active),
-                volatile: "magnet-rise",
-              });
-            }
-          }
-        }
+        processSimpleVolatileCountdown(host, "magnet-rise");
         break;
       case "uproar": {
         // Source: pret/pokeemerald -- Uproar: countdown duration, wake sleeping Pokemon

--- a/packages/battle/tests/engine/gen4-eot-handlers.test.ts
+++ b/packages/battle/tests/engine/gen4-eot-handlers.test.ts
@@ -920,6 +920,227 @@ describe("slow-start-countdown EoT slot", () => {
   });
 });
 
+// ─── Shared Countdown Handler Coverage ───────────────────────────────────────
+
+describe("simple volatile countdown EoT slots", () => {
+  const removalCases = [
+    {
+      effect: "taunt-countdown",
+      volatile: "taunt",
+      source: 'Bulbapedia — "Taunt lasts for 3 turns in Gen 4"',
+    },
+    {
+      effect: "heal-block-countdown",
+      volatile: "heal-block",
+      source: "Bulbapedia / Showdown Gen 4 mod — Heal Block lasts 5 turns",
+    },
+    {
+      effect: "embargo-countdown",
+      volatile: "embargo",
+      source: "Bulbapedia / Showdown Gen 4 mod — Embargo lasts 5 turns",
+    },
+    {
+      effect: "magnet-rise-countdown",
+      volatile: "magnet-rise",
+      source: "Bulbapedia / Showdown Gen 4 mod — Magnet Rise lasts 5 turns",
+    },
+  ] as const;
+
+  for (const testCase of removalCases) {
+    it(`given ${testCase.volatile} with turnsLeft=1, when ${testCase.effect} runs, then it expires and emits volatile-end`, () => {
+      // Source: see per-case source string above; these countdown volatiles expire once the
+      // final end-of-turn tick decrements turnsLeft from 1 to 0.
+      const ruleset = new Gen4MockRuleset();
+      ruleset.setFixedDamage(0);
+      ruleset.getEndOfTurnOrder = (): readonly EndOfTurnEffect[] => [testCase.effect];
+
+      const { engine, events } = createEngine({ ruleset });
+      engine.start();
+
+      const active0 = engine.state.sides[0].active[0];
+      active0?.volatileStatuses.set(testCase.volatile, { turnsLeft: 1 });
+
+      events.length = 0;
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Source: the volatile should be removed after the last tick, and the engine emits
+      // one matching volatile-end event for the expired status.
+      expect(active0?.volatileStatuses.has(testCase.volatile)).toBe(false);
+      const volatileEndEvents = events.filter(
+        (e) => e.type === "volatile-end" && "volatile" in e && e.volatile === testCase.volatile,
+      );
+      expect(volatileEndEvents.length).toBe(1);
+    });
+  }
+
+  it("given disable with turnsLeft=2, when disable-countdown runs, then it decrements to 1 and stays active", () => {
+    // Source: Bulbapedia — Disable lasts 4-7 turns in Gen 4, so a mid-countdown tick
+    // should decrement by exactly 1 without ending the volatile early.
+    const ruleset = new Gen4MockRuleset();
+    ruleset.setFixedDamage(0);
+    ruleset.getEndOfTurnOrder = (): readonly EndOfTurnEffect[] => ["disable-countdown"];
+
+    const { engine, events } = createEngine({ ruleset });
+    engine.start();
+
+    const active0 = engine.state.sides[0].active[0];
+    active0?.volatileStatuses.set("disable", { turnsLeft: 2 });
+
+    events.length = 0;
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Source: after one tick the volatile should remain with turnsLeft=1 and emit no
+    // volatile-end event yet.
+    expect(active0?.volatileStatuses.get("disable")?.turnsLeft).toBe(1);
+    const volatileEndEvents = events.filter(
+      (e) => e.type === "volatile-end" && "volatile" in e && e.volatile === "disable",
+    );
+    expect(volatileEndEvents.length).toBe(0);
+  });
+});
+
+describe("yawn-countdown EoT slot", () => {
+  it("given yawn with turnsLeft=2, when yawn-countdown runs, then it decrements to 1 without applying sleep", () => {
+    // Source: Bulbapedia / Showdown Gen 4 mod — Yawn resolves at the end of the next turn,
+    // so the first countdown tick should only decrement the drowsy volatile.
+    const ruleset = new Gen4MockRuleset();
+    ruleset.setFixedDamage(0);
+    ruleset.getEndOfTurnOrder = (): readonly EndOfTurnEffect[] => ["yawn-countdown"];
+
+    const { engine, events } = createEngine({ ruleset });
+    engine.start();
+
+    const active0 = engine.state.sides[0].active[0];
+    active0?.volatileStatuses.set("yawn", { turnsLeft: 2 });
+
+    events.length = 0;
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Source: the first tick leaves Yawn active with one turn remaining and does not inflict sleep yet.
+    expect(active0?.volatileStatuses.get("yawn")?.turnsLeft).toBe(1);
+    expect(active0?.pokemon.status).toBe(null);
+    const volatileEndEvents = events.filter(
+      (e) => e.type === "volatile-end" && "volatile" in e && e.volatile === "yawn",
+    );
+    expect(volatileEndEvents.length).toBe(0);
+  });
+
+  it("given yawn with turnsLeft=1 and no existing status, when yawn-countdown runs, then the target falls asleep and yawn ends", () => {
+    // Source: Bulbapedia / Showdown Gen 4 mod — Yawn causes drowsiness now and sleep at
+    // the end of the next turn, so turnsLeft=1 should resolve to sleep on this tick.
+    const ruleset = new Gen4MockRuleset();
+    ruleset.setFixedDamage(0);
+    ruleset.getEndOfTurnOrder = (): readonly EndOfTurnEffect[] => ["yawn-countdown"];
+
+    const { engine, events } = createEngine({ ruleset });
+    engine.start();
+
+    const active0 = engine.state.sides[0].active[0];
+    active0?.volatileStatuses.set("yawn", { turnsLeft: 1 });
+
+    events.length = 0;
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Source: Yawn removes the volatile and inflicts sleep exactly once when it resolves.
+    expect(active0?.volatileStatuses.has("yawn")).toBe(false);
+    expect(active0?.pokemon.status).toBe("sleep");
+    const volatileEndEvents = events.filter(
+      (e) => e.type === "volatile-end" && "volatile" in e && e.volatile === "yawn",
+    );
+    expect(volatileEndEvents.length).toBe(1);
+  });
+
+  it("given yawn with turnsLeft=1 and an existing primary status, when yawn-countdown runs, then it ends without overwriting the status", () => {
+    // Source: Pokemon sleep clauses in cartridge/Showdown behavior only apply sleep if the
+    // target is currently status-free; Yawn still ends even when sleep cannot be applied.
+    const ruleset = new Gen4MockRuleset();
+    ruleset.setFixedDamage(0);
+    ruleset.getEndOfTurnOrder = (): readonly EndOfTurnEffect[] => ["yawn-countdown"];
+
+    const { engine, events } = createEngine({ ruleset });
+    engine.start();
+
+    const active0 = engine.state.sides[0].active[0];
+    if (active0) {
+      active0.pokemon.status = "paralysis";
+      active0.volatileStatuses.set("yawn", { turnsLeft: 1 });
+    }
+
+    events.length = 0;
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Source: the status remains paralysis because Yawn only applies sleep to status-free targets.
+    expect(active0?.volatileStatuses.has("yawn")).toBe(false);
+    expect(active0?.pokemon.status).toBe("paralysis");
+    const volatileEndEvents = events.filter(
+      (e) => e.type === "volatile-end" && "volatile" in e && e.volatile === "yawn",
+    );
+    expect(volatileEndEvents.length).toBe(1);
+  });
+});
+
+describe("room countdown EoT slots", () => {
+  it("given Magic Room with turnsLeft=1, when magic-room-countdown runs, then it deactivates and emits the field message", () => {
+    // Source: Showdown magicroom condition — Magic Room duration is 5 turns and the field
+    // ends once the final countdown tick reaches 0.
+    const ruleset = new Gen4MockRuleset();
+    ruleset.setFixedDamage(0);
+    ruleset.getEndOfTurnOrder = (): readonly EndOfTurnEffect[] => ["magic-room-countdown"];
+
+    const { engine, events } = createEngine({ ruleset });
+    engine.start();
+
+    engine.state.magicRoom.active = true;
+    engine.state.magicRoom.turnsLeft = 1;
+
+    events.length = 0;
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Source: the final tick deactivates the room and emits Showdown's return-to-normal message.
+    expect(engine.state.magicRoom.active).toBe(false);
+    expect(engine.state.magicRoom.turnsLeft).toBe(0);
+    const roomMessages = events.filter(
+      (e) => e.type === "message" && "text" in e && e.text === "The area returned to normal!",
+    );
+    expect(roomMessages.length).toBe(1);
+  });
+
+  it("given Wonder Room with turnsLeft=1, when wonder-room-countdown runs, then it deactivates and emits the field message", () => {
+    // Source: Showdown wonderroom condition — Wonder Room duration is 5 turns and the field
+    // ends once the final countdown tick reaches 0.
+    const ruleset = new Gen4MockRuleset();
+    ruleset.setFixedDamage(0);
+    ruleset.getEndOfTurnOrder = (): readonly EndOfTurnEffect[] => ["wonder-room-countdown"];
+
+    const { engine, events } = createEngine({ ruleset });
+    engine.start();
+
+    engine.state.wonderRoom.active = true;
+    engine.state.wonderRoom.turnsLeft = 1;
+
+    events.length = 0;
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Source: the final tick deactivates the room and emits the Showdown/engine message.
+    expect(engine.state.wonderRoom.active).toBe(false);
+    expect(engine.state.wonderRoom.turnsLeft).toBe(0);
+    const roomMessages = events.filter(
+      (e) =>
+        e.type === "message" &&
+        "text" in e &&
+        e.text === "Wonder Room wore off, and Defense and Sp. Def stats returned to normal!",
+    );
+    expect(roomMessages.length).toBe(1);
+  });
+});
+
 // ─── Gen 5+ EoT Stub Tests ───────────────────────────────────────────────────
 
 describe("Gen 5+ EoT handler stubs", () => {


### PR DESCRIPTION
## Summary
- extract shared helpers for repeated end-of-turn volatile and field countdown handlers in `BattleEndOfTurnPipeline`
- add characterization tests for the affected Gen 4 countdown effects before and after expiration
- keep the already-extracted `BattleEngine` pipeline handoff intact and close the remaining duplication tracked by #763

## Issue
Closes #763

## Notes
- The original issue's `BattleEngine.ts` concern is already resolved on `origin/main`; this PR closes the remaining duplication that still lived in `BattleEndOfTurnPipeline.ts`.
- The refactor keeps `slow-start` and `yawn` as separate paths where their expiration semantics differ from the simple countdown helpers.

## Validation
- `npm run build --workspace @pokemon-lib-ts/core`
- `npm run typecheck --workspace @pokemon-lib-ts/battle`
- `npm run test --workspace @pokemon-lib-ts/battle -- --run tests/engine/gen4-eot-handlers.test.ts tests/engine/eot-bugs.test.ts tests/engine/gravity.test.ts`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEndOfTurnPipeline.ts packages/battle/tests/engine/gen4-eot-handlers.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate countdown handlers in the end-of-turn pipeline for volatile statuses and field effects while maintaining identical observable behavior.

* **Tests**
  * Added regression test coverage for Gen 4 residual effects, verifying proper countdown progression and expiration for multiple volatile statuses and field room mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->