### PR TITLE
fix: normalize move-like queued battle actions

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -42,6 +42,7 @@ import type {
   MoveAction,
   RunAction,
 } from "../events";
+import { isMoveLikeAction } from "../events/BattleAction";
 import type {
   BattleGimmickType,
   ExpRecipient,
@@ -1642,7 +1643,7 @@ export class BattleEngine implements BattleEventEmitter {
 
       // Skip if this side's Pokemon was phased out (Roar/Whirlwind) earlier this turn.
       // The replacement should not execute the phased-out Pokemon's queued action.
-      if (action.type === "move" && this.phasedSides.has(action.side)) {
+      if (isMoveLikeAction(action) && this.phasedSides.has(action.side)) {
         continue;
       }
 

--- a/packages/battle/src/events/BattleAction.ts
+++ b/packages/battle/src/events/BattleAction.ts
@@ -107,3 +107,16 @@ export interface StruggleAction {
   /** Which side's Pokémon is struggling */
   readonly side: 0 | 1;
 }
+
+/**
+ * Returns whether an action occupies the side's normal combat slot in turn order.
+ *
+ * This groups standard move submissions with move-like queued actions that still
+ * resolve in the move-vs-move ordering lane, such as forced recharge turns and
+ * Struggle fallback turns.
+ */
+export function isMoveLikeAction(
+  action: BattleAction,
+): action is MoveAction | RechargeAction | StruggleAction {
+  return action.type === "move" || action.type === "recharge" || action.type === "struggle";
+}

--- a/packages/battle/src/ruleset/BaseRuleset.ts
+++ b/packages/battle/src/ruleset/BaseRuleset.ts
@@ -54,7 +54,7 @@ import type {
   ValidationResult,
   WeatherEffectResult,
 } from "../context";
-import type { BattleAction } from "../events/BattleAction";
+import { type BattleAction, isMoveLikeAction } from "../events/BattleAction";
 import type { ActivePokemon, BattleSide } from "../state/BattleSide";
 import type { BattleState } from "../state/BattleState";
 import type {
@@ -207,41 +207,48 @@ export abstract class BaseRuleset implements GenerationRuleset {
       if (actionA.type === "switch" && actionB.type !== "switch") return -1;
       if (actionB.type === "switch" && actionA.type !== "switch") return 1;
 
-      // Item usage goes before moves
-      if (actionA.type === "item" && actionB.type === "move") return -1;
-      if (actionB.type === "item" && actionA.type === "move") return 1;
+      // Item usage goes before move-like combat actions
+      if (actionA.type === "item" && isMoveLikeAction(actionB)) return -1;
+      if (actionB.type === "item" && isMoveLikeAction(actionA)) return 1;
 
-      // Run goes before moves
-      if (actionA.type === "run" && actionB.type === "move") return -1;
-      if (actionB.type === "run" && actionA.type === "move") return 1;
+      // Run goes before move-like combat actions
+      if (actionA.type === "run" && isMoveLikeAction(actionB)) return -1;
+      if (actionB.type === "run" && isMoveLikeAction(actionA)) return 1;
 
-      // For moves, compare priority then speed
-      if (actionA.type === "move" && actionB.type === "move") {
+      // For move-like combat actions, compare priority then speed.
+      // Recharge occupies the user's normal combat slot even though it does not execute move data.
+      if (isMoveLikeAction(actionA) && isMoveLikeAction(actionB)) {
         const sideA = state.sides[actionA.side];
         const sideB = state.sides[actionB.side];
         const activeA = sideA?.active[0];
         const activeB = sideB?.active[0];
         if (!activeA || !activeB) return 0;
 
-        const moveSlotA = activeA.pokemon.moves[actionA.moveIndex];
-        const moveSlotB = activeB.pokemon.moves[actionB.moveIndex];
-        if (!moveSlotA || !moveSlotB) return 0;
-
         let priorityA = 0;
         let priorityB = 0;
         let moveDataA: MoveData | undefined;
         let moveDataB: MoveData | undefined;
-        try {
-          moveDataA = this.dataManager.getMove(moveSlotA.moveId);
-          priorityA = moveDataA.priority;
-        } catch {
-          /* default 0 */
+
+        if (actionA.type === "move") {
+          const moveSlotA = activeA.pokemon.moves[actionA.moveIndex];
+          if (!moveSlotA) return 0;
+          try {
+            moveDataA = this.dataManager.getMove(moveSlotA.moveId);
+            priorityA = moveDataA.priority;
+          } catch {
+            /* default 0 */
+          }
         }
-        try {
-          moveDataB = this.dataManager.getMove(moveSlotB.moveId);
-          priorityB = moveDataB.priority;
-        } catch {
-          /* default 0 */
+
+        if (actionB.type === "move") {
+          const moveSlotB = activeB.pokemon.moves[actionB.moveIndex];
+          if (!moveSlotB) return 0;
+          try {
+            moveDataB = this.dataManager.getMove(moveSlotB.moveId);
+            priorityB = moveDataB.priority;
+          } catch {
+            /* default 0 */
+          }
         }
 
         // Ability-based priority boosts (Prankster, Gale Wings, Triage, etc.)
@@ -259,8 +266,8 @@ export abstract class BaseRuleset implements GenerationRuleset {
         if (priorityA !== priorityB) return priorityB - priorityA; // higher priority first
 
         // Quick Claw / go-first item: activated holders go first within same priority bracket
-        const qcA = quickClawActivated.has(a.idx);
-        const qcB = quickClawActivated.has(b.idx);
+        const qcA = actionA.type === "move" && quickClawActivated.has(a.idx);
+        const qcB = actionB.type === "move" && quickClawActivated.has(b.idx);
         if (qcA && !qcB) return -1;
         if (qcB && !qcA) return 1;
 

--- a/packages/battle/tests/integration/engine/forced-switch.test.ts
+++ b/packages/battle/tests/integration/engine/forced-switch.test.ts
@@ -1,5 +1,5 @@
 import type { PokemonInstance } from "@pokemon-lib-ts/core";
-import { CORE_MOVE_IDS } from "@pokemon-lib-ts/core";
+import { CORE_MOVE_IDS, CORE_VOLATILE_IDS } from "@pokemon-lib-ts/core";
 import { describe, expect, it } from "vitest";
 import type { BattleConfig } from "../../../src/context";
 import { BattleEngine } from "../../../src/engine";
@@ -161,5 +161,76 @@ describe("Forced switch (phazing) action inheritance", () => {
     const side0Active = engine.state.sides[0].active[0];
     expect(side0Active).toBeDefined();
     expect(side0Active!.pokemon.currentHp).toBe(153);
+  });
+
+  it("given a phased side had queued Struggle, when the faster opponent forces a switch first, then the replacement does not inherit the queued Struggle", () => {
+    // Arrange
+    const { engine, ruleset, events } = createPhazeTestEngine({ seed: 7 });
+    ruleset.setMoveEffectResult({ switchOut: true, forcedSwitch: true });
+
+    engine.start();
+
+    // Act
+    events.length = 0;
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "struggle", side: 1 });
+
+    // Assert
+    const side1Active = engine.state.sides[1].active[0];
+    expect(side1Active).toBeDefined();
+    expect(side1Active!.pokemon.uid).toBe("pikachu-bench");
+
+    const side0Active = engine.state.sides[0].active[0];
+    expect(side0Active).toBeDefined();
+    expect(side0Active!.pokemon.currentHp).toBe(153);
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === "move-start" && "move" in event && event.move === CORE_MOVE_IDS.struggle,
+      ),
+    ).toBe(false);
+    expect(
+      events.some(
+        (event) =>
+          event.type === "damage" && "source" in event && event.source === CORE_MOVE_IDS.struggle,
+      ),
+    ).toBe(false);
+  });
+
+  it("given a phased side had a queued recharge turn, when the faster opponent forces a switch first, then the replacement does not inherit the recharge action", () => {
+    // Arrange
+    const { engine, ruleset, events } = createPhazeTestEngine({ seed: 11 });
+    ruleset.setMoveEffectResult({ switchOut: true, forcedSwitch: true });
+
+    engine.start();
+
+    const side1ActiveBeforeTurn = engine.state.sides[1].active[0];
+    if (!side1ActiveBeforeTurn) {
+      throw new Error("Expected an active Pokemon on side 1");
+    }
+    side1ActiveBeforeTurn.volatileStatuses.set(CORE_VOLATILE_IDS.recharge, { turnsLeft: 1 });
+
+    // Act
+    events.length = 0;
+    engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+    engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+    // Assert
+    const side1Active = engine.state.sides[1].active[0];
+    expect(side1Active).toBeDefined();
+    expect(side1Active!.pokemon.uid).toBe("pikachu-bench");
+
+    const side0Active = engine.state.sides[0].active[0];
+    expect(side0Active).toBeDefined();
+    expect(side0Active!.pokemon.currentHp).toBe(153);
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === "message" &&
+          (event.text === "Blastoise must recharge!" || event.text === "Pikachu must recharge!"),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/battle/tests/integration/engine/recharge-and-struggle.test.ts
+++ b/packages/battle/tests/integration/engine/recharge-and-struggle.test.ts
@@ -148,6 +148,73 @@ describe("recharge enforcement (#104)", () => {
       const moveStart = events.find((e) => e.type === "move-start" && e.side === 0);
       expect(moveStart).toBeDefined();
     });
+
+    it("when the recharging Pokemon is faster than the opponent, then the recharge turn is consumed before the opponent's move starts", () => {
+      // Arrange
+      const { engine, events } = createEngine();
+      engine.start();
+
+      const active = engine.state.sides[0].active[0];
+      if (!active) {
+        throw new Error("Expected an active Pokemon on side 0");
+      }
+      active.volatileStatuses.set(VOLATILE_IDS.recharge, { turnsLeft: 1 });
+
+      // Act
+      events.length = 0;
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert
+      const rechargeIndex = events.findIndex(
+        (event) => event.type === "message" && event.text === "Charizard must recharge!",
+      );
+      const opponentMoveIndex = events.findIndex(
+        (event) => event.type === "move-start" && event.side === 1,
+      );
+
+      expect(rechargeIndex).toBeGreaterThan(-1);
+      expect(opponentMoveIndex).toBeGreaterThan(rechargeIndex);
+    });
+
+    it("when the recharging Pokemon is slower than the opponent, then the opponent's move starts before the recharge turn is consumed", () => {
+      // Arrange
+      const { engine, events } = createEngine();
+      engine.start();
+
+      const active = engine.state.sides[0].active[0];
+      if (!active) {
+        throw new Error("Expected an active Pokemon on side 0");
+      }
+      const opponent = engine.state.sides[1].active[0];
+      if (!opponent) {
+        throw new Error("Expected an active Pokemon on side 1");
+      }
+
+      if (!active.pokemon.calculatedStats || !opponent.pokemon.calculatedStats) {
+        throw new Error("Expected calculated stats for both active Pokemon");
+      }
+
+      active.pokemon.calculatedStats.speed = 80;
+      opponent.pokemon.calculatedStats.speed = 120;
+      active.volatileStatuses.set(VOLATILE_IDS.recharge, { turnsLeft: 1 });
+
+      // Act
+      events.length = 0;
+      engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+      engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+
+      // Assert
+      const rechargeIndex = events.findIndex(
+        (event) => event.type === "message" && event.text === "Charizard must recharge!",
+      );
+      const opponentMoveIndex = events.findIndex(
+        (event) => event.type === "move-start" && event.side === 1,
+      );
+
+      expect(opponentMoveIndex).toBeGreaterThan(-1);
+      expect(rechargeIndex).toBeGreaterThan(opponentMoveIndex);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- treat `recharge` and `struggle` as move-like queued combat actions in shared battle turn ordering
- skip phased queued `recharge` / `struggle` actions so replacements do not inherit them
- add direct integration coverage for recharge ordering and phazing invalidation

## Issue
- fixes #1049

## Verification
- `npx vitest run packages/battle/tests/integration/engine/recharge-and-struggle.test.ts packages/battle/tests/integration/engine/forced-switch.test.ts`
- `npx vitest run packages/battle/tests/integration/engine/battle-engine-advanced.test.ts packages/battle/tests/integration/engine/go-first-item-activation.test.ts packages/battle/tests/integration/engine/battle-engine-branches.test.ts packages/battle/tests/unit/ruleset/base-ruleset-branches.test.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/battle`
- `npx @biomejs/biome check packages/battle/src/events/BattleAction.ts packages/battle/src/ruleset/BaseRuleset.ts packages/battle/src/engine/BattleEngine.ts packages/battle/tests/integration/engine/recharge-and-struggle.test.ts packages/battle/tests/integration/engine/forced-switch.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved turn order resolution to correctly handle move-like combat actions (moves, recharge, struggle) during forced switches and phazing.
  * Fixed queued action handling to prevent recharge and struggle effects from applying after a forced switch.
  * Enhanced event ordering accuracy for all combat action types.

* **Tests**
  * Added integration tests for forced switch behavior with queued recharge and struggle actions.
  * Expanded event ordering test coverage for recharge status mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->