### PR TITLE
refactor: route move prechecks through rulesets

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -2153,44 +2153,22 @@ export class BattleEngine implements BattleEventEmitter {
       }
     }
 
-    // Terrain priority block (Gen 7+: Psychic Terrain blocks priority moves)
-    // Source: Showdown data/conditions.ts -- psychicterrain.onTryHit:
-    //   if (target.isGrounded() && move.priority > 0) { return false; }
-    if (this.ruleset.shouldBlockPriorityMove) {
-      const naturalPriority: number = effectiveMoveData.priority ?? 0;
-      if (
-        naturalPriority > 0 &&
-        this.ruleset.shouldBlockPriorityMove(actor, effectiveMoveData, defender, this.state)
-      ) {
-        this.emit({
-          type: "move-fail",
-          side: action.side,
-          pokemon: getPokemonName(actor),
-          move: effectiveMoveData.id,
-          reason: "blocked by terrain",
-        });
-        actor.lastMoveUsed = moveData.id;
-        actor.movedThisTurn = true;
-        return;
+    const preExecutionMoveFailure = this.ruleset.getPreExecutionMoveFailure?.(
+      actor,
+      defender,
+      effectiveMoveData,
+      this.state,
+    );
+    if (preExecutionMoveFailure) {
+      for (const message of preExecutionMoveFailure.messages ?? []) {
+        this.emit({ type: "message", text: message });
       }
-    }
-
-    // Gen 7+: Prankster-boosted status moves fail against Dark-type targets.
-    // Source: Showdown data/abilities.ts -- prankster: Dark targets block boosted status moves
-    if (
-      this.ruleset.checkPranksterDarkImmunity?.(
-        actor,
-        defender,
-        effectiveMoveData,
-        effectiveMoveData.target,
-      )
-    ) {
       this.emit({
         type: "move-fail",
         side: action.side,
         pokemon: getPokemonName(actor),
         move: effectiveMoveData.id,
-        reason: "blocked by Dark-type immunity",
+        reason: preExecutionMoveFailure.reason,
       });
       actor.lastMoveUsed = moveData.id;
       actor.movedThisTurn = true;

--- a/packages/battle/src/index.ts
+++ b/packages/battle/src/index.ts
@@ -124,6 +124,7 @@ export type {
   HazardSystem,
   ItemSystem,
   MoveSystem,
+  PreExecutionMoveFailure,
   StatCalculator,
   StatusSystem,
   SwitchSystem,

--- a/packages/battle/src/ruleset/BaseRuleset.ts
+++ b/packages/battle/src/ruleset/BaseRuleset.ts
@@ -62,6 +62,7 @@ import type {
   ExpRecipient,
   ExpRecipientSelectionContext,
   GenerationRuleset,
+  PreExecutionMoveFailure,
 } from "./GenerationRuleset";
 import { hasGoFirstItemActivated } from "./GoFirstItemActivation";
 
@@ -363,6 +364,35 @@ export abstract class BaseRuleset implements GenerationRuleset {
     return result;
   }
 
+  getPreExecutionMoveFailure(
+    attacker: ActivePokemon,
+    defender: ActivePokemon,
+    move: MoveData,
+    state: BattleState,
+  ): PreExecutionMoveFailure | null {
+    const naturalPriority = move.priority ?? 0;
+    if (naturalPriority > 0 && this.shouldBlockPriorityMove(attacker, move, defender, state)) {
+      return { reason: "blocked by terrain" };
+    }
+
+    return null;
+  }
+
+  /**
+   * Terrain-priority interaction hook (Psychic Terrain).
+   *
+   * Gen 3-6: no priority-move blocking from terrain.
+   * Gen 7+: override in gen rulesets to block when terrain is active.
+   */
+  shouldBlockPriorityMove(
+    _actor: ActivePokemon,
+    _move: MoveData,
+    _defender: ActivePokemon,
+    _state: BattleState,
+  ): boolean {
+    return false;
+  }
+
   /**
    * Default: no moves can hit a semi-invulnerable target.
    * The caller may still pass the generic `"charging"` marker for two-turn moves
@@ -422,20 +452,6 @@ export abstract class BaseRuleset implements GenerationRuleset {
     _state: BattleState,
   ): { reflected: true; messages: string[] } | null {
     return null;
-  }
-
-  /**
-   * Default: no Prankster-vs-Dark immunity. Gen 7+ rulesets override this.
-   *
-   * Source: Showdown data/abilities.ts -- prankster Dark-type immunity starts in Gen 7
-   */
-  checkPranksterDarkImmunity(
-    _attacker: ActivePokemon,
-    _defender: ActivePokemon,
-    _move: MoveData,
-    _moveTarget: MoveData["target"],
-  ): boolean {
-    return false;
   }
 
   // Burn: Gen 7+ default (1/16 max HP); Gen 3-6 must override (1/8 max HP)

--- a/packages/battle/src/ruleset/GenerationRuleset.ts
+++ b/packages/battle/src/ruleset/GenerationRuleset.ts
@@ -38,6 +38,13 @@ import type { BattleAction } from "../events/BattleAction";
 import type { ActivePokemon, BattleSide } from "../state/BattleSide";
 import type { BattleState } from "../state/BattleState";
 
+export interface PreExecutionMoveFailure {
+  /** Human-readable explanation for why the move failed before execution. */
+  readonly reason: string;
+  /** Optional message events to emit before the move-fail event. */
+  readonly messages?: readonly string[];
+}
+
 // ─── Sub-interfaces (ISP: Interface Segregation Principle) ───────────────────
 // Consumers that only need one aspect of the ruleset can type-narrow to the
 // relevant sub-interface (e.g., pass only `DamageSystem` to a damage calculator).
@@ -161,21 +168,19 @@ export interface DamageSystem {
   ): boolean;
 
   /**
-   * Returns `true` if a Prankster-boosted status move should fail against the defender.
+   * Returns a generic pre-execution failure for the move, or `null` when the move
+   * is allowed to continue toward reflection/accuracy/damage handling.
    *
-   * Gen 7+: Dark-type targets are immune to status moves that gained priority from Prankster.
-   * Called by the engine before move execution so the move fails on the real execution path,
-   * not just during turn-order calculation.
-   *
-   * Source: Showdown data/abilities.ts -- prankster: Dark targets block boosted status moves
-   * Source: Bulbapedia "Prankster" Gen 7+ -- status moves fail against Dark-type targets
+   * This keeps the battle engine generation-agnostic while still allowing
+   * generation rulesets to own mechanic-specific early failures such as
+   * Psychic Terrain priority blocking and Gen 7+ Prankster-vs-Dark immunity.
    */
-  checkPranksterDarkImmunity?(
+  getPreExecutionMoveFailure?(
     attacker: ActivePokemon,
     defender: ActivePokemon,
     move: MoveData,
-    moveTarget: MoveData["target"],
-  ): boolean;
+    state: BattleState,
+  ): PreExecutionMoveFailure | null;
 
   /**
    * Returns `true` if the given move, when used by the given actor, can bypass Protect-type

--- a/packages/battle/src/ruleset/index.ts
+++ b/packages/battle/src/ruleset/index.ts
@@ -16,6 +16,7 @@ export type {
   HazardSystem,
   ItemSystem,
   MoveSystem,
+  PreExecutionMoveFailure,
   StatCalculator,
   StatusSystem,
   SwitchSystem,

--- a/packages/gen7/src/Gen7Ruleset.ts
+++ b/packages/gen7/src/Gen7Ruleset.ts
@@ -17,6 +17,7 @@ import type {
   ItemResult,
   MoveEffectContext,
   MoveEffectResult,
+  PreExecutionMoveFailure,
   TerrainEffectResult,
   WeatherEffectResult,
 } from "@pokemon-lib-ts/battle";
@@ -648,27 +649,24 @@ export class Gen7Ruleset extends BaseRuleset {
     return result.priorityBoost ?? 0;
   }
 
-  /**
-   * Check if a Prankster-boosted move fails against a Dark-type target.
-   *
-   * Gen 7 nerf: status moves boosted by Prankster have no effect on Dark-type Pokemon.
-   * Called by the engine before executing a move.
-   *
-   * Source: Showdown data/abilities.ts -- prankster: Dark targets block boosted status moves
-   * Source: Bulbapedia "Prankster" Gen 7 -- "Status moves fail against Dark-type targets"
-   */
-  checkPranksterDarkImmunity(
+  override getPreExecutionMoveFailure(
     attacker: ActivePokemon,
     defender: ActivePokemon,
     move: MoveData,
-    moveTarget: MoveData["target"],
-  ): boolean {
-    return isPranksterBlockedByDarkType(
-      attacker.ability,
-      move.category,
-      defender.types,
-      moveTarget,
-    );
+    state: BattleState,
+  ): PreExecutionMoveFailure | null {
+    const baseFailure = super.getPreExecutionMoveFailure(attacker, defender, move, state);
+    if (baseFailure) {
+      return baseFailure;
+    }
+
+    if (
+      isPranksterBlockedByDarkType(attacker.ability, move.category, defender.types, move.target)
+    ) {
+      return { reason: "blocked by Dark-type immunity" };
+    }
+
+    return null;
   }
 
   // --- Turn Order ---

--- a/packages/gen7/tests/integration/integration.test.ts
+++ b/packages/gen7/tests/integration/integration.test.ts
@@ -502,6 +502,34 @@ describe("Integration: Psychic Terrain priority blocking", () => {
 // ===========================================================================
 
 describe("Integration: Prankster vs Dark-type immunity", () => {
+  it("given a Gen 7 ruleset and a Prankster status move into a Dark-type defender, then pre-execution failure is returned", () => {
+    // Source: Showdown data/abilities.ts -- prankster: Dark targets block boosted status moves
+    // Source: Bulbapedia "Prankster" Gen 7 -- "Status moves fail against Dark-type targets"
+    const ruleset = new Gen7Ruleset();
+    const attacker = createSyntheticOnFieldPokemon({
+      ability: ABILITIES.prankster,
+      moveIds: [MOVES.thunderWave],
+      nickname: "Whimsicott",
+      types: [TYPES.grass, TYPES.fairy],
+    });
+    const defender = createSyntheticOnFieldPokemon({
+      nickname: "Umbreon",
+      types: [TYPES.dark],
+    });
+    const thunderWave = getCanonicalMove(MOVES.thunderWave);
+
+    const result = ruleset.getPreExecutionMoveFailure(
+      attacker,
+      defender,
+      thunderWave,
+      createSyntheticBattleState(),
+    );
+
+    expect(result).toEqual({
+      reason: "blocked by Dark-type immunity",
+    });
+  });
+
   it("given Prankster user using status move vs Dark-type, move is blocked", () => {
     // Source: Showdown data/abilities.ts -- prankster: Dark targets block boosted status moves
     // Source: Bulbapedia "Prankster" Gen 7 -- "Status moves fail against Dark-type targets"

--- a/packages/gen8/src/Gen8Ruleset.ts
+++ b/packages/gen8/src/Gen8Ruleset.ts
@@ -15,6 +15,7 @@ import type {
   ExpContext,
   ItemContext,
   ItemResult,
+  PreExecutionMoveFailure,
   TerrainEffectResult,
   WeatherEffectResult,
 } from "@pokemon-lib-ts/battle";
@@ -278,18 +279,24 @@ export class Gen8Ruleset extends BaseRuleset {
     return super.getAbilityPriorityBoost(active, moveData, state);
   }
 
-  override checkPranksterDarkImmunity(
+  override getPreExecutionMoveFailure(
     attacker: ActivePokemon,
     defender: ActivePokemon,
     move: MoveData,
-    moveTarget: MoveData["target"],
-  ): boolean {
-    return isPranksterBlockedByDarkType(
-      attacker.ability,
-      move.category,
-      defender.types,
-      moveTarget,
-    );
+    state: BattleState,
+  ): PreExecutionMoveFailure | null {
+    const baseFailure = super.getPreExecutionMoveFailure(attacker, defender, move, state);
+    if (baseFailure) {
+      return baseFailure;
+    }
+
+    if (
+      isPranksterBlockedByDarkType(attacker.ability, move.category, defender.types, move.target)
+    ) {
+      return { reason: "blocked by Dark-type immunity" };
+    }
+
+    return null;
   }
 
   /**

--- a/packages/gen8/tests/priority-boost.test.ts
+++ b/packages/gen8/tests/priority-boost.test.ts
@@ -241,14 +241,46 @@ describe("Gen8Ruleset.resolveTurnOrder -- Prankster priority boost (#783)", () =
       });
       const agility = dataManager.getMove(moveIds.agility);
 
-      const blocked = ruleset.checkPranksterDarkImmunity(
-        pranksterUser,
-        opponent,
-        agility,
-        agility.target,
-      );
+      const state = createBattleState({
+        generation: 8,
+        sides: [
+          createBattleSide({ index: 0, active: [pranksterUser] }),
+          createBattleSide({ index: 1, active: [opponent] }),
+        ],
+        rng: makeRng(),
+      });
+      const blocked = ruleset.getPreExecutionMoveFailure(pranksterUser, opponent, agility, state);
 
-      expect(blocked).toBe(false);
+      expect(blocked).toBeNull();
+    },
+  );
+
+  it(
+    "given Prankster user with a status move and a Dark-type opposing defender, " +
+      "when checking pre-execution failure, then the move is blocked",
+    () => {
+      const pranksterUser = createOnFieldPokemon({
+        ability: abilityIds.prankster,
+        moves: [createScenarioMoveSlot(moveIds.willOWisp)],
+      });
+      const opponent = createOnFieldPokemon({
+        types: [typeIds.dark],
+      });
+      const willOWisp = dataManager.getMove(moveIds.willOWisp);
+      const state = createBattleState({
+        generation: 8,
+        sides: [
+          createBattleSide({ index: 0, active: [pranksterUser] }),
+          createBattleSide({ index: 1, active: [opponent] }),
+        ],
+        rng: makeRng(),
+      });
+
+      const result = ruleset.getPreExecutionMoveFailure(pranksterUser, opponent, willOWisp, state);
+
+      expect(result).toEqual({
+        reason: "blocked by Dark-type immunity",
+      });
     },
   );
 });

--- a/packages/gen9/src/Gen9Ruleset.ts
+++ b/packages/gen9/src/Gen9Ruleset.ts
@@ -16,6 +16,7 @@ import type {
   ItemResult,
   MoveEffectContext,
   MoveEffectResult,
+  PreExecutionMoveFailure,
   TerrainEffectResult,
   WeatherEffectResult,
 } from "@pokemon-lib-ts/battle";
@@ -766,17 +767,23 @@ export class Gen9Ruleset extends BaseRuleset {
    * Source: Showdown data/abilities.ts -- prankster: Dark targets block boosted status moves
    * Source: Bulbapedia "Prankster" Gen 7+ -- "Status moves fail against Dark-type targets"
    */
-  override checkPranksterDarkImmunity(
+  override getPreExecutionMoveFailure(
     attacker: ActivePokemon,
     defender: ActivePokemon,
     move: MoveData,
-    moveTarget: MoveData["target"],
-  ): boolean {
-    return isPranksterBlockedByDarkType(
-      attacker.ability,
-      move.category,
-      defender.types,
-      moveTarget,
-    );
+    state: BattleState,
+  ): PreExecutionMoveFailure | null {
+    const baseFailure = super.getPreExecutionMoveFailure(attacker, defender, move, state);
+    if (baseFailure) {
+      return baseFailure;
+    }
+
+    if (
+      isPranksterBlockedByDarkType(attacker.ability, move.category, defender.types, move.target)
+    ) {
+      return { reason: "blocked by Dark-type immunity" };
+    }
+
+    return null;
   }
 }

--- a/packages/gen9/tests/priority-boost.test.ts
+++ b/packages/gen9/tests/priority-boost.test.ts
@@ -259,15 +259,17 @@ describe("Gen9Ruleset.resolveTurnOrder -- Prankster priority boost (#783)", () =
       const defender = createOnFieldPokemon({
         types: [CORE_TYPE_IDS.dark],
       });
-
-      const blocked = ruleset.checkPranksterDarkImmunity(
+      const move = dataManager.getMove(moveIds.willOWisp);
+      const result = ruleset.getPreExecutionMoveFailure(
         attacker,
         defender,
-        dataManager.getMove(moveIds.willOWisp),
-        dataManager.getMove(moveIds.willOWisp).target,
+        move,
+        createBattleState(createSide(0, [attacker]), createSide(1, [defender])),
       );
 
-      expect(blocked).toBe(true);
+      expect(result).toEqual({
+        reason: "blocked by Dark-type immunity",
+      });
     },
   );
 
@@ -284,14 +286,15 @@ describe("Gen9Ruleset.resolveTurnOrder -- Prankster priority boost (#783)", () =
         types: [CORE_TYPE_IDS.normal],
       });
 
-      const blocked = ruleset.checkPranksterDarkImmunity(
+      const move = dataManager.getMove(moveIds.willOWisp);
+      const result = ruleset.getPreExecutionMoveFailure(
         attacker,
         defender,
-        dataManager.getMove(moveIds.willOWisp),
-        dataManager.getMove(moveIds.willOWisp).target,
+        move,
+        createBattleState(createSide(0, [attacker]), createSide(1, [defender])),
       );
 
-      expect(blocked).toBe(false);
+      expect(result).toBeNull();
     },
   );
 
@@ -309,14 +312,14 @@ describe("Gen9Ruleset.resolveTurnOrder -- Prankster priority boost (#783)", () =
       });
       const agility = dataManager.getMove(moveIds.agility);
 
-      const blocked = ruleset.checkPranksterDarkImmunity(
+      const result = ruleset.getPreExecutionMoveFailure(
         attacker,
         defender,
         agility,
-        agility.target,
+        createBattleState(createSide(0, [attacker]), createSide(1, [defender])),
       );
 
-      expect(blocked).toBe(false);
+      expect(result).toBeNull();
     },
   );
 });


### PR DESCRIPTION
## Summary
- add a generic ruleset-owned pre-execution move failure hook to the battle contract
- route BattleEngine early move-fail emission through that hook instead of a dedicated Prankster branch
- migrate Gen 7/8/9 Prankster-vs-Dark handling and direct ruleset tests onto the generic hook

Fixes #1043.

## Verification
- `npx @biomejs/biome check packages/gen7/tests/integration/integration.test.ts packages/battle/src/ruleset/GenerationRuleset.ts packages/battle/src/ruleset/BaseRuleset.ts packages/battle/src/engine/BattleEngine.ts packages/battle/src/ruleset/index.ts packages/battle/src/index.ts packages/gen7/src/Gen7Ruleset.ts packages/gen8/src/Gen8Ruleset.ts packages/gen9/src/Gen9Ruleset.ts packages/gen8/tests/priority-boost.test.ts packages/gen9/tests/priority-boost.test.ts packages/gen9/tests/bughunt-fixes.test.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/battle`
- `npm run typecheck --workspace @pokemon-lib-ts/gen7`
- `npm run typecheck --workspace @pokemon-lib-ts/gen8`
- `npm run typecheck --workspace @pokemon-lib-ts/gen9`
- `npx vitest run packages/gen7/tests/integration/integration.test.ts packages/gen8/tests/priority-boost.test.ts packages/gen9/tests/priority-boost.test.ts packages/gen9/tests/bughunt-fixes.test.ts packages/battle/tests/integration/engine/battle-engine-advanced.test.ts`

## Notes
- Full root `npm run typecheck` / `npm run build` from this task worktree hit the existing workspace-node_modules path artifact caused by the dirty root checkout resolving sibling package builds against `/home/uehlbran/projects/pokemon-lib-ts/packages/*` instead of the task worktree. Clean GitHub CI is the authoritative full-repo gate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated move pre-execution failure handling into a unified mechanism for improved code maintainability.
  
* **Tests**
  * Updated test cases across generation rulesets to verify updated move failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->