### PR TITLE
fix: ground gen5 airborne hazard checks

### DIFF
--- a/packages/gen5/src/Gen5EntryHazards.ts
+++ b/packages/gen5/src/Gen5EntryHazards.ts
@@ -110,6 +110,13 @@ export function isGen5Grounded(pokemon: ActivePokemon, gravityActive: boolean): 
   // so we cast. The combat move handler uses the same cast pattern.
   if (pokemon.volatileStatuses.has(CORE_VOLATILE_IDS.smackDown as VolatileStatus)) return true;
 
+  // Airborne semi-invulnerable charge turns are not grounded.
+  // Source: BattleEngine two-turn move handling -- `flying` and `shadow-force-charging`
+  //   volatiles represent the airborne / phased-out charge turn state for Fly/Bounce and
+  //   Shadow Force respectively.
+  if (pokemon.volatileStatuses.has(CORE_VOLATILE_IDS.flying)) return false;
+  if (pokemon.volatileStatuses.has(CORE_VOLATILE_IDS.shadowForceCharging)) return false;
+
   // Flying-type is not grounded
   if (pokemon.types.includes(CORE_TYPE_IDS.flying)) return false;
 

--- a/packages/gen5/tests/entry-hazards.test.ts
+++ b/packages/gen5/tests/entry-hazards.test.ts
@@ -174,6 +174,20 @@ describe("Gen5 isGen5Grounded", () => {
     expect(isGen5Grounded(pokemon, false)).toBe(true);
   });
 
+  it("given a Pokemon in the airborne Fly/Bounce charge turn, when checking grounding, then is NOT grounded", () => {
+    // Source: BattleEngine two-turn move handling — `flying` marks the airborne charge turn
+    const volatiles = new Map([[V.flying, { turnsLeft: 1 }]]);
+    const pokemon = createSyntheticOnFieldPokemon({ volatiles });
+    expect(isGen5Grounded(pokemon, false)).toBe(false);
+  });
+
+  it("given a Pokemon in the Shadow Force charge turn, when checking grounding, then is NOT grounded", () => {
+    // Source: BattleEngine two-turn move handling — `shadow-force-charging` marks the phased-out charge turn
+    const volatiles = new Map([[V.shadowForceCharging, { turnsLeft: 1 }]]);
+    const pokemon = createSyntheticOnFieldPokemon({ volatiles });
+    expect(isGen5Grounded(pokemon, false)).toBe(false);
+  });
+
   it("given a Flying-type Pokemon with Ingrain, when checking grounding, then IS grounded", () => {
     // Source: Bulbapedia -- Ingrain: "The user is affected by hazards on the ground,
     //   even if it is a Flying-type or has the Levitate ability."
@@ -265,6 +279,14 @@ describe("Gen5 Spikes", () => {
   it("given Spikes, when a Flying-type switches in, then takes no damage (returns null)", () => {
     // Source: Showdown data/moves.ts -- spikes: if (!pokemon.isGrounded()) return;
     const pokemon = createSyntheticOnFieldPokemon({ maxHp: 200, types: [T.flying] });
+    const result = applyGen5SpikesHazard(pokemon, 1, false);
+    expect(result).toBeNull();
+  });
+
+  it("given Spikes, when a Pokemon is in the airborne Fly/Bounce charge turn, then takes no damage (returns null)", () => {
+    // Source: BattleEngine two-turn move handling — airborne charge-turn users are not grounded
+    const volatiles = new Map([[V.flying, { turnsLeft: 1 }]]);
+    const pokemon = createSyntheticOnFieldPokemon({ maxHp: 200, volatiles });
     const result = applyGen5SpikesHazard(pokemon, 1, false);
     expect(result).toBeNull();
   });
@@ -451,6 +473,15 @@ describe("Gen5 Toxic Spikes", () => {
     // Source: Showdown -- Levitate means not grounded
     const pokemon = createSyntheticOnFieldPokemon({ ability: A.levitate });
     const result = applyGen5ToxicSpikes(pokemon, 1, false);
+    expect(result.absorbed).toBe(false);
+    expect(result.status).toBeNull();
+  });
+
+  it("given Toxic Spikes, when a Pokemon is in the Shadow Force charge turn, then is immune (not grounded)", () => {
+    // Source: BattleEngine two-turn move handling — `shadow-force-charging` is semi-invulnerable and airborne
+    const volatiles = new Map([[V.shadowForceCharging, { turnsLeft: 1 }]]);
+    const pokemon = createSyntheticOnFieldPokemon({ volatiles });
+    const result = applyGen5ToxicSpikes(pokemon, 2, false);
     expect(result.absorbed).toBe(false);
     expect(result.status).toBeNull();
   });


### PR DESCRIPTION
## Summary
- treat Gen 5 airborne semi-invulnerable charge turns as ungrounded in `isGen5Grounded()`
- add direct Gen 5 hazard coverage for Fly/Bounce and Shadow Force charge-turn immunity
- keep the slice limited to the remaining Gen 5 portion of issue `#800`

Closes #800.

## Testing
- `npx vitest run packages/gen5/tests/entry-hazards.test.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/gen5`
- `npm run test --workspace @pokemon-lib-ts/gen5`
- `npx @biomejs/biome check packages/gen5/src/Gen5EntryHazards.ts packages/gen5/tests/entry-hazards.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed entry hazard interactions during two-turn moves (Fly, Bounce, Shadow Force)—affected Pokémon are now correctly treated as ungrounded on charge turns and won't take damage from ground-based hazards.

* **Tests**
  * Added test coverage for entry hazard behavior during airborne and phased charge turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->