### PR TITLE
fix: move shared damage constants to core

### DIFF
--- a/.changeset/shared-damage-constants-core.md
+++ b/.changeset/shared-damage-constants-core.md
@@ -1,0 +1,13 @@
+---
+"@pokemon-lib-ts/core": minor
+"@pokemon-lib-ts/battle": major
+"@pokemon-lib-ts/gen4": patch
+"@pokemon-lib-ts/gen5": patch
+"@pokemon-lib-ts/gen6": patch
+"@pokemon-lib-ts/gen7": patch
+"@pokemon-lib-ts/gen8": patch
+"@pokemon-lib-ts/gen9": patch
+---
+
+Move the shared Gen 4-9 damage lookup tables into `@pokemon-lib-ts/core` and
+remove the obsolete `@pokemon-lib-ts/battle/data` export surface.

--- a/packages/battle/package.json
+++ b/packages/battle/package.json
@@ -12,11 +12,6 @@
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.js",
       "require": "./dist/utils/index.cjs"
-    },
-    "./data": {
-      "types": "./dist/data/index.d.ts",
-      "import": "./dist/data/index.js",
-      "require": "./dist/data/index.cjs"
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/battle/src/data/index.ts
+++ b/packages/battle/src/data/index.ts
@@ -1,5 +1,0 @@
-export {
-  BASE_PINCH_ABILITY_TYPES,
-  BASE_PLATE_ITEMS,
-  BASE_TYPE_BOOST_ITEMS,
-} from "./damage-calc-constants";

--- a/packages/battle/src/index.ts
+++ b/packages/battle/src/index.ts
@@ -38,12 +38,6 @@ export type {
   ValidationResult,
   WeatherEffectResult,
 } from "./context";
-// Data
-export {
-  BASE_PINCH_ABILITY_TYPES,
-  BASE_PLATE_ITEMS,
-  BASE_TYPE_BOOST_ITEMS,
-} from "./data";
 // Engine
 export { BattleEngine } from "./engine";
 // Events

--- a/packages/battle/tests/index.test.ts
+++ b/packages/battle/tests/index.test.ts
@@ -11,9 +11,6 @@ describe("barrel exports", () => {
     expect(mod.GenerationRegistry).toBeDefined();
     expect(mod.generations).toBeDefined();
     expect(mod.RandomAI).toBeDefined();
-    expect(mod.BASE_TYPE_BOOST_ITEMS).toBeDefined();
-    expect(mod.BASE_PLATE_ITEMS).toBeDefined();
-    expect(mod.BASE_PINCH_ABILITY_TYPES).toBeDefined();
     expect(mod.createPokemonSnapshot).toBeDefined();
     expect(mod.getPokemonName).toBeDefined();
 
@@ -21,16 +18,9 @@ describe("barrel exports", () => {
     expect(Object.hasOwn(mod, "createActivePokemon")).toBe(false);
     expect(Object.hasOwn(mod, "createDefaultStatStages")).toBe(false);
     expect(Object.hasOwn(mod, "createTestPokemon")).toBe(false);
-  });
-
-  it("given the shared data entrypoint, when imported, then the damage-calc tables are exposed there", async () => {
-    // Act
-    const data = await import("../src/data/index");
-
-    // Assert — the dedicated submodule exposes the shared tables
-    expect(data.BASE_TYPE_BOOST_ITEMS).toBeDefined();
-    expect(data.BASE_PLATE_ITEMS).toBeDefined();
-    expect(data.BASE_PINCH_ABILITY_TYPES).toBeDefined();
+    expect(Object.hasOwn(mod, "BASE_TYPE_BOOST_ITEMS")).toBe(false);
+    expect(Object.hasOwn(mod, "BASE_PLATE_ITEMS")).toBe(false);
+    expect(Object.hasOwn(mod, "BASE_PINCH_ABILITY_TYPES")).toBe(false);
   });
 
   it("given the utils entrypoint, when imported, then internal helpers are exposed there", async () => {

--- a/packages/battle/tsup.config.ts
+++ b/packages/battle/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/utils/index.ts", "src/data/index.ts"],
+  entry: ["src/index.ts", "src/utils/index.ts"],
   format: ["esm", "cjs"],
   dts: true,
   clean: true,

--- a/packages/core/src/constants/damage-calc-shared.ts
+++ b/packages/core/src/constants/damage-calc-shared.ts
@@ -1,11 +1,11 @@
-import type { PokemonType } from "@pokemon-lib-ts/core";
+import type { PokemonType } from "../entities/types";
 
 /**
- * Battle-local shared lookup tables for damage calculation.
+ * Shared offensive lookup tables used by Gen 4-9 damage calculators.
  *
- * These are the stable offensive tables that are duplicated across multiple
- * generation damage calculators. Generation-specific files extend these tables
- * only when a newer generation adds an entry.
+ * These tables are generation-agnostic constants, so they belong in core rather than
+ * the battle engine package. Later generations extend them locally when mechanics add
+ * new entries such as Pixie Plate or Roseli Berry.
  */
 
 export const BASE_TYPE_BOOST_ITEMS: Readonly<Record<string, PokemonType>> = {

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -1,2 +1,7 @@
+export {
+  BASE_PINCH_ABILITY_TYPES,
+  BASE_PLATE_ITEMS,
+  BASE_TYPE_BOOST_ITEMS,
+} from "./damage-calc-shared";
 export { ALL_NATURES, NATURES_BY_ID } from "./natures";
 export { GEN6_TYPE_CHART } from "./type-chart-data";

--- a/packages/core/tests/constants/damage-calc-shared.test.ts
+++ b/packages/core/tests/constants/damage-calc-shared.test.ts
@@ -1,24 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { BASE_PINCH_ABILITY_TYPES, BASE_PLATE_ITEMS, BASE_TYPE_BOOST_ITEMS } from "../../src/data";
+import {
+  BASE_PINCH_ABILITY_TYPES,
+  BASE_PLATE_ITEMS,
+  BASE_TYPE_BOOST_ITEMS,
+} from "../../src/constants/damage-calc-shared";
 
-describe("battle damage-calc shared constants", () => {
-  it("given the shared offensive lookup tables, when they are imported, then they match the documented cartridge-era item and ability sets", () => {
+describe("shared damage calculation constants", () => {
+  it("given the shared offensive item table, when imported, then it matches the Gen 4-9 base set", () => {
     // Source: Bulbapedia "Type-enhancing item" list for the 17 held items shared across gens 4-9.
     expect(Object.keys(BASE_TYPE_BOOST_ITEMS)).toHaveLength(17);
     // Source: Showdown data/items.ts Charcoal entry + Bulbapedia "Charcoal".
     expect(BASE_TYPE_BOOST_ITEMS.charcoal).toBe("fire");
     // Source: Showdown data/items.ts Silk Scarf entry + Bulbapedia "Silk Scarf".
     expect(BASE_TYPE_BOOST_ITEMS["silk-scarf"]).toBe("normal");
+  });
 
+  it("given the shared plate table, when imported, then it excludes later-generation additions", () => {
     // Source: Bulbapedia "Plate" list for the 16 Arceus plates introduced in Gen 4.
     expect(Object.keys(BASE_PLATE_ITEMS)).toHaveLength(16);
     // Source: Showdown data/items.ts Flame Plate entry + Bulbapedia "Flame Plate".
     expect(BASE_PLATE_ITEMS["flame-plate"]).toBe("fire");
     // Source: Showdown data/items.ts Iron Plate entry + Bulbapedia "Iron Plate".
     expect(BASE_PLATE_ITEMS["iron-plate"]).toBe("steel");
-    // Source: Bulbapedia "Pixie Plate" documents it as Gen 6+, so it is absent from the shared base Gen 4+ table.
+    // Source: Bulbapedia "Pixie Plate" documents it as Gen 6+, so it is absent from the shared base table.
     expect(BASE_PLATE_ITEMS["pixie-plate"]).toBeUndefined();
+  });
 
+  it("given the shared pinch ability table, when imported, then it contains only the four classic abilities", () => {
     // Source: Bulbapedia ability pages + Showdown pinch-ability handling for Overgrow/Blaze/Torrent/Swarm only.
     expect(Object.keys(BASE_PINCH_ABILITY_TYPES)).toHaveLength(4);
     // Source: Bulbapedia "Overgrow" + Showdown data/abilities.ts.

--- a/packages/core/tests/public-api.test.ts
+++ b/packages/core/tests/public-api.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "vitest";
 import * as core from "../src/index.js";
 
 describe("core public API exports", () => {
+  it("exports the shared damage lookup tables from the root barrel", () => {
+    expect(core.BASE_TYPE_BOOST_ITEMS).toBeDefined();
+    expect(core.BASE_PLATE_ITEMS).toBeDefined();
+    expect(core.BASE_PINCH_ABILITY_TYPES).toBeDefined();
+  });
+
   it("exports the clearer shared-mechanics names from the root barrel", () => {
     expect(core.gen1to2FullParalysisCheck).toBeDefined();
     expect(core.gen1to4MultiHitRoll).toBeDefined();

--- a/packages/gen4/src/Gen4DamageCalc.ts
+++ b/packages/gen4/src/Gen4DamageCalc.ts
@@ -4,13 +4,11 @@ import type {
   DamageContext,
   DamageResult,
 } from "@pokemon-lib-ts/battle";
+import type { MoveEffect, PokemonType, TypeChart } from "@pokemon-lib-ts/core";
 import {
   BASE_PINCH_ABILITY_TYPES,
   BASE_PLATE_ITEMS,
   BASE_TYPE_BOOST_ITEMS,
-} from "@pokemon-lib-ts/battle/data";
-import type { MoveEffect, PokemonType, TypeChart } from "@pokemon-lib-ts/core";
-import {
   getStabModifier,
   getStatStageMultiplier,
   getTypeEffectiveness,

--- a/packages/gen5/src/Gen5DamageCalc.ts
+++ b/packages/gen5/src/Gen5DamageCalc.ts
@@ -5,13 +5,11 @@ import type {
   DamageResult,
 } from "@pokemon-lib-ts/battle";
 import { getEffectiveStatStage } from "@pokemon-lib-ts/battle";
+import type { MoveEffect, PokemonType, TypeChartLookup } from "@pokemon-lib-ts/core";
 import {
   BASE_PINCH_ABILITY_TYPES,
   BASE_PLATE_ITEMS,
   BASE_TYPE_BOOST_ITEMS,
-} from "@pokemon-lib-ts/battle/data";
-import type { MoveEffect, PokemonType, TypeChartLookup } from "@pokemon-lib-ts/core";
-import {
   getStabModifier,
   getStatStageMultiplier,
   getTypeEffectiveness,

--- a/packages/gen6/src/Gen6DamageCalc.ts
+++ b/packages/gen6/src/Gen6DamageCalc.ts
@@ -5,13 +5,11 @@ import type {
   DamageResult,
 } from "@pokemon-lib-ts/battle";
 import { getEffectiveStatStage } from "@pokemon-lib-ts/battle";
+import type { MoveEffect, PokemonType, TypeChartLookup } from "@pokemon-lib-ts/core";
 import {
   BASE_PINCH_ABILITY_TYPES,
   BASE_PLATE_ITEMS,
   BASE_TYPE_BOOST_ITEMS,
-} from "@pokemon-lib-ts/battle/data";
-import type { MoveEffect, PokemonType, TypeChartLookup } from "@pokemon-lib-ts/core";
-import {
   getStabModifier,
   getStatStageMultiplier,
   getTypeEffectiveness,

--- a/packages/gen7/src/Gen7DamageCalc.ts
+++ b/packages/gen7/src/Gen7DamageCalc.ts
@@ -37,11 +37,6 @@ import type {
   DamageResult,
 } from "@pokemon-lib-ts/battle";
 import { getEffectiveStatStage } from "@pokemon-lib-ts/battle";
-import {
-  BASE_PINCH_ABILITY_TYPES,
-  BASE_PLATE_ITEMS,
-  BASE_TYPE_BOOST_ITEMS,
-} from "@pokemon-lib-ts/battle/data";
 import type {
   MoveEffect,
   PokemonType,
@@ -49,6 +44,9 @@ import type {
   VolatileStatus,
 } from "@pokemon-lib-ts/core";
 import {
+  BASE_PINCH_ABILITY_TYPES,
+  BASE_PLATE_ITEMS,
+  BASE_TYPE_BOOST_ITEMS,
   getStabModifier,
   getStatStageMultiplier,
   getTypeEffectiveness,

--- a/packages/gen8/src/Gen8DamageCalc.ts
+++ b/packages/gen8/src/Gen8DamageCalc.ts
@@ -41,11 +41,6 @@ import type {
   DamageResult,
 } from "@pokemon-lib-ts/battle";
 import { getEffectiveStatStage } from "@pokemon-lib-ts/battle";
-import {
-  BASE_PINCH_ABILITY_TYPES,
-  BASE_PLATE_ITEMS,
-  BASE_TYPE_BOOST_ITEMS,
-} from "@pokemon-lib-ts/battle/data";
 import type {
   MoveEffect,
   PokemonType,
@@ -53,6 +48,9 @@ import type {
   VolatileStatus,
 } from "@pokemon-lib-ts/core";
 import {
+  BASE_PINCH_ABILITY_TYPES,
+  BASE_PLATE_ITEMS,
+  BASE_TYPE_BOOST_ITEMS,
   getStabModifier,
   getStatStageMultiplier,
   getTypeEffectiveness,

--- a/packages/gen9/src/Gen9DamageCalc.ts
+++ b/packages/gen9/src/Gen9DamageCalc.ts
@@ -41,18 +41,20 @@ import type {
   DamageResult,
 } from "@pokemon-lib-ts/battle";
 import { getEffectiveStatStage } from "@pokemon-lib-ts/battle";
-import {
-  BASE_PINCH_ABILITY_TYPES,
-  BASE_PLATE_ITEMS,
-  BASE_TYPE_BOOST_ITEMS,
-} from "@pokemon-lib-ts/battle/data";
 import type {
   MoveEffect,
   PokemonType,
   TypeChartLookup,
   VolatileStatus,
 } from "@pokemon-lib-ts/core";
-import { getStatStageMultiplier, getTypeEffectiveness, pokeRound } from "@pokemon-lib-ts/core";
+import {
+  BASE_PINCH_ABILITY_TYPES,
+  BASE_PLATE_ITEMS,
+  BASE_TYPE_BOOST_ITEMS,
+  getStatStageMultiplier,
+  getTypeEffectiveness,
+  pokeRound,
+} from "@pokemon-lib-ts/core";
 import {
   getFluffyModifier,
   getHadronEngineSpAModifier,


### PR DESCRIPTION
## Summary
- closes #1027
- move the shared Gen4-9 damage lookup tables into `@pokemon-lib-ts/core`
- remove the obsolete `@pokemon-lib-ts/battle/data` export surface and battle root re-exports
- update Gen4-9 damage calculators and API tests to use the new ownership model

## Why
These tables are generation-agnostic shared data, not battle-engine behavior. Keeping them under `battle` forced internal consumers through a fragile package subpath and left the package boundary in the wrong place.

## Changes
- add `BASE_TYPE_BOOST_ITEMS`, `BASE_PLATE_ITEMS`, and `BASE_PINCH_ABILITY_TYPES` to `@pokemon-lib-ts/core`
- move the constant tests into `core`
- remove `battle/data` and stop exporting the constants from `@pokemon-lib-ts/battle`
- update Gen4-9 damage calculators to import the shared tables from `@pokemon-lib-ts/core`
- add a changeset for the API move/removal

## Validation
- `npx @biomejs/biome check .changeset/shared-damage-constants-core.md packages/core/src/constants/damage-calc-shared.ts packages/core/src/constants/index.ts packages/core/tests/constants/damage-calc-shared.test.ts packages/core/tests/public-api.test.ts packages/battle/package.json packages/battle/src/index.ts packages/battle/tests/index.test.ts packages/battle/tsup.config.ts packages/gen4/src/Gen4DamageCalc.ts packages/gen5/src/Gen5DamageCalc.ts packages/gen6/src/Gen6DamageCalc.ts packages/gen7/src/Gen7DamageCalc.ts packages/gen8/src/Gen8DamageCalc.ts packages/gen9/src/Gen9DamageCalc.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/core`
- `npm run test --workspace @pokemon-lib-ts/core`
- `npm run build --workspace @pokemon-lib-ts/core`
- `npm run typecheck --workspace @pokemon-lib-ts/battle`
- `npm run build --workspace @pokemon-lib-ts/battle`
- `npm run test --workspace @pokemon-lib-ts/battle`
- `npm run typecheck --workspace @pokemon-lib-ts/gen4`
- `npm run typecheck --workspace @pokemon-lib-ts/gen5`
- `npm run typecheck --workspace @pokemon-lib-ts/gen6`
- `npm run typecheck --workspace @pokemon-lib-ts/gen7`
- `npm run typecheck --workspace @pokemon-lib-ts/gen8`
- `npm run typecheck --workspace @pokemon-lib-ts/gen9`
- `npm run test --workspace @pokemon-lib-ts/gen4 -- --run tests/damage-calc.test.ts`
- `npm run test --workspace @pokemon-lib-ts/gen5 -- --run tests/damage-calc.test.ts`
- `npm run test --workspace @pokemon-lib-ts/gen6 -- --run tests/damage-calc.test.ts`
- `npm run test --workspace @pokemon-lib-ts/gen7 -- --run tests/damage-calc.test.ts`
- `npm run test --workspace @pokemon-lib-ts/gen8 -- --run tests/damage-calc.test.ts`
- `npm run test --workspace @pokemon-lib-ts/gen9 -- --run tests/damage-calc.test.ts`
- `npm run build --workspace @pokemon-lib-ts/gen1`
- `npm run build --workspace @pokemon-lib-ts/gen2`
- `npm run build --workspace @pokemon-lib-ts/gen3`
- `npm run build --workspace @pokemon-lib-ts/gen4`
- `npm run build --workspace @pokemon-lib-ts/gen5`
- `npm run build --workspace @pokemon-lib-ts/gen6`
- `npm run build --workspace @pokemon-lib-ts/gen7`
- `npm run build --workspace @pokemon-lib-ts/gen8`
- `npm run build --workspace @pokemon-lib-ts/gen9`
- `npm run ci:package-boundaries`

## Follow-up
- opened #1026 for the unrelated `@pokemon-lib-ts/battle` circular-chunk build warnings discovered during validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Damage calculation constants are now available from the core package.

* **Breaking Changes**
  * The data export from the battle package has been removed. Shared damage lookup tables have been consolidated into the core package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->