### PR TITLE
test: pin battle helper setup invariants

### DIFF
--- a/packages/battle/src/utils/BattleHelpers.ts
+++ b/packages/battle/src/utils/BattleHelpers.ts
@@ -132,7 +132,14 @@ export function createOnFieldPokemon(
       : isTerastallized && teraType
         ? [teraType]
         : resolvedTypes;
-  assertValidTypeList(teraResolvedTypes, "resolvedTypes");
+  const resolvedTypeSource = isTerastallized
+    ? pokemon.teraTypes && pokemon.teraTypes.length > 0
+      ? "teraTypes"
+      : "teraType"
+    : isMega && pokemon.megaTypes
+      ? "megaTypes"
+      : "baseTypes";
+  assertValidTypeList(teraResolvedTypes, resolvedTypeSource);
 
   return {
     pokemon,

--- a/packages/battle/tests/unit/utils/battle-helpers.test.ts
+++ b/packages/battle/tests/unit/utils/battle-helpers.test.ts
@@ -114,6 +114,31 @@ describe("BattleHelpers", () => {
       ).toThrow("baseTypes cannot contain duplicate types");
     });
 
+    it("given invalid persisted Mega or Tera type lists, when createOnFieldPokemon is called, then the error points at the persisted source field", () => {
+      expect(() =>
+        createOnFieldPokemon(
+          createTestPokemon(6, 50, {
+            megaAbility: CORE_ABILITY_IDS.solarPower,
+            megaTypes: [CORE_TYPE_IDS.fire, CORE_TYPE_IDS.fire],
+          }),
+          0,
+          fireFlyingTypes,
+        ),
+      ).toThrow("megaTypes cannot contain duplicate types");
+
+      expect(() =>
+        createOnFieldPokemon(
+          createTestPokemon(6, 50, {
+            terastallized: true,
+            teraType: CORE_TYPE_IDS.grass,
+            teraTypes: [CORE_TYPE_IDS.grass, CORE_TYPE_IDS.grass],
+          }),
+          0,
+          fireFlyingTypes,
+        ),
+      ).toThrow("teraTypes cannot contain duplicate types");
+    });
+
     it("given a caller-owned base types array, when createOnFieldPokemon is called, then the ActivePokemon gets its own copy", () => {
       const pokemon = createTestPokemon(6, 50);
       const types: PokemonType[] = [...fireFlyingTypes];


### PR DESCRIPTION
## Summary
- validate exported battle wrapper/state helpers against malformed runtime shapes
- add direct coverage for battle side/state helper invariants and Mega/Tera restoration
- pin clonePokemonInstance deep-copy behavior directly in the helper test suite

Closes #1069

## Testing
- npx @biomejs/biome check packages/battle/src/utils/BattleHelpers.ts packages/battle/tests/unit/utils/battle-helpers.test.ts
- npx vitest run packages/battle/tests/unit/utils/battle-helpers.test.ts
- npx vitest run packages/battle/tests/unit
- npm run --workspace @pokemon-lib-ts/battle typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for battle logic, including validation of Pokémon data, side layouts, transformation restore behavior (Mega/Terastallize), and deep-copy semantics.

* **Bug Fixes**
  * Strengthened validation across team and battle state initialization (slots, types, transformations, turn/flee counters, active Pokémon constraints) to prevent malformed battles and inconsistent transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->