### PR TITLE
docs(core): clarify PokemonInstance battle-state exception (#778)

### DIFF
--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -24,6 +24,7 @@ src/
 - **Lowercase string literals** for all entity types: `'fire'`, `'physical'`, `'paralysis'` — never UPPERCASE enums.
 - **Discriminated unions** over class hierarchies for MoveEffect, categories, etc.
 - Interfaces must be **generation-agnostic**. Gen-specific behavior belongs in the gen package's ruleset, not here.
+- Exception: `PokemonInstance` may carry persisted battle-state fields when the engine must restore that state after a switch (for example Mega form identity, Terastallization state, Dynamax level, once-per-battle ability flags, or Rage Fist counters). Prefer documenting that persistence over introducing per-gen interface trees that leak through every battle/state API.
 
 ## Stat Formulas (Quick Reference)
 

--- a/packages/core/src/entities/pokemon.ts
+++ b/packages/core/src/entities/pokemon.ts
@@ -92,7 +92,10 @@ export interface PokemonInstance {
   /** Computed stats — recalculated when level/EVs/nature change */
   calculatedStats?: StatBlock;
 
-  // --- Generation-specific fields ---
+  // --- Persisted battle-state fields ---
+  // Exception to the usual "generation-agnostic interfaces" rule: these values are stored
+  // on PokemonInstance because createActivePokemon() must restore them after a switch.
+  // Keep transient battle state on ActivePokemon or in volatiles instead.
 
   /** Tera Type for Gen 9 battles */
   teraType?: PokemonType;


### PR DESCRIPTION
Closes #778.

## Summary
- document the `PokemonInstance` exception to core's generation-agnostic interface rule in `packages/core/CLAUDE.md`
- relabel the affected section in `packages/core/src/entities/pokemon.ts` as persisted battle-state fields and explain why those values live on `PokemonInstance`

## Evidence
- `packages/battle/src/utils/BattleHelpers.ts` restores Mega and Tera state from `PokemonInstance` on switch-in, so those values cannot live only on `ActivePokemon`.
- `packages/gen9/src/Gen9Terastallization.ts` and `packages/gen6/src/Gen6MegaEvolution.ts` explicitly persist battle-long form state so `createActivePokemon()` can restore it later.
- `packages/core/src/entities/pokemon.ts` now carries several persisted battle-state fields beyond Gen8/9-only metadata (`megaTypes`, `megaAbility`, `terastallized`, `teraTypes`, `swordBoost`, `shieldBoost`, `timesAttacked`), so the right fix is to document the architectural exception instead of forcing a per-generation interface tree through every battle API.

## Validation
- `npx @biomejs/biome check packages/core/src/entities/pokemon.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/core`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architecture documentation clarifying how battle state persistence works in the Pokemon system.

*Note: No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->