### PR TITLE
docs(core): document PokemonInstance generation exception (#778)

### DIFF
--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -24,6 +24,7 @@ src/
 - **Lowercase string literals** for all entity types: `'fire'`, `'physical'`, `'paralysis'` — never UPPERCASE enums.
 - **Discriminated unions** over class hierarchies for MoveEffect, categories, etc.
 - Interfaces must be **generation-agnostic**. Gen-specific behavior belongs in the gen package's ruleset, not here.
+- Exception: `PokemonInstance` may carry optional per-generation team metadata or persisted cross-switch battle state when the value belongs to the individual Pokemon rather than the ruleset. Examples: `dynamaxLevel`, `teraType`, Mega form restoration data, and once-per-battle flags that must survive switching.
 
 ## Stat Formulas (Quick Reference)
 

--- a/packages/core/src/entities/pokemon.ts
+++ b/packages/core/src/entities/pokemon.ts
@@ -92,12 +92,18 @@ export interface PokemonInstance {
   /** Computed stats — recalculated when level/EVs/nature change */
   calculatedStats?: StatBlock;
 
-  // --- Generation-specific fields ---
+  // --- Generation-specific metadata and persisted battle state ---
+  //
+  // This is the deliberate exception to core's generation-agnostic interface rule.
+  // These fields are stored here only when they are properties of the individual
+  // Pokemon or battle state that must survive switching (for example team-sheet
+  // metadata like Tera Type / Dynamax Level, or once-per-battle activation state).
+  // The mechanics that interpret these fields still live in the generation packages.
 
-  /** Tera Type for Gen 9 battles */
+  /** Tera Type assigned to this Pokemon for Gen 9 battles. */
   teraType?: PokemonType;
 
-  /** Dynamax Level for Gen 8 battles (0-10) */
+  /** Dynamax Level assigned to this Pokemon for Gen 8 battles (0-10). */
   dynamaxLevel?: number;
 
   /**
@@ -198,6 +204,9 @@ export interface PokemonCreationOptions {
   originalTrainer: string;
   originalTrainerId: number;
   pokeball: string;
+  /** Optional Gen 9 team-sheet metadata. Earlier generations ignore this. */
   teraType?: PokemonType;
+
+  /** Optional Gen 8 team-sheet metadata. Earlier generations ignore this. */
   dynamaxLevel?: number;
 }


### PR DESCRIPTION
Closes #778

## Summary
- document the explicit `PokemonInstance` exception to core's generation-agnostic interface rule
- explain why optional fields like `teraType` and `dynamaxLevel` remain on the individual Pokemon shape
- clarify that gen-specific mechanics still belong in the generation packages even when the persisted metadata lives in core

## Why this resolves the issue
I verified the issue premise is real: `PokemonInstance` does carry Gen8/9-specific optional fields. I also verified that these fields are not arbitrary leakage from rulesets. `createPokemonInstance()` persists `teraType` and `dynamaxLevel` as team-sheet data, and later-generation mechanics persist cross-switch state such as Mega restoration data, Terastallization state, and once-per-battle ability flags on the same instance shape. A structural split would add churn across the repo without improving the actual ownership boundary. The correct fix is to document the exception precisely.

## Validation
- `npx @biomejs/biome check packages/core/src/entities/pokemon.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/core`