### PR TITLE
docs: refresh testing confidence matrix

### DIFF
--- a/specs/reference/testing-status.md
+++ b/specs/reference/testing-status.md
@@ -77,6 +77,8 @@ Showdown parity is not the success criterion for Gen 1-4. For those gens, cartri
 
 ## Architecture Confidence Matrix (Initial Seed)
 
+Metric provenance: the LOC / `switch` / `if` counts below were measured at commit `4c730459` with a local `wc -l` + `rg -c '\bswitch\b'` + `rg -c '\bif\b'` scan across the listed source files on current `main`.
+
 | Hotspot | Risk | Evidence | Suggested Refactor Direction |
 | --- | --- | --- | --- |
 | `packages/battle/src/engine/BattleEngine.ts` | High | 6133 lines, 58 `switch`, 528 `if`; shared engine choke point for action resolution, event emission, and battle-state mutation | Split action resolution, turn progression, event emission, and state-transition pipelines into smaller engine modules with explicit contracts |


### PR DESCRIPTION
## Summary
- refresh the testing confidence status doc with current-main behavioral evidence
- reclassify live issues into confidence-relevant buckets and mark stale tracker overlap
- update the architecture hotspot matrix and compliance fast-path notes with current evidence

## Changes
- promoted several behavioral matrix rows from weak to strong with direct current-main test citations
- refreshed the architecture hotspot matrix with current LOC / `switch` / `if` evidence and added metric provenance
- split live issue classification into confidence-relevant buckets and marked stale Spectral Thief tracker overlap
- updated the compliance fast-path section to reflect machine-readable check ids and live Gen 2/3 disagreement entries

## Related Issue
Closes: N/A

## Affected Packages
- docs only (`specs/reference/testing-status.md`)

## Type
- documentation

## Test Plan
- `git diff --check`
- targeted source-evidence scans against current `main`
- `npx @biomejs/biome check specs/reference/testing-status.md` *(Biome ignores this doc path under current repo config, so the gate here is documented-source verification plus `git diff --check`)*

## Checklist
- [x] current-main evidence rechecked before editing the matrix
- [x] open-issue taxonomy refreshed against the live tracker
- [x] architecture counts annotated with measurement provenance
- [x] no code or package behavior changed in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised testing-status docs: raised confidence for invalid-state rejection and certain battle determinism items with added test evidence.
  * Clarified remaining gaps and missing combined-interaction coverage.
  * Expanded architecture confidence with metric provenance notes and a hotspots table.
  * Reorganized issue taxonomy and reclassified several items as low-severity debt or stale overlap.
  * Added machine-readable check IDs and first recorded known disagreements for specific type-chart interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->