### PR TITLE
test: strengthen regional-form species id regressions

### DIFF
--- a/packages/gen7/tests/damage-calc.test.ts
+++ b/packages/gen7/tests/damage-calc.test.ts
@@ -3627,6 +3627,9 @@ describe("Gen 7 attack stat item coverage", () => {
     // Source: Showdown data/items.ts -- Thick Club: 2x Atk for Cubone/Marowak.
     // Source: the shipped runtime species model keys Marowak by National Dex id 105, not a
     // separate regional-form runtime species id.
+    // Base-damage derivation at L50, 50 BP, 100 Atk vs 100 Def:
+    // without item: floor(floor(22 * 50 * 100 / 100) / 50) + 2 = 24
+    // with Thick Club: floor(floor(22 * 50 * 200 / 100) / 50) + 2 = 46
     const ctx = createDamageContext({
       attacker: createOnFieldPokemon({
         speciesId: SPECIES_IDS.marowak,
@@ -3648,6 +3651,39 @@ describe("Gen 7 attack stat item coverage", () => {
     });
     const with_ = calculateGen7Damage(ctx, typeChart);
     const without = calculateGen7Damage(ctxNo, typeChart);
+    expect(with_.breakdown?.baseDamage).toBe(46);
+    expect(without.breakdown?.baseDamage).toBe(24);
+    expect(with_.damage).toBeGreaterThan(without.damage);
+  });
+
+  it("given Cubone with Thick Club using physical move, then attack doubled via National Dex species id 104", () => {
+    // Source: Showdown data/items.ts -- Thick Club: 2x Atk for Cubone/Marowak.
+    // Base-damage derivation at L50, 50 BP, 100 Atk vs 100 Def:
+    // without item: floor(floor(22 * 50 * 100 / 100) / 50) + 2 = 24
+    // with Thick Club: floor(floor(22 * 50 * 200 / 100) / 50) + 2 = 46
+    const ctx = createDamageContext({
+      attacker: createOnFieldPokemon({
+        speciesId: SPECIES_IDS.cubone,
+        attack: 100,
+        heldItem: ITEM_IDS.thickClub,
+        types: [TYPE_IDS.ground],
+      }),
+      defender: createOnFieldPokemon({}),
+      move: createSyntheticMove({ power: 50, category: MOVE_CATEGORIES.physical }),
+    });
+    const ctxNo = createDamageContext({
+      attacker: createOnFieldPokemon({
+        speciesId: SPECIES_IDS.cubone,
+        attack: 100,
+        types: [TYPE_IDS.ground],
+      }),
+      defender: createOnFieldPokemon({}),
+      move: createSyntheticMove({ power: 50, category: MOVE_CATEGORIES.physical }),
+    });
+    const with_ = calculateGen7Damage(ctx, typeChart);
+    const without = calculateGen7Damage(ctxNo, typeChart);
+    expect(with_.breakdown?.baseDamage).toBe(46);
+    expect(without.breakdown?.baseDamage).toBe(24);
     expect(with_.damage).toBeGreaterThan(without.damage);
   });
 

--- a/packages/gen7/tests/data-loading.test.ts
+++ b/packages/gen7/tests/data-loading.test.ts
@@ -199,7 +199,7 @@ describe("Gen 7 DataManager -- data loading", () => {
     // Source: tools/data-importer/src/import-gen.ts -- form entries are not emitted as standalone
     // runtime species rows today, so only the National Dex id 105 is loadable.
     const dm = createGen7DataManager();
-    expect(() => dm.getSpecies(10115)).toThrow("Species with id 10115 not found");
+    expect(() => dm.getSpecies(10115)).toThrow(/Species with id 10115/);
   });
 
   it("given gen7 data, when looking up Zeraora, then type is Electric", () => {

--- a/packages/gen8/tests/coverage-gaps-3.test.ts
+++ b/packages/gen8/tests/coverage-gaps-3.test.ts
@@ -590,6 +590,9 @@ describe(`getAttackStat — ability and item buffs (via calculateGen${GEN8_SPECI
   it(`given Cubone (speciesId=104) holds ${CORE_ITEM_IDS.thickClub}, when using physical move, then doubled Attack damage`, () => {
     // Source: Showdown data/items.ts -- Thick Club doubles Attack for Cubone/Marowak.
     // Regional-form species ids are tracked separately from the current National Dex model.
+    // Base-damage derivation at L50, 65 BP, 100 Atk vs 100 Def:
+    // without item: floor(floor(22 * 65 * 100 / 100) / 50) + 2 = 30
+    // with Thick Club: floor(floor(22 * 65 * 200 / 100) / 50) + 2 = 59
     const cubone = createSyntheticOnFieldPokemon({
       speciesId: SP.cubone,
       attack: 100,
@@ -605,17 +608,20 @@ describe(`getAttackStat — ability and item buffs (via calculateGen${GEN8_SPECI
     const defender = createSyntheticOnFieldPokemon({ defense: 100 });
     const move = SYNTHETIC_NORMAL_PHYSICAL_65();
 
-    const dmgThickClub = calcDmg(createDamageContext({ attacker: cubone, defender, move })).damage;
-    const dmgNoItem = calcDmg(
-      createDamageContext({ attacker: cuboneNoItem, defender, move }),
-    ).damage;
+    const thickClubResult = calcDmg(createDamageContext({ attacker: cubone, defender, move }));
+    const noItemResult = calcDmg(createDamageContext({ attacker: cuboneNoItem, defender, move }));
 
-    expect(dmgThickClub).toBeGreaterThan(dmgNoItem);
+    expect(thickClubResult.breakdown?.baseDamage).toBe(59);
+    expect(noItemResult.breakdown?.baseDamage).toBe(30);
+    expect(thickClubResult.damage).toBeGreaterThan(noItemResult.damage);
   });
 
   it(`given Marowak (speciesId=105) holds ${CORE_ITEM_IDS.thickClub}, when using physical move, then doubled Attack damage`, () => {
     // Source: Showdown data/items.ts -- Thick Club doubles Attack for Cubone/Marowak.
     // The shipped runtime species model uses National Dex ids, so Marowak remains speciesId 105.
+    // Base-damage derivation at L50, 65 BP, 100 Atk vs 100 Def:
+    // without item: floor(floor(22 * 65 * 100 / 100) / 50) + 2 = 30
+    // with Thick Club: floor(floor(22 * 65 * 200 / 100) / 50) + 2 = 59
     const marowak = createSyntheticOnFieldPokemon({
       speciesId: SP.marowak,
       attack: 100,
@@ -631,12 +637,12 @@ describe(`getAttackStat — ability and item buffs (via calculateGen${GEN8_SPECI
     const defender = createSyntheticOnFieldPokemon({ defense: 100 });
     const move = SYNTHETIC_NORMAL_PHYSICAL_65();
 
-    const dmgThickClub = calcDmg(createDamageContext({ attacker: marowak, defender, move })).damage;
-    const dmgNoItem = calcDmg(
-      createDamageContext({ attacker: marowakNoItem, defender, move }),
-    ).damage;
+    const thickClubResult = calcDmg(createDamageContext({ attacker: marowak, defender, move }));
+    const noItemResult = calcDmg(createDamageContext({ attacker: marowakNoItem, defender, move }));
 
-    expect(dmgThickClub).toBeGreaterThan(dmgNoItem);
+    expect(thickClubResult.breakdown?.baseDamage).toBe(59);
+    expect(noItemResult.breakdown?.baseDamage).toBe(30);
+    expect(thickClubResult.damage).toBeGreaterThan(noItemResult.damage);
   });
 
   it(`given non-Cubone/Marowak pokemon holds ${CORE_ITEM_IDS.thickClub}, when using physical move, then no boost`, () => {

--- a/packages/gen8/tests/data-loading.test.ts
+++ b/packages/gen8/tests/data-loading.test.ts
@@ -228,7 +228,7 @@ describe("Gen 8 DataManager -- data loading", () => {
     // Source: tools/data-importer/src/import-gen.ts -- form entries are not emitted as standalone
     // runtime species rows today, so only the National Dex id 105 is loadable.
     const dm = createGen8DataManager();
-    expect(() => dm.getSpecies(10115)).toThrow("Species with id 10115 not found");
+    expect(() => dm.getSpecies(10115)).toThrow(/Species with id 10115/);
   });
 
   it("given gen8 data, when looking up Eternatus, then types are Poison/Dragon", () => {


### PR DESCRIPTION
## Summary
- strengthen the Gen 7 and Gen 8 Thick Club regressions with exact base-damage expectations instead of only `toBeGreaterThan`
- relax the new data-loading throw assertions to match the relevant failure without coupling to the full message text
- close the actionable Qodo follow-up from the merged `#1072` slice

## Testing
- npx @biomejs/biome check packages/gen7/tests/damage-calc.test.ts packages/gen7/tests/data-loading.test.ts packages/gen8/tests/coverage-gaps-3.test.ts packages/gen8/tests/data-loading.test.ts
- npx vitest run packages/gen7/tests/damage-calc.test.ts packages/gen7/tests/data-loading.test.ts packages/gen8/tests/coverage-gaps-3.test.ts packages/gen8/tests/data-loading.test.ts
- npm run --workspace @pokemon-lib-ts/gen7 typecheck && npm run --workspace @pokemon-lib-ts/gen8 typecheck

Closes: N/A
Refs #1014
Follow-up to #1072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened damage-calculation tests to assert intermediate base-damage values precisely and retain relative damage comparisons.
  * Relaxed data-loading tests to match error messages via patterns instead of exact strings, making them more tolerant of message variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->