### PR TITLE
fix: stop masking missing gen1 calculated stats

### DIFF
--- a/packages/gen1/src/Gen1DamageCalc.ts
+++ b/packages/gen1/src/Gen1DamageCalc.ts
@@ -35,6 +35,14 @@ export function isGen1PhysicalType(moveType: PokemonType): boolean {
   return (GEN1_PHYSICAL_TYPES as readonly string[]).includes(moveType);
 }
 
+function requireCalculatedStats(pokemon: ActivePokemon) {
+  const stats = pokemon.pokemon.calculatedStats;
+  if (!stats) {
+    throw new Error("Gen1 damage calculation requires calculatedStats");
+  }
+  return stats;
+}
+
 /**
  * Get the effective attack stat for a move in Gen 1.
  * Physical types use Attack; special types use SpAttack (which equals Special).
@@ -47,18 +55,17 @@ function getAttackStat(
 ): number {
   const physical = isGen1PhysicalType(moveType);
   const statKey = physical ? "attack" : "spAttack";
-  const stats = attacker.pokemon.calculatedStats;
+  const stats = requireCalculatedStats(attacker);
 
   if (isCrit) {
     // Source: pret/pokered engine/battle/core.asm:4060-4071 GetDamageVarsForPlayerAttack
     // On critical hits, loads from wPartyMon1Attack (unmodified party data), not wBattleMonAttack
     // (which has burn halving applied). Therefore burn does NOT affect crits in Gen 1.
     // Critical hits use the unmodified stat (ignore stat stages AND burn).
-    const baseStat = stats ? stats[statKey] : 100;
-    return baseStat;
+    return stats[statKey];
   }
 
-  const baseStat = stats ? stats[statKey] : 100;
+  const baseStat = stats[statKey];
   const stage = physical ? attacker.statStages.attack : attacker.statStages.spAttack;
   // Source: pret/pokered data/battle/stat_modifiers.asm — integer table (num/den), not float approximation
   // e.g. stage -1: 66/100 (integer) vs 2/3 (float). floor(150*66/100)=99 vs floor(150*0.6667)=100.
@@ -101,14 +108,14 @@ function getDefenseStat(
 ): number {
   const physical = isGen1PhysicalType(moveType);
   const statKey = physical ? "defense" : "spDefense";
-  const stats = defender.pokemon.calculatedStats;
+  const stats = requireCalculatedStats(defender);
 
   if (isCrit) {
     // Source: gen1-ground-truth.md §3 — Crit ignores ALL stat stages, Reflect, Light Screen
-    return Math.max(1, stats ? stats[statKey] : 100);
+    return Math.max(1, stats[statKey]);
   }
 
-  const baseStat = stats ? stats[statKey] : 100;
+  const baseStat = stats[statKey];
   const stage = physical ? defender.statStages.defense : defender.statStages.spDefense;
   // Source: pret/pokered data/battle/stat_modifiers.asm — integer table (num/den), not float approximation
   const defRatio = getGen12StatStageRatio(stage);

--- a/packages/gen1/src/Gen1Ruleset.ts
+++ b/packages/gen1/src/Gen1Ruleset.ts
@@ -257,9 +257,21 @@ export class Gen1Ruleset implements GenerationRuleset {
    * Calculate effective speed for turn order.
    * In Gen 1, paralysis reduces speed to 25%.
    */
-  private getEffectiveSpeed(active: ActivePokemon): number {
+  private requireCalculatedStats(active: ActivePokemon, context: string) {
     const stats = active.pokemon.calculatedStats;
-    const baseSpeed = stats ? stats.speed : 100;
+    if (!stats) {
+      throw new Error(`Gen1 ${context} requires calculatedStats`);
+    }
+    return stats;
+  }
+
+  private requireMaxHp(active: ActivePokemon): number {
+    return this.requireCalculatedStats(active, "max-HP calculation").hp;
+  }
+
+  private getEffectiveSpeed(active: ActivePokemon): number {
+    const stats = this.requireCalculatedStats(active, "turn-order calculation");
+    const baseSpeed = stats.speed;
 
     // Apply stat stages (integer arithmetic — Source: pret/pokered data/battle/stat_modifiers.asm)
     const speedRatio = getGen12StatStageRatio(active.statStages.speed);
@@ -649,7 +661,7 @@ export class Gen1Ruleset implements GenerationRuleset {
       }
 
       case "heal": {
-        const maxHp = attacker.pokemon.calculatedStats?.hp ?? attacker.pokemon.currentHp;
+        const maxHp = this.requireMaxHp(attacker);
         result.healAmount = Math.max(1, Math.floor(maxHp * effect.amount));
         break;
       }
@@ -847,7 +859,7 @@ export class Gen1Ruleset implements GenerationRuleset {
           // Source: pret/pokered src/engine/battle/effect_commands.asm — Rest
           // Rest heals to full HP and puts the user to sleep for exactly 2 turns.
           // Fails if user is at full HP AND has no primary status condition.
-          const maxHp = attacker.pokemon.calculatedStats?.hp ?? attacker.pokemon.currentHp;
+          const maxHp = this.requireMaxHp(attacker);
           const isFullHp = attacker.pokemon.currentHp >= maxHp;
           const hasStatus =
             attacker.pokemon.status !== null && attacker.pokemon.status !== undefined;
@@ -922,7 +934,7 @@ export class Gen1Ruleset implements GenerationRuleset {
           // Source: pret/pokered SubstituteEffect + gen1-ground-truth.md
           // Creates a substitute that absorbs damage. Costs 1/4 max HP.
           // Source: pokered SubstituteEffect — cartridge uses <= comparison: if currentHP <= subCost, Substitute fails.
-          const maxHp = attacker.pokemon.calculatedStats?.hp ?? attacker.pokemon.currentHp;
+          const maxHp = this.requireMaxHp(attacker);
           const subHp = Math.floor(maxHp / 4);
           if (attacker.substituteHp > 0) {
             result.messages.push("But it failed!");
@@ -1252,7 +1264,7 @@ export class Gen1Ruleset implements GenerationRuleset {
   // --- Status Conditions ---
 
   applyStatusDamage(pokemon: ActivePokemon, status: PrimaryStatus, _state: BattleState): number {
-    const maxHp = pokemon.pokemon.calculatedStats?.hp ?? pokemon.pokemon.currentHp;
+    const maxHp = this.requireMaxHp(pokemon);
 
     switch (status) {
       case "burn": {
@@ -1556,9 +1568,9 @@ export class Gen1Ruleset implements GenerationRuleset {
     // Burn halves physical attack even on confusion self-hits.
     // (Showdown gen1 conditions.ts:147-149)
     const level = pokemon.pokemon.level;
-    const calcStats = pokemon.pokemon.calculatedStats;
-    const baseAtk = calcStats?.attack ?? 50;
-    const baseDef = calcStats?.defense ?? 50;
+    const calcStats = this.requireCalculatedStats(pokemon, "confusion damage calculation");
+    const baseAtk = calcStats.attack;
+    const baseDef = calcStats.defense;
 
     // Integer stat-stage arithmetic — Source: pret/pokered data/battle/stat_modifiers.asm
     const { num: atkNum, den: atkDen } = getGen12StatStageRatio(pokemon.statStages.attack);
@@ -1908,7 +1920,7 @@ export class Gen1Ruleset implements GenerationRuleset {
     // Source: gen1-ground-truth.md §8 — Leech Seed shares the N/16 counter with burn/poison.
     // When the toxic-counter volatile exists (set by Toxic), Leech Seed uses and increments
     // that shared counter. Without it, Leech Seed drains the standard 1/16 max HP.
-    const maxHp = pokemon.pokemon.calculatedStats?.hp ?? pokemon.pokemon.currentHp;
+    const maxHp = this.requireMaxHp(pokemon);
     const seedState = pokemon.volatileStatuses.get("toxic-counter");
     if (seedState) {
       const counter = (seedState.data?.counter as number) ?? 1;

--- a/packages/gen1/tests/unit/damage-calc.test.ts
+++ b/packages/gen1/tests/unit/damage-calc.test.ts
@@ -300,6 +300,77 @@ function calcDamage(params: {
 describe("Gen 1 Damage Calculation", () => {
   // --- Basic Damage Calculation ---
 
+  it("given attacker without calculatedStats, when damage is calculated, then throws instead of fabricating attack stats", () => {
+    const attacker = createActivePokemon({
+      level: 50,
+      attack: 80,
+      defense: 60,
+      spAttack: 80,
+      spDefense: 60,
+      types: [TYPES.normal],
+    });
+    attacker.pokemon.calculatedStats = undefined;
+
+    const defender = createActivePokemon({
+      level: 50,
+      attack: 80,
+      defense: 60,
+      spAttack: 80,
+      spDefense: 60,
+      types: [TYPES.normal],
+    });
+    const move = createPhysicalMove(50);
+    const rng = createMockRng(255);
+    const context = {
+      attacker,
+      defender,
+      move,
+      rng,
+      isCrit: false,
+      state: { sides: [] },
+    } as unknown as DamageContext;
+
+    expect(() => calculateGen1Damage(context, createNeutralTypeChart(), createSpecies())).toThrow(
+      /Gen1 damage calculation requires calculatedStats/i,
+    );
+  });
+
+  it("given defender without calculatedStats, when damage is calculated, then throws instead of fabricating defense stats", () => {
+    const attacker = createActivePokemon({
+      level: 50,
+      attack: 80,
+      defense: 60,
+      spAttack: 80,
+      spDefense: 60,
+      types: [TYPES.normal],
+    });
+
+    const defender = createActivePokemon({
+      level: 50,
+      attack: 80,
+      defense: 60,
+      spAttack: 80,
+      spDefense: 60,
+      types: [TYPES.normal],
+    });
+    defender.pokemon.calculatedStats = undefined;
+
+    const move = createPhysicalMove(50);
+    const rng = createMockRng(255);
+    const context = {
+      attacker,
+      defender,
+      move,
+      rng,
+      isCrit: false,
+      state: { sides: [] },
+    } as unknown as DamageContext;
+
+    expect(() => calculateGen1Damage(context, createNeutralTypeChart(), createSpecies())).toThrow(
+      /Gen1 damage calculation requires calculatedStats/i,
+    );
+  });
+
   it("given known attacker/defender stats and a physical move, when calculating damage at max roll, then returns exact expected value", () => {
     // Arrange: Level 50 attacker with Attack 100, Defender with Defense 100, Power 80 move
     const params = {

--- a/packages/gen1/tests/unit/gen1-mechanic-bugs-regression.test.ts
+++ b/packages/gen1/tests/unit/gen1-mechanic-bugs-regression.test.ts
@@ -1211,6 +1211,21 @@ describe("#414 — Substitute + confusion: confusion self-hit bypasses Substitut
     // Assert
     expect(damage).toBe(35);
   });
+
+  it("given Gen 1 ruleset, when calculateConfusionDamage is called without calculatedStats, then throws instead of fabricating Attack and Defense", () => {
+    const pokemon = createActivePokemon({
+      pokemon: {
+        ...createActivePokemon().pokemon,
+        calculatedStats: undefined,
+      } as PokemonInstance,
+    });
+    const state = createBattleState();
+    const rng = new SeededRandom(0);
+
+    expect(() => ruleset.calculateConfusionDamage(pokemon, state, rng)).toThrow(
+      /Gen1 confusion damage calculation requires calculatedStats/i,
+    );
+  });
 });
 
 // ============================================================================

--- a/packages/gen1/tests/unit/gen1-mechanics.test.ts
+++ b/packages/gen1/tests/unit/gen1-mechanics.test.ts
@@ -546,6 +546,40 @@ describe("OHKO moves (Fissure, Guillotine, Horn Drill)", () => {
     expect(result).toBe(false);
   });
 
+  it("given OHKO accuracy checks with missing calculatedStats, when doesMoveHit evaluates the speed gate, then it throws instead of fabricating speed", () => {
+    const attacker = createSyntheticOnFieldPokemon({
+      pokemon: {
+        ...createSyntheticOnFieldPokemon().pokemon,
+        calculatedStats: undefined,
+      } as PokemonInstance,
+    });
+    const defender = createSyntheticOnFieldPokemon({
+      pokemon: {
+        ...createSyntheticOnFieldPokemon().pokemon,
+        calculatedStats: {
+          hp: 100,
+          attack: 80,
+          defense: 60,
+          spAttack: 80,
+          spDefense: 60,
+          speed: 200,
+        },
+      } as PokemonInstance,
+    });
+    const state = createBattleState();
+    const guaranteedHitRng = { int: () => 0 } as unknown as SeededRandom;
+
+    expect(() =>
+      ruleset.doesMoveHit({
+        attacker,
+        defender,
+        move: FISSURE,
+        state,
+        rng: guaranteedHitRng,
+      }),
+    ).toThrow(/Gen1 turn-order calculation requires calculatedStats/i);
+  });
+
   it("given OHKO effect move, when executeMoveEffect is called, then customDamage equals defender's current HP", () => {
     // Arrange
     const defender = createSyntheticOnFieldPokemon({

--- a/packages/gen1/tests/unit/ruleset-branches.test.ts
+++ b/packages/gen1/tests/unit/ruleset-branches.test.ts
@@ -594,7 +594,7 @@ describe("Gen1Ruleset applyStatusDamage", () => {
     expect(damage).toBe(0);
   });
 
-  it("given a Pokemon with no calculatedStats, when applying burn damage, then uses currentHp as fallback for max HP", () => {
+  it("given a Pokemon with no calculatedStats, when applying burn damage, then throws instead of fabricating max HP", () => {
     // Arrange
     const pokemon = createActivePokemonFixture({
       pokemon: {
@@ -604,10 +604,9 @@ describe("Gen1Ruleset applyStatusDamage", () => {
       } as PokemonInstance,
     });
     const state = makeBattleState();
-    // Act
-    const damage = ruleset.applyStatusDamage(pokemon, CORE_STATUS_IDS.burn, state);
-    // Assert: floor(160 / 16) = 10
-    expect(damage).toBe(10);
+    expect(() => ruleset.applyStatusDamage(pokemon, CORE_STATUS_IDS.burn, state)).toThrow(
+      /Gen1 max-HP calculation requires calculatedStats/i,
+    );
   });
 });
 
@@ -888,7 +887,7 @@ describe("Gen1Ruleset executeMoveEffect", () => {
     expect(result.healAmount).toBe(100);
   });
 
-  it("given a heal effect when attacker has no calculatedStats, when executing, then uses currentHp as fallback", () => {
+  it("given a heal effect when attacker has no calculatedStats, when executing, then throws instead of fabricating max HP", () => {
     // Arrange
     const attacker = createActivePokemonFixture({
       pokemon: {
@@ -901,10 +900,9 @@ describe("Gen1Ruleset executeMoveEffect", () => {
       effect: { type: "heal", amount: 0.5 },
     });
     const ctx = createMoveEffectContextFixture({ attacker, move });
-    // Act
-    const result = ruleset.executeMoveEffect(ctx);
-    // Assert: max(1, floor(80 * 0.5)) = 40
-    expect(result.healAmount).toBe(40);
+    expect(() => ruleset.executeMoveEffect(ctx)).toThrow(
+      /Gen1 max-HP calculation requires calculatedStats/i,
+    );
   });
 
   // --- multi effect ---
@@ -1674,7 +1672,7 @@ describe("Gen1Ruleset resolveTurnOrder", () => {
     ).toThrow(/custom loader exploded/i);
   });
 
-  it("given a Pokemon with no calculatedStats, when resolving turn order, then uses default speed of 100", () => {
+  it("given a Pokemon with no calculatedStats, when resolving turn order, then throws instead of fabricating speed", () => {
     // Arrange
     const move0: BattleAction = { type: "move", side: 0, moveIndex: 0 };
     const move1: BattleAction = { type: "move", side: 1, moveIndex: 0 };
@@ -1699,10 +1697,10 @@ describe("Gen1Ruleset resolveTurnOrder", () => {
     });
     const state = makeBattleState({ side0Active: noStatsPokemon, side1Active: fastPokemon });
     const rng = new SeededRandom(42);
-    // Act
-    const ordered = ruleset.resolveTurnOrder([move0, move1], state, rng);
-    // Assert: Side 1 (speed 200) should go first since default speed is 100
-    expect(ordered[0]?.side).toBe(1);
+    // Assert: missing calculatedStats is invalid runtime state and must not be masked
+    expect(() => ruleset.resolveTurnOrder([move0, move1], state, rng)).toThrow(
+      /Gen1 turn-order calculation requires calculatedStats/i,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- fail fast in Gen 1 damage, turn-order speed, and confusion self-hit paths when `calculatedStats` is missing instead of fabricating plausible-looking fallback stats
- add direct regressions for the attacker/defender damage paths, turn-order resolution, and confusion self-hit invalid-state contract
- keep the slice scoped to issue `#910`; adjacent max-HP fallback paths stay out of this PR

## Related Issue
Closes #910

## Changes
- replace the Gen 1 damage-calculation fallback `100` attack/defense values with explicit invalid-state errors
- replace the Gen 1 turn-order fallback `100` speed value with an explicit invalid-state error
- replace the Gen 1 confusion fallback `50` attack/defense values with an explicit invalid-state error
- update the affected Gen 1 regression tests to assert the new fail-fast contract

## Affected Packages
- [ ] `@pokemon-lib-ts/core`
- [ ] `@pokemon-lib-ts/battle`
- [x] `@pokemon-lib-ts/gen1`
- [ ] `@pokemon-lib-ts/gen2`

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Data/schema change
- [x] Tests
- [ ] CI/tooling

## Test Plan
- `npx vitest run packages/gen1/tests/unit/damage-calc.test.ts packages/gen1/tests/unit/ruleset-branches.test.ts packages/gen1/tests/unit/gen1-mechanic-bugs-regression.test.ts`
- `npx vitest run packages/gen1/tests/unit/formula-bug-fixes.test.ts packages/gen1/tests/unit/gen1-mechanics.test.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/gen1`
- `npx @biomejs/biome check packages/gen1/src/Gen1DamageCalc.ts packages/gen1/src/Gen1Ruleset.ts packages/gen1/tests/unit/damage-calc.test.ts packages/gen1/tests/unit/ruleset-branches.test.ts packages/gen1/tests/unit/gen1-mechanic-bugs-regression.test.ts PROGRESS.md`
- `git diff --check`
- `npm run verify:local` currently fails on fresh `origin/main` due an unrelated pre-existing local workspace build drift in `@pokemon-lib-ts/battle` DTS generation; not caused by this Gen 1 patch

## Checklist
- [ ] Local verification passes (`npm run verify:local`)
- [x] `/review` run locally (falcon + kestrel + sentinel)
- [x] `git pushreview` run after pushing the PR
- [x] Tests were written first or updated before the implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced validation of required statistical data in Gen 1 damage calculations and battle mechanics, replacing silent fallback defaults with explicit error handling to prevent invalid calculations.

* **Tests**
  * Added comprehensive test coverage for error scenarios when statistical data is missing in damage calculations, turn order resolution, and status effect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->