### PR TITLE
fix: clarify runtime species ids for regional forms

### DIFF
--- a/packages/core/src/data/data-manager.ts
+++ b/packages/core/src/data/data-manager.ts
@@ -112,6 +112,8 @@ export class DataManager {
    *
    * @param id - National Pokédex number (e.g., 1 for Bulbasaur, 151 for Mew).
    *   Valid range depends on the generation (Gen 1: 1–151, Gen 2: 1–251, etc.).
+   *   Regional forms are currently represented as metadata on the National Dex
+   *   species entry, not as separate runtime species ids.
    * @returns The species data object.
    * @throws If no species with the given ID exists in the loaded data.
    */

--- a/packages/core/src/entities/species.ts
+++ b/packages/core/src/entities/species.ts
@@ -84,8 +84,9 @@ export interface PokemonSpeciesData {
 
   /**
    * Regional forms (Alolan, Galarian, Hisuian, Paldean).
-   * Each regional form is essentially a separate species entry
-   * but linked to the original via this field.
+   * The shipped runtime species model still keys `speciesId` by National Dex id,
+   * so this field is metadata about alternate forms rather than a promise that
+   * each regional form is exposed through its own runtime species entry.
    */
   readonly regionalForms?: readonly RegionalFormData[];
 }
@@ -205,7 +206,11 @@ export interface RegionalFormData {
   /** Region identifier */
   readonly region: "alola" | "galar" | "hisui" | "paldea";
 
-  /** Species ID of the regional form (PokeAPI assigns separate IDs) */
+  /**
+   * PokeAPI species id for the regional form metadata.
+   * The shipped runtime model does not currently expose these as separate
+   * `PokemonInstance.speciesId` values.
+   */
   readonly formSpeciesId: number;
 
   /** Types of the regional form */

--- a/packages/gen7/tests/damage-calc.test.ts
+++ b/packages/gen7/tests/damage-calc.test.ts
@@ -3623,6 +3623,34 @@ describe("Gen 7 attack stat item coverage", () => {
     expect(with_.damage).toBeGreaterThan(without.damage);
   });
 
+  it("given Marowak with Thick Club using physical move, then attack doubled via National Dex species id 105", () => {
+    // Source: Showdown data/items.ts -- Thick Club: 2x Atk for Cubone/Marowak.
+    // Source: the shipped runtime species model keys Marowak by National Dex id 105, not a
+    // separate regional-form runtime species id.
+    const ctx = createDamageContext({
+      attacker: createOnFieldPokemon({
+        speciesId: SPECIES_IDS.marowak,
+        attack: 100,
+        heldItem: ITEM_IDS.thickClub,
+        types: [TYPE_IDS.ground],
+      }),
+      defender: createOnFieldPokemon({}),
+      move: createSyntheticMove({ power: 50, category: MOVE_CATEGORIES.physical }),
+    });
+    const ctxNo = createDamageContext({
+      attacker: createOnFieldPokemon({
+        speciesId: SPECIES_IDS.marowak,
+        attack: 100,
+        types: [TYPE_IDS.ground],
+      }),
+      defender: createOnFieldPokemon({}),
+      move: createSyntheticMove({ power: 50, category: MOVE_CATEGORIES.physical }),
+    });
+    const with_ = calculateGen7Damage(ctx, typeChart);
+    const without = calculateGen7Damage(ctxNo, typeChart);
+    expect(with_.damage).toBeGreaterThan(without.damage);
+  });
+
   it("given attacker with Hustle using physical move, then attack is 1.5x", () => {
     // Source: Showdown data/abilities.ts -- Hustle: 1.5x physical attack
     const ctx = createDamageContext({

--- a/packages/gen7/tests/data-loading.test.ts
+++ b/packages/gen7/tests/data-loading.test.ts
@@ -186,6 +186,22 @@ describe("Gen 7 DataManager -- data loading", () => {
     expect(marshadow.types).toEqual([CORE_TYPE_IDS.fighting, CORE_TYPE_IDS.ghost]);
   });
 
+  it("given gen7 data, when looking up Marowak by National Dex id 105, then returns Marowak", () => {
+    // Source: packages/gen7/data/pokemon.json -- shipped Gen 7 data exposes Marowak at id 105.
+    // Regional-form runtime ids such as 10115 are not part of the shipped species model.
+    const dm = createGen7DataManager();
+    const marowak = dm.getSpecies(GEN7_SPECIES_IDS.marowak);
+    expect(marowak.name).toBe("marowak");
+    expect(marowak.id).toBe(105);
+  });
+
+  it("given gen7 data, when looking up Alolan Marowak form id 10115, then lookup throws", () => {
+    // Source: tools/data-importer/src/import-gen.ts -- form entries are not emitted as standalone
+    // runtime species rows today, so only the National Dex id 105 is loadable.
+    const dm = createGen7DataManager();
+    expect(() => dm.getSpecies(10115)).toThrow("Species with id 10115 not found");
+  });
+
   it("given gen7 data, when looking up Zeraora, then type is Electric", () => {
     // Source: Bulbapedia -- Zeraora (#807) is a pure Electric-type
     // Last standard Pokemon in Gen 7 National Dex

--- a/packages/gen8/tests/coverage-gaps-3.test.ts
+++ b/packages/gen8/tests/coverage-gaps-3.test.ts
@@ -613,6 +613,32 @@ describe(`getAttackStat — ability and item buffs (via calculateGen${GEN8_SPECI
     expect(dmgThickClub).toBeGreaterThan(dmgNoItem);
   });
 
+  it(`given Marowak (speciesId=105) holds ${CORE_ITEM_IDS.thickClub}, when using physical move, then doubled Attack damage`, () => {
+    // Source: Showdown data/items.ts -- Thick Club doubles Attack for Cubone/Marowak.
+    // The shipped runtime species model uses National Dex ids, so Marowak remains speciesId 105.
+    const marowak = createSyntheticOnFieldPokemon({
+      speciesId: SP.marowak,
+      attack: 100,
+      ability: CORE_ABILITY_IDS.none,
+      heldItem: CORE_ITEM_IDS.thickClub,
+    });
+    const marowakNoItem = createSyntheticOnFieldPokemon({
+      speciesId: SP.marowak,
+      attack: 100,
+      ability: CORE_ABILITY_IDS.none,
+      heldItem: null,
+    });
+    const defender = createSyntheticOnFieldPokemon({ defense: 100 });
+    const move = SYNTHETIC_NORMAL_PHYSICAL_65();
+
+    const dmgThickClub = calcDmg(createDamageContext({ attacker: marowak, defender, move })).damage;
+    const dmgNoItem = calcDmg(
+      createDamageContext({ attacker: marowakNoItem, defender, move }),
+    ).damage;
+
+    expect(dmgThickClub).toBeGreaterThan(dmgNoItem);
+  });
+
   it(`given non-Cubone/Marowak pokemon holds ${CORE_ITEM_IDS.thickClub}, when using physical move, then no boost`, () => {
     // Source: Showdown data/items.ts -- Thick Club only boosts Cubone/Marowak in the
     // current shipped species-id model (National Dex ids 104 and 105).

--- a/packages/gen8/tests/data-loading.test.ts
+++ b/packages/gen8/tests/data-loading.test.ts
@@ -215,6 +215,22 @@ describe("Gen 8 DataManager -- data loading", () => {
     expect(zamazenta.types).toEqual([TYPES.fighting]);
   });
 
+  it("given gen8 data, when looking up Marowak by National Dex id 105, then returns Marowak", () => {
+    // Source: packages/gen8/data/pokemon.json -- shipped Gen 8 data exposes Marowak at id 105.
+    // Regional-form runtime ids such as 10115 are not part of the shipped species model.
+    const dm = createGen8DataManager();
+    const marowak = dm.getSpecies(SPECIES.marowak);
+    expect(marowak.name).toBe("marowak");
+    expect(marowak.id).toBe(105);
+  });
+
+  it("given gen8 data, when looking up Alolan Marowak form id 10115, then lookup throws", () => {
+    // Source: tools/data-importer/src/import-gen.ts -- form entries are not emitted as standalone
+    // runtime species rows today, so only the National Dex id 105 is loadable.
+    const dm = createGen8DataManager();
+    expect(() => dm.getSpecies(10115)).toThrow("Species with id 10115 not found");
+  });
+
   it("given gen8 data, when looking up Eternatus, then types are Poison/Dragon", () => {
     // Source: Bulbapedia -- Eternatus (#890) is Poison/Dragon
     const dm = createGen8DataManager();

--- a/packages/gen9/src/Gen9DamageCalc.ts
+++ b/packages/gen9/src/Gen9DamageCalc.ts
@@ -424,8 +424,10 @@ function getAttackStat(
 
   // Thick Club: 2x Attack for Cubone (104) / Marowak (105)
   // Source: Showdown data/items.ts -- Thick Club
-  // The shipped species model uses National Dex ids and does not yet expose
-  // regional-form species entries through `speciesId`; tracked separately.
+  // The shipped runtime species model uses National Dex ids and does not yet expose
+  // regional-form species entries through `speciesId`; tracked separately. The current Gen 9
+  // data bundle also does not ship Cubone/Marowak species entries, so this path is mainly
+  // relevant for synthetic/manual runtime instances rather than canonical loaded species data.
   if (
     !attackerHasKlutz &&
     isPhysical &&

--- a/specs/core/01-entities.md
+++ b/specs/core/01-entities.md
@@ -402,8 +402,9 @@ export interface PokemonSpeciesData {
 
   /**
    * Regional forms (Alolan, Galarian, Hisuian, Paldean).
-   * Each regional form is essentially a separate species entry
-   * but linked to the original via this field.
+   * The shipped runtime species model still keys `speciesId` by National Dex id,
+   * so this field is metadata about alternate forms rather than a promise that
+   * each regional form is exposed through its own runtime species entry.
    */
   readonly regionalForms?: readonly RegionalFormData[];
 }
@@ -528,7 +529,11 @@ export interface RegionalFormData {
   /** Region identifier */
   readonly region: 'alola' | 'galar' | 'hisui' | 'paldea';
 
-  /** Species ID of the regional form (PokeAPI assigns separate IDs) */
+  /**
+   * PokeAPI species id for the regional form metadata.
+   * The shipped runtime model does not currently expose these as separate
+   * `PokemonInstance.speciesId` values.
+   */
   readonly formSpeciesId: number;
 
   /** Types of the regional form */


### PR DESCRIPTION
## Summary
- clarify that runtime `speciesId` values still use National Dex ids and do not expose regional-form ids as standalone runtime species entries
- add Gen 7 and Gen 8 regression coverage for Marowak resolving at National Dex id `105` and rejecting unsupported form id `10115`
- document the Gen 9 data-bundle limitation at the Thick Club check instead of implying canonical Marowak rows exist there

## Testing
- npx @biomejs/biome check packages/core/src/data/data-manager.ts packages/core/src/entities/species.ts specs/core/01-entities.md packages/gen7/tests/damage-calc.test.ts packages/gen7/tests/data-loading.test.ts packages/gen8/tests/coverage-gaps-3.test.ts packages/gen8/tests/data-loading.test.ts packages/gen9/src/Gen9DamageCalc.ts
- npx vitest run packages/gen7/tests/damage-calc.test.ts packages/gen7/tests/data-loading.test.ts packages/gen8/tests/coverage-gaps-3.test.ts packages/gen8/tests/data-loading.test.ts packages/gen9/tests/damage-calc.test.ts
- npm run --workspace @pokemon-lib-ts/core typecheck && npm run --workspace @pokemon-lib-ts/gen7 typecheck && npm run --workspace @pokemon-lib-ts/gen8 typecheck && npm run --workspace @pokemon-lib-ts/gen9 typecheck

Closes #1014