### PR TITLE
fix: harden gen8 quick draw and grounding behavior

### DIFF
--- a/packages/gen8/src/Gen8DamageCalc.ts
+++ b/packages/gen8/src/Gen8DamageCalc.ts
@@ -81,6 +81,11 @@ const DIALGA_SPECIES_ID = 483;
 const PALKIA_SPECIES_ID = 484;
 const GIRATINA_SPECIES_ID = 487;
 
+const AIRBORNE_SEMI_INVULNERABLE: ReadonlySet<VolatileStatus> = new Set([
+  CORE_VOLATILE_IDS.flying,
+  CORE_VOLATILE_IDS.shadowForceCharging,
+]);
+
 // ---- Type-Resist Berries ----
 
 /**
@@ -247,6 +252,14 @@ function isSheerForceEligibleMove(effect: MoveEffect | null, moveId: string): bo
  */
 export function isGen8Grounded(pokemon: ActivePokemon, gravityActive: boolean): boolean {
   if (gravityActive) return true;
+
+  // Fly/Bounce and Shadow Force/Phantom Force place the user in an airborne semi-invulnerable
+  // state that terrain and grounded-only effects should treat as not grounded.
+  // Source: Showdown sim/pokemon.ts -- isGrounded checks airborne semi-invulnerable volatiles
+  for (const volatile of AIRBORNE_SEMI_INVULNERABLE) {
+    if (pokemon.volatileStatuses.has(volatile)) return false;
+  }
+
   if (pokemon.volatileStatuses.has(CORE_VOLATILE_IDS.ingrain)) return true;
 
   const itemsSuppressed =

--- a/packages/gen8/src/Gen8Ruleset.ts
+++ b/packages/gen8/src/Gen8Ruleset.ts
@@ -2,6 +2,7 @@ import type {
   AbilityContext,
   AbilityResult,
   ActivePokemon,
+  BattleAction,
   BattleGimmick,
   BattleGimmickType,
   BattleSide,
@@ -37,12 +38,14 @@ import type {
 } from "@pokemon-lib-ts/core";
 import {
   CORE_ABILITY_IDS,
+  CORE_ABILITY_TRIGGER_IDS,
   CORE_END_OF_TURN_EFFECT_IDS,
   CORE_HAZARD_IDS,
   CORE_ITEM_IDS,
   CORE_VOLATILE_IDS,
 } from "@pokemon-lib-ts/core";
 import { createGen8DataManager } from "./data/index.js";
+import { GEN8_ABILITY_IDS } from "./data/reference-ids.js";
 import { handleGen8DamageImmunityAbility } from "./Gen8AbilitiesDamage.js";
 import { handleGen8StatAbility } from "./Gen8AbilitiesStat.js";
 import {
@@ -211,6 +214,53 @@ export class Gen8Ruleset extends BaseRuleset {
   }
 
   // --- Switch System ---
+
+  /**
+   * Quick Draw uses a within-bracket "go first" roll, matching Quick Claw style ordering
+   * rather than a true +1 priority boost.
+   *
+   * Source: Showdown data/abilities.ts -- quickdraw: onFractionalPriority
+   * Source: Bulbapedia "Quick Draw" -- "move first in its priority bracket"
+   */
+  protected override getQuickClawActivated(
+    actions: BattleAction[],
+    state: BattleState,
+    rng: SeededRandom,
+  ): Set<number> {
+    const activated = super.getQuickClawActivated(actions, state, rng);
+
+    for (const [index, action] of actions.entries()) {
+      if (action.type !== "move") continue;
+
+      const active = state.sides[action.side]?.active[0];
+      if (!active || active.ability !== GEN8_ABILITY_IDS.quickDraw) continue;
+
+      const moveSlot = active.pokemon.moves[action.moveIndex];
+      if (!moveSlot) continue;
+
+      let moveData: MoveData | null = null;
+      try {
+        moveData = this.dataManager.getMove(moveSlot.moveId);
+      } catch {
+        moveData = null;
+      }
+      if (!moveData) continue;
+
+      const result = this.applyAbility(CORE_ABILITY_TRIGGER_IDS.onPriorityCheck, {
+        pokemon: active,
+        state,
+        rng,
+        trigger: CORE_ABILITY_TRIGGER_IDS.onPriorityCheck,
+        move: moveData,
+      });
+
+      if (result.activated) {
+        activated.add(index);
+      }
+    }
+
+    return activated;
+  }
 
   /**
    * Pursuit was removed in Gen 8 (Sword/Shield).

--- a/packages/gen8/tests/coverage-gaps-3.test.ts
+++ b/packages/gen8/tests/coverage-gaps-3.test.ts
@@ -2,7 +2,8 @@
  * Targeted branch-coverage tests for Gen 8 Wave 9 — batch 3.
  *
  * Covers previously-uncovered branches in Gen8DamageCalc.ts:
- *   1. isGen8Grounded  — gravity, iron-ball, smackdown, magnet-rise, telekinesis, klutz
+ *   1. isGen8Grounded  — gravity, iron-ball, smackdown, magnet-rise, telekinesis, klutz,
+ *                        airborne semi-invulnerable volatiles
  *   2. getAttackStat   — huge-power, pure-power, gorilla-tactics, choice-band/specs (klutz),
  *                        deep-sea-tooth, light-ball, thick-club, hustle, guts, slow-start,
  *                        defeatist (HP > 50%), crit + negative attack stage
@@ -300,6 +301,24 @@ describe(`isGen8G${CORE_MOVE_IDS.round}ed`, () => {
     // Source: Showdown data/moves.ts -- Telekinesis applies the telekinesis volatile and ungrounds the target.
     const volatiles = new Map([[TELEKINESIS_VOLATILE, { turnsLeft: 3 }]]);
     const pokemon = createSyntheticOnFieldPokemon({ types: [CORE_TYPE_IDS.normal], volatiles });
+    const result = isGen8Grounded(pokemon, false);
+    expect(result).toBe(false);
+  });
+
+  it(`given pokemon has airborne ${CORE_VOLATILE_IDS.flying} volatile, when checking grounded, then returns false`, () => {
+    // Source: BattleEngine.ts -- Fly/Bounce set the shared airborne volatile
+    // Source: Showdown sim/pokemon.ts -- airborne semi-invulnerable users are not grounded
+    const volatiles = new Map([[CORE_VOLATILE_IDS.flying, { turnsLeft: 1 }]]);
+    const pokemon = createSyntheticOnFieldPokemon({ types: [CORE_TYPE_IDS.normal], volatiles });
+    const result = isGen8Grounded(pokemon, false);
+    expect(result).toBe(false);
+  });
+
+  it(`given pokemon has airborne ${CORE_VOLATILE_IDS.shadowForceCharging} volatile, when checking grounded, then returns false`, () => {
+    // Source: BattleEngine.ts -- Shadow Force / Phantom Force share the disappearing airborne volatile
+    // Source: Showdown sim/pokemon.ts -- airborne semi-invulnerable users are not grounded
+    const volatiles = new Map([[CORE_VOLATILE_IDS.shadowForceCharging, { turnsLeft: 1 }]]);
+    const pokemon = createSyntheticOnFieldPokemon({ types: [CORE_TYPE_IDS.ghost], volatiles });
     const result = isGen8Grounded(pokemon, false);
     expect(result).toBe(false);
   });

--- a/packages/gen8/tests/priority-boost.test.ts
+++ b/packages/gen8/tests/priority-boost.test.ts
@@ -137,11 +137,11 @@ function createOnFieldPokemon(
   return active;
 }
 
-function makeRng(nextVal = 0.5): SeededRandom {
+function makeRng(nextVal = 0.5, chanceResult = false): SeededRandom {
   return {
     next: () => nextVal,
     int: () => 1,
-    chance: () => false,
+    chance: () => chanceResult,
     pick: <T>(arr: readonly T[]) => arr[0] as T,
     shuffle: <T>(arr: T[]) => arr,
     getState: () => 0,
@@ -386,4 +386,104 @@ describe("Gen8Ruleset.resolveTurnOrder -- Triage priority boost (#783)", () => {
       expect((ordered[0] as { side: number }).side).toBe(1);
     },
   );
+});
+
+// ---------------------------------------------------------------------------
+// Quick Draw priority boost (#801)
+// ---------------------------------------------------------------------------
+
+describe("Gen8Ruleset.resolveTurnOrder -- Quick Draw priority boost (#801)", () => {
+  const ruleset = new Gen8Ruleset();
+
+  it("given Quick Draw activates for a slower user, when resolving turn order against a faster priority-0 move, then the Quick Draw user moves first", () => {
+    // Source: Showdown data/abilities.ts -- quickdraw: 30% chance to move first in its priority bracket
+    const quickDrawUser = createOnFieldPokemon({
+      ability: abilityIds.quickDraw,
+      speed: 50,
+      moves: [createScenarioMoveSlot(moveIds.tackle)],
+    });
+    const opponent = createOnFieldPokemon({
+      speed: 200,
+      moves: [createScenarioMoveSlot(moveIds.tackle)],
+    });
+
+    const sideA = createBattleSide({ index: 0, active: [quickDrawUser] });
+    const sideB = createBattleSide({ index: 1, active: [opponent] });
+    const state = createBattleState({
+      generation: 8,
+      sides: [sideA, sideB],
+      rng: makeRng(0.5, true),
+    });
+
+    const actions: BattleAction[] = [
+      { type: "move", side: 0, moveIndex: 0, target: 1 },
+      { type: "move", side: 1, moveIndex: 0, target: 0 },
+    ];
+
+    const ordered = ruleset.resolveTurnOrder(actions, state, makeRng(0.5, true));
+
+    expect(ordered[0].type).toBe("move");
+    expect((ordered[0] as { side: number }).side).toBe(0);
+  });
+
+  it("given Quick Draw activates against a higher-priority move, when resolving turn order, then the higher-priority move still goes first", () => {
+    // Source: Bulbapedia "Quick Draw" -- only moves first within its current priority bracket
+    const quickDrawUser = createOnFieldPokemon({
+      ability: abilityIds.quickDraw,
+      speed: 200,
+      moves: [createScenarioMoveSlot(moveIds.tackle)],
+    });
+    const opponent = createOnFieldPokemon({
+      speed: 50,
+      moves: [createScenarioMoveSlot(moveIds.quickAttack)],
+    });
+
+    const sideA = createBattleSide({ index: 0, active: [quickDrawUser] });
+    const sideB = createBattleSide({ index: 1, active: [opponent] });
+    const state = createBattleState({
+      generation: 8,
+      sides: [sideA, sideB],
+      rng: makeRng(0.5, true),
+    });
+
+    const actions: BattleAction[] = [
+      { type: "move", side: 0, moveIndex: 0, target: 1 },
+      { type: "move", side: 1, moveIndex: 0, target: 0 },
+    ];
+
+    const ordered = ruleset.resolveTurnOrder(actions, state, makeRng(0.5, true));
+
+    expect(ordered[0].type).toBe("move");
+    expect((ordered[0] as { side: number }).side).toBe(1);
+  });
+
+  it("given Quick Draw does not activate for a slower user, when resolving turn order against a faster priority-0 move, then the faster opponent still moves first", () => {
+    const quickDrawUser = createOnFieldPokemon({
+      ability: abilityIds.quickDraw,
+      speed: 50,
+      moves: [createScenarioMoveSlot(moveIds.tackle)],
+    });
+    const opponent = createOnFieldPokemon({
+      speed: 200,
+      moves: [createScenarioMoveSlot(moveIds.tackle)],
+    });
+
+    const sideA = createBattleSide({ index: 0, active: [quickDrawUser] });
+    const sideB = createBattleSide({ index: 1, active: [opponent] });
+    const state = createBattleState({
+      generation: 8,
+      sides: [sideA, sideB],
+      rng: makeRng(0.5, false),
+    });
+
+    const actions: BattleAction[] = [
+      { type: "move", side: 0, moveIndex: 0, target: 1 },
+      { type: "move", side: 1, moveIndex: 0, target: 0 },
+    ];
+
+    const ordered = ruleset.resolveTurnOrder(actions, state, makeRng(0.5, false));
+
+    expect(ordered[0].type).toBe("move");
+    expect((ordered[0] as { side: number }).side).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- fix Gen 8 Quick Draw turn-order handling by using the within-priority-bracket go-first lane instead of a real +1 boost
- make Gen 8 grounding checks treat airborne semi-invulnerable states as ungrounded
- add targeted Gen 8 regression coverage for both mechanics

## Issue Links
- Closes #801
- Refs #800

## Verification
- npx vitest run packages/gen8/tests/abilities-stat.test.ts packages/gen8/tests/priority-boost.test.ts packages/gen8/tests/coverage-gaps-3.test.ts
- npm run test --workspace @pokemon-lib-ts/gen8
- npm run typecheck --workspace @pokemon-lib-ts/gen8
- npx @biomejs/biome check packages/gen8/src/Gen8Ruleset.ts packages/gen8/src/Gen8DamageCalc.ts packages/gen8/tests/priority-boost.test.ts packages/gen8/tests/coverage-gaps-3.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick Draw ability now properly determines priority boost chances that affect turn order in battles.

* **Bug Fixes**
  * Airborne Pokémon states (Flying and Shadow Force charging) now correctly prevent grounding effects.

* **Tests**
  * Added test coverage for airborne state grounding behavior and Quick Draw priority mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->