### PR TITLE
fix: relink deserialized active pokemon

### DIFF
--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -138,6 +138,13 @@ interface PreDamageResolutionParams {
  * a stream of BattleEvents for UI/logging consumers.
  */
 export class BattleEngine implements BattleEventEmitter {
+  private static readonly STABLE_CHECKPOINT_PHASES: ReadonlySet<BattlePhase> = new Set([
+    "battle-start",
+    "action-select",
+    "switch-prompt",
+    "battle-end",
+  ]);
+
   // ─── State mutation model ───────────────────────────────────────────────────
   // BattleState is the source of truth. It is mutated in-place during turn
   // resolution. Events (BattleEvent[]) are emitted as notifications for UI/replay
@@ -1285,6 +1292,7 @@ export class BattleEngine implements BattleEventEmitter {
       parsed.state.generation,
       ruleset,
     );
+    BattleEngine.assertDeserializablePhase(parsed.state.phase);
     BattleEngine.assertSinglesOnlyFormat("BattleEngine.deserialize", parsed.state.format);
     BattleEngine.relinkRestoredActivePokemon(parsed.state);
 
@@ -1376,7 +1384,19 @@ export class BattleEngine implements BattleEventEmitter {
     return engine;
   }
 
+  private static assertDeserializablePhase(phase: BattlePhase): void {
+    if (BattleEngine.STABLE_CHECKPOINT_PHASES.has(phase)) {
+      return;
+    }
+
+    throw new Error(
+      `BattleEngine.deserialize cannot restore phase ${phase}; save only from stable checkpoint phases`,
+    );
+  }
+
   private static relinkRestoredActivePokemon(state: BattleState): void {
+    const expectedActiveSlotsPerSide = state.phase === "battle-start" ? 0 : 1;
+
     for (const side of state.sides) {
       if (!Array.isArray(side.active)) {
         throw new Error(
@@ -1384,14 +1404,18 @@ export class BattleEngine implements BattleEventEmitter {
         );
       }
 
-      if (side.active.length > 1) {
+      if (side.active.length !== expectedActiveSlotsPerSide) {
         throw new Error(
-          `BattleEngine.deserialize: singles battle cannot restore ${side.active.length} active slots on side ${side.index}`,
+          `BattleEngine.deserialize: phase ${state.phase} requires ${expectedActiveSlotsPerSide} active slot(s) on side ${side.index}, got ${side.active.length}`,
         );
       }
 
       for (const active of side.active) {
-        if (!active) continue;
+        if (!active || typeof active !== "object") {
+          throw new Error(
+            `BattleEngine.deserialize: side ${side.index} has invalid active slot payload`,
+          );
+        }
 
         if (!Number.isInteger(active.teamSlot) || active.teamSlot < 0) {
           throw new Error(
@@ -1434,14 +1458,7 @@ export class BattleEngine implements BattleEventEmitter {
   }
 
   private assertSerializablePhase(): void {
-    const stableCheckpointPhases: ReadonlySet<BattlePhase> = new Set([
-      "battle-start",
-      "action-select",
-      "switch-prompt",
-      "battle-end",
-    ]);
-
-    if (stableCheckpointPhases.has(this.state.phase)) {
+    if (BattleEngine.STABLE_CHECKPOINT_PHASES.has(this.state.phase)) {
       return;
     }
 

--- a/packages/battle/tests/integration/engine/deserialize.test.ts
+++ b/packages/battle/tests/integration/engine/deserialize.test.ts
@@ -297,6 +297,24 @@ describe("BattleEngine.deserialize", () => {
     ).toThrow('BattleEngine.deserialize: battle format "triples" is not supported');
   });
 
+  it("given a serialized battle with a non-checkpoint phase, when deserialized, then it rejects the lossy snapshot instead of restoring transient turn state", () => {
+    const { engine } = createTestEngine();
+    engine.start();
+
+    const parsed = JSON.parse(engine.serialize()) as {
+      state: {
+        phase: string;
+      };
+    };
+    parsed.state.phase = "turn-resolve";
+
+    expect(() =>
+      BattleEngine.deserialize(JSON.stringify(parsed), new MockRuleset(), createMockDataManager()),
+    ).toThrow(
+      "BattleEngine.deserialize cannot restore phase turn-resolve; save only from stable checkpoint phases",
+    );
+  });
+
   it("given a restored battle, when the active pokemon changes and later switches out and back in, then the restored team instance keeps the post-load HP and PP state", () => {
     const { dataManager, engine, ruleset } = createSwitchPromptBattleWithBench();
 
@@ -364,7 +382,46 @@ describe("BattleEngine.deserialize", () => {
 
     expect(() =>
       BattleEngine.deserialize(JSON.stringify(parsed), new MockRuleset(), createMockDataManager()),
-    ).toThrow("BattleEngine.deserialize: singles battle cannot restore 2 active slots on side 0");
+    ).toThrow(
+      "BattleEngine.deserialize: phase action-select requires 1 active slot(s) on side 0, got 2",
+    );
+  });
+
+  it("given a serialized checkpoint phase with a null active slot payload, when deserialized, then it rejects the malformed singles active shape", () => {
+    const { engine } = createTestEngine();
+    engine.start();
+
+    const parsed = JSON.parse(engine.serialize()) as {
+      state: {
+        sides: Array<{
+          active: unknown[];
+        }>;
+      };
+    };
+    parsed.state.sides[0].active[0] = null;
+
+    expect(() =>
+      BattleEngine.deserialize(JSON.stringify(parsed), new MockRuleset(), createMockDataManager()),
+    ).toThrow("BattleEngine.deserialize: side 0 has invalid active slot payload");
+  });
+
+  it("given a serialized battle-start snapshot with active slots still present, when deserialized, then it rejects the impossible checkpoint shape", () => {
+    const { engine } = createTestEngine();
+
+    const parsed = JSON.parse(engine.serialize()) as {
+      state: {
+        sides: Array<{
+          active: unknown[];
+        }>;
+      };
+    };
+    parsed.state.sides[0].active = [{ teamSlot: 0, pokemon: { uid: "charizard-1" } }];
+
+    expect(() =>
+      BattleEngine.deserialize(JSON.stringify(parsed), new MockRuleset(), createMockDataManager()),
+    ).toThrow(
+      "BattleEngine.deserialize: phase battle-start requires 0 active slot(s) on side 0, got 1",
+    );
   });
 
   it("given a serialized battle with an invalid active pokemon payload, when deserialized, then it rejects the malformed save with a deterministic error", () => {


### PR DESCRIPTION
## Summary
- relink deserialized active Pokemon back to their owning team slots before the engine resumes
- reject tampered save data when an active Pokemon uid no longer matches the referenced team slot
- add regression coverage proving post-load HP and PP changes survive switch-out and switch-in

## Changes
- add `BattleEngine.relinkRestoredActivePokemon(state)` during `BattleEngine.deserialize`
- validate restored `teamSlot` values and active/team uid integrity before installing the state
- extend `deserialize.test.ts` with a live-state switch round-trip regression and a tampered-save rejection case

## Related Issue
- Closes: N/A

## Affected Packages
- `@pokemon-lib-ts/battle`

## Type
- bug fix
- tests

## Test Plan
- `npx vitest run packages/battle/tests/integration/engine/deserialize.test.ts`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/integration/engine/deserialize.test.ts`
- `npm run --workspace @pokemon-lib-ts/battle typecheck`
- `git diff --check`

## Checklist
- [x] Tests added or updated for the behavior change
- [x] Targeted verification completed
- [x] No unrelated files changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened save-state deserialization to re-link active Pokémon back to their original team instances and ensure reference integrity.
  * Now rejects snapshots saved in non-checkpoint (transient) phases and other malformed or inconsistent restored battle states (wrong UIDs, invalid/mismatched active slots), returning deterministic errors.

* **Tests**
  * Added integration tests covering re-linking behavior and rejection of invalid or non-checkpoint serialized states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->