### PR TITLE
docs(core): clarify PokemonInstance persistence exception (#778)

### DIFF
--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -24,6 +24,7 @@ src/
 - **Lowercase string literals** for all entity types: `'fire'`, `'physical'`, `'paralysis'` — never UPPERCASE enums.
 - **Discriminated unions** over class hierarchies for MoveEffect, categories, etc.
 - Interfaces must be **generation-agnostic**. Gen-specific behavior belongs in the gen package's ruleset, not here.
+- Narrow exception: `PokemonInstance` may carry optional generation-specific fields only when they are durable per-Pokemon attributes or persistent battle-state restoration data that must survive switch-out / switch-in reconstruction. If you add one, document why it cannot live on `ActivePokemon` or in the ruleset alone.
 
 ## Stat Formulas (Quick Reference)
 

--- a/packages/core/src/entities/pokemon.ts
+++ b/packages/core/src/entities/pokemon.ts
@@ -92,12 +92,32 @@ export interface PokemonInstance {
   /** Computed stats — recalculated when level/EVs/nature change */
   calculatedStats?: StatBlock;
 
-  // --- Generation-specific fields ---
+  // --- Persisted per-Pokemon attributes / battle-state restoration fields ---
 
-  /** Tera Type for Gen 9 battles */
+  /**
+   * Exception to the usual core rule that interfaces stay generation-agnostic.
+   *
+   * `PokemonInstance` is the durable per-Pokemon record used by factories, save-state-like
+   * battle restoration, and switch-out / switch-in reconstruction. A generation-specific
+   * field is only allowed here when it represents either:
+   *   1. intrinsic per-Pokemon data that exists before battle setup, or
+   *   2. persistent battle-form state that must survive switching for the rest of the battle.
+   *
+   * That is why assigned Tera metadata, Dynamax level, Mega state, and once-per-battle
+   * activation flags live here instead of on short-lived `ActivePokemon` wrappers.
+   */
+
+  /**
+   * Assigned Tera Type for Gen 9 battles.
+   * Stored on the durable Pokemon record because gimmick eligibility is decided from the
+   * underlying team member before any active-battle wrapper is created.
+   */
   teraType?: PokemonType;
 
-  /** Dynamax Level for Gen 8 battles (0-10) */
+  /**
+   * Dynamax Level for Gen 8 battles (0-10).
+   * This is a persistent per-Pokemon progression value, not transient battle state.
+   */
   dynamaxLevel?: number;
 
   /**
@@ -198,6 +218,8 @@ export interface PokemonCreationOptions {
   originalTrainer: string;
   originalTrainerId: number;
   pokeball: string;
+  /** Optional Gen 9 assigned Tera Type for the created Pokemon. */
   teraType?: PokemonType;
+  /** Optional Gen 8 Dynamax Level progression value for the created Pokemon. */
   dynamaxLevel?: number;
 }


### PR DESCRIPTION
Closes #778

## Summary
- clarify in `packages/core/CLAUDE.md` that `PokemonInstance` is the narrow exception to the usual generation-agnostic interface rule
- document in `packages/core/src/entities/pokemon.ts` why `teraType` and `dynamaxLevel` stay on the durable Pokemon record instead of transient battle wrappers
- make the allowed scope explicit: intrinsic per-Pokemon data and battle-state restoration fields that must survive switch-out / switch-in reconstruction

## Why this is the best fix
`teraType` and `dynamaxLevel` are not arbitrary behavior flags leaked into core. They are durable per-Pokemon data used by the factory layer and by battle restoration paths such as `createActivePokemon()` and Gen 9 Terastallization persistence. Removing them from `PokemonInstance` would push that state into wider cross-package extension types without reducing actual coupling. The real problem was that the exception existed implicitly instead of being documented.

## Evidence
- `packages/core/src/logic/pokemon-factory.ts` assigns default `teraType` and `dynamaxLevel` when creating a `PokemonInstance`
- `packages/battle/src/utils/BattleHelpers.ts` restores Tera state from persisted `PokemonInstance` fields on switch-in
- `packages/gen9/src/Gen9Terastallization.ts` persists Tera state onto `PokemonInstance` specifically so it survives switching

## Validation
- `npx @biomejs/biome check packages/core/src/entities/pokemon.ts packages/core/CLAUDE.md`
- `npm run typecheck --workspace @pokemon-lib-ts/core`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for generation-specific Pokémon attributes, including Tera Type (Gen 9) and Dynamax Level (Gen 8), with improved explanations of when these persistent fields are appropriate for storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->