### PR TITLE
fix: bypass crit armor for gen7 signature moves

### DIFF
--- a/packages/gen7/src/Gen7Ruleset.ts
+++ b/packages/gen7/src/Gen7Ruleset.ts
@@ -494,7 +494,11 @@ export class Gen7Ruleset extends BaseRuleset {
    */
   rollCritical(context: CritContext): boolean {
     const defenderAbility = context.defender?.ability;
-    if (defenderAbility === "battle-armor" || defenderAbility === "shell-armor") {
+    if (
+      !moveIgnoresDefenderAbility(context.move) &&
+      (defenderAbility === GEN7_ABILITY_IDS.battleArmor ||
+        defenderAbility === GEN7_ABILITY_IDS.shellArmor)
+    ) {
       return false;
     }
     return super.rollCritical(context);

--- a/packages/gen7/tests/ruleset.test.ts
+++ b/packages/gen7/tests/ruleset.test.ts
@@ -1092,6 +1092,38 @@ describe("Gen7Ruleset — rollCritical (ability immunity)", () => {
     };
     expect(ruleset.rollCritical(context as any)).toBe(false);
   });
+
+  it("given Moongeist Beam against Battle Armor with guaranteed crit stage, when rolling crit, then Battle Armor is ignored", () => {
+    // Source: Showdown data/moves.ts -- moongeist-beam: ignoreAbility
+    const context = {
+      attacker: createSyntheticActive({
+        ability: ABILITY_IDS.superLuck,
+        heldItem: ITEM_IDS.scopeLens,
+        volatiles: [[VOLATILE_IDS.focusEnergy, { turnsLeft: -1 }]],
+      }),
+      defender: createSyntheticActive({ ability: ABILITY_IDS.battleArmor }),
+      move: MOONGEIST_BEAM_MOVE,
+      rng: { int: () => 1 } as unknown as SeededRandom,
+    };
+
+    expect(ruleset.rollCritical(context as any)).toBe(true);
+  });
+
+  it("given Sunsteel Strike against Shell Armor with guaranteed crit stage, when rolling crit, then Shell Armor is ignored", () => {
+    // Source: Showdown data/moves.ts -- sunsteel-strike: ignoreAbility
+    const context = {
+      attacker: createSyntheticActive({
+        ability: ABILITY_IDS.superLuck,
+        heldItem: ITEM_IDS.scopeLens,
+        volatiles: [[VOLATILE_IDS.focusEnergy, { turnsLeft: -1 }]],
+      }),
+      defender: createSyntheticActive({ ability: ABILITY_IDS.shellArmor }),
+      move: SUNSTEEL_STRIKE_MOVE,
+      rng: { int: () => 1 } as unknown as SeededRandom,
+    };
+
+    expect(ruleset.rollCritical(context as any)).toBe(true);
+  });
 });
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
- thread the existing Gen 7 signature-move ability bypass through `rollCritical()`
- let `Sunsteel Strike` and `Moongeist Beam` ignore `Battle Armor` and `Shell Armor`
- add focused Gen 7 ruleset regressions for the crit-immunity bypass path

## Testing
- `npx vitest run packages/gen7/tests/ruleset.test.ts packages/gen7/tests/damage-calc.test.ts`
- `npm run typecheck --workspace @pokemon-lib-ts/gen7`
- `npx @biomejs/biome check packages/gen7/src/Gen7Ruleset.ts packages/gen7/tests/ruleset.test.ts`
- `git diff --check`

## Related Issue
Closes: N/A
Refs #789


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed critical hit calculation to properly respect moves that ignore the defender's ability. Battle Armor and Shell Armor now correctly allow critical hits when the attacker uses ability-ignoring moves like Moongeist Beam or Sunsteel Strike.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->