### PR TITLE
fix: repair reconciliation worktree inventory

### DIFF
--- a/scripts/check-reconciliation.mjs
+++ b/scripts/check-reconciliation.mjs
@@ -3,7 +3,8 @@
 import { spawnSync } from "node:child_process";
 import {
   createReconciliationLedger,
-  isTaskBranchEntry,
+  getSharedRepoRoot,
+  parseTaskWorktreeEntries,
   validateReconciliationLedger,
 } from "./lib/reconciliation-gate.mjs";
 import { getWorkflowStatePaths, readJsonFile } from "./lib/workflow-state.mjs";
@@ -16,69 +17,17 @@ function runGit(args) {
   }
   return result.stdout.trim();
 }
-
-function parseWorktrees(porcelain, repoRoot) {
-  const records = [];
-  let current = {};
-
-  for (const line of porcelain.split(/\r?\n/)) {
-    if (line.length === 0) {
-      if (current.path) {
-        records.push(current);
-      }
-      current = {};
-      continue;
-    }
-
-    const [key, ...rest] = line.split(" ");
-    const value = rest.join(" ");
-
-    if (key === "worktree") {
-      current.path = value;
-    } else if (key === "HEAD") {
-      current.head = value;
-    } else if (key === "branch") {
-      current.branch = value.replace("refs/heads/", "");
-    }
-  }
-
-  if (current.path) {
-    records.push(current);
-  }
-
-  const primaryWorktree = records[0]?.path ?? repoRoot;
-
-  return records
-    .filter((entry) =>
-      isTaskBranchEntry({
-        path: entry.path,
-        branch: entry.branch,
-        primaryWorktree,
-        repoRoot,
-      }),
-    )
-    .map((entry) => {
-      const mergedResult = spawnSync(
-        "git",
-        ["merge-base", "--is-ancestor", entry.head, "origin/main"],
-        {
-          encoding: "utf8",
-        },
-      );
-
-      return {
-        branch: entry.branch,
-        path: entry.path,
-        head: entry.head,
-        mergedIntoMain: mergedResult.status === 0,
-      };
-    });
-}
-
-const repoRoot = runGit(["rev-parse", "--show-toplevel"]);
-const gitCommonDir = runGit(["rev-parse", "--git-common-dir"]);
+const gitCommonDir = runGit(["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+const repoRoot = getSharedRepoRoot(gitCommonDir);
 const { reconciliationPath } = getWorkflowStatePaths(gitCommonDir);
-const currentEntries = parseWorktrees(runGit(["worktree", "list", "--porcelain"]), repoRoot);
+const currentEntries = parseTaskWorktreeEntries({
+  porcelain: runGit(["worktree", "list", "--porcelain"]),
+  repoRoot,
+  isHeadMergedIntoMain: (head) =>
+    spawnSync("git", ["merge-base", "--is-ancestor", head, "origin/main"], {
+      encoding: "utf8",
+    }).status === 0,
+});
 
 if (currentEntries.length === 0) {
   process.exit(0);

--- a/scripts/lib/reconciliation-gate.mjs
+++ b/scripts/lib/reconciliation-gate.mjs
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+
 export const RECONCILIATION_STATUSES = [
   "unclassified",
   "merged-equivalent",
@@ -11,11 +13,67 @@ export function isTaskBranchEntry({ path, branch, primaryWorktree, repoRoot }) {
     return false;
   }
 
+  if (branch === "main" || branch === "master") {
+    return false;
+  }
+
   if (path === primaryWorktree) {
-    return branch !== "main" && branch !== "master";
+    return true;
   }
 
   return path.startsWith(`${repoRoot}/.worktrees/`);
+}
+
+export function getSharedRepoRoot(gitCommonDir) {
+  return resolve(gitCommonDir, "..");
+}
+
+export function parseTaskWorktreeEntries({ porcelain, repoRoot, isHeadMergedIntoMain }) {
+  const records = [];
+  let current = {};
+
+  for (const line of porcelain.split(/\r?\n/)) {
+    if (line.length === 0) {
+      if (current.path) {
+        records.push(current);
+      }
+      current = {};
+      continue;
+    }
+
+    const [key, ...rest] = line.split(" ");
+    const value = rest.join(" ");
+
+    if (key === "worktree") {
+      current.path = value;
+    } else if (key === "HEAD") {
+      current.head = value;
+    } else if (key === "branch") {
+      current.branch = value.replace("refs/heads/", "");
+    }
+  }
+
+  if (current.path) {
+    records.push(current);
+  }
+
+  const primaryWorktree = records[0]?.path ?? repoRoot;
+
+  return records
+    .filter((entry) =>
+      isTaskBranchEntry({
+        path: entry.path,
+        branch: entry.branch,
+        primaryWorktree,
+        repoRoot,
+      }),
+    )
+    .map((entry) => ({
+      branch: entry.branch,
+      path: entry.path,
+      head: entry.head,
+      mergedIntoMain: isHeadMergedIntoMain(entry.head),
+    }));
 }
 
 export function createReconciliationLedger({ existingLedger, currentEntries, generatedAt }) {

--- a/scripts/reconcile-worktrees.mjs
+++ b/scripts/reconcile-worktrees.mjs
@@ -3,7 +3,8 @@
 import { spawnSync } from "node:child_process";
 import {
   createReconciliationLedger,
-  isTaskBranchEntry,
+  getSharedRepoRoot,
+  parseTaskWorktreeEntries,
   validateReconciliationLedger,
 } from "./lib/reconciliation-gate.mjs";
 import { getWorkflowStatePaths, readJsonFile, writeJsonFile } from "./lib/workflow-state.mjs";
@@ -54,64 +55,6 @@ function parseArgs(args) {
   return options;
 }
 
-function parseWorktrees(porcelain, repoRoot) {
-  const records = [];
-  let current = {};
-
-  for (const line of porcelain.split(/\r?\n/)) {
-    if (line.length === 0) {
-      if (current.path) {
-        records.push(current);
-      }
-      current = {};
-      continue;
-    }
-
-    const [key, ...rest] = line.split(" ");
-    const value = rest.join(" ");
-
-    if (key === "worktree") {
-      current.path = value;
-    } else if (key === "HEAD") {
-      current.head = value;
-    } else if (key === "branch") {
-      current.branch = value.replace("refs/heads/", "");
-    }
-  }
-
-  if (current.path) {
-    records.push(current);
-  }
-
-  const primaryWorktree = records[0]?.path ?? repoRoot;
-
-  return records
-    .filter((entry) =>
-      isTaskBranchEntry({
-        path: entry.path,
-        branch: entry.branch,
-        primaryWorktree,
-        repoRoot,
-      }),
-    )
-    .map((entry) => {
-      const mergedResult = spawnSync(
-        "git",
-        ["merge-base", "--is-ancestor", entry.head, "origin/main"],
-        {
-          encoding: "utf8",
-        },
-      );
-
-      return {
-        branch: entry.branch,
-        path: entry.path,
-        head: entry.head,
-        mergedIntoMain: mergedResult.status === 0,
-      };
-    });
-}
-
 function setClassification(ledger, value) {
   const [branch, status] = (value ?? "").split("=");
 
@@ -144,11 +87,18 @@ function setRetired(ledger, branch) {
 }
 
 const options = parseArgs(process.argv.slice(2));
-const repoRoot = runGit(["rev-parse", "--show-toplevel"]);
-const gitCommonDir = runGit(["rev-parse", "--git-common-dir"]);
+const gitCommonDir = runGit(["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+const repoRoot = getSharedRepoRoot(gitCommonDir);
 const { reconciliationPath } = getWorkflowStatePaths(gitCommonDir);
 const existingLedger = readJsonFile(reconciliationPath);
-const currentEntries = parseWorktrees(runGit(["worktree", "list", "--porcelain"]), repoRoot);
+const currentEntries = parseTaskWorktreeEntries({
+  porcelain: runGit(["worktree", "list", "--porcelain"]),
+  repoRoot,
+  isHeadMergedIntoMain: (head) =>
+    spawnSync("git", ["merge-base", "--is-ancestor", head, "origin/main"], {
+      encoding: "utf8",
+    }).status === 0,
+});
 
 const ledger = createReconciliationLedger({
   existingLedger,

--- a/scripts/tests/reconciliation-gate.test.mjs
+++ b/scripts/tests/reconciliation-gate.test.mjs
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   createReconciliationLedger,
+  getSharedRepoRoot,
+  isTaskBranchEntry,
+  parseTaskWorktreeEntries,
   validateReconciliationLedger,
 } from "../lib/reconciliation-gate.mjs";
 
@@ -267,4 +270,56 @@ test("rejects stale merged-equivalent entries when the current branch is no long
 
   assert.equal(result.isValid, false);
   assert.match(result.errors[0] ?? "", /stale/i);
+});
+
+test("excludes main worktrees from task-branch reconciliation even when linked", () => {
+  assert.equal(
+    isTaskBranchEntry({
+      path: "/repo/.worktrees/main-maintenance",
+      branch: "main",
+      primaryWorktree: "/repo",
+      repoRoot: "/repo",
+    }),
+    false,
+  );
+});
+
+test("derives the shared repository root from the git common dir", () => {
+  assert.equal(getSharedRepoRoot("/repo/.git"), "/repo");
+});
+
+test("parses task worktrees across sibling linked worktrees using the shared repo root", () => {
+  const entries = parseTaskWorktreeEntries({
+    porcelain: [
+      "worktree /repo",
+      "HEAD aaa111",
+      "branch refs/heads/docs/update-readmes-758",
+      "",
+      "worktree /repo/.worktrees/main-maintenance",
+      "HEAD bbb222",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.worktrees/fix-example",
+      "HEAD ccc333",
+      "branch refs/heads/fix/example",
+      "",
+    ].join("\n"),
+    repoRoot: "/repo",
+    isHeadMergedIntoMain: (head) => head === "bbb222",
+  });
+
+  assert.deepEqual(entries, [
+    {
+      branch: "docs/update-readmes-758",
+      path: "/repo",
+      head: "aaa111",
+      mergedIntoMain: false,
+    },
+    {
+      branch: "fix/example",
+      path: "/repo/.worktrees/fix-example",
+      head: "ccc333",
+      mergedIntoMain: false,
+    },
+  ]);
 });


### PR DESCRIPTION
## Summary
- derive reconciliation inventory from the shared git common dir so linked worktrees see the full backlog
- exclude linked `main`/`master` worktrees from task-branch reconciliation
- share the worktree parser between reconciliation scripts and add regressions for the inventory bugs

## Testing
- npm run test:workflow
- npm run typecheck
- npx biome check scripts/check-reconciliation.mjs scripts/reconcile-worktrees.mjs scripts/lib/reconciliation-gate.mjs scripts/tests/reconciliation-gate.test.mjs
- node scripts/reconcile-worktrees.mjs
- node /home/uehlbran/projects/pokemon-lib-ts/.worktrees/fix-workflow-reconciliation-followups/scripts/reconcile-worktrees.mjs

Closes #1078

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated worktree parsing logic into shared utilities for improved code reusability across build scripts.
  * Enhanced repository root resolution with absolute path handling.

* **Tests**
  * Added comprehensive test coverage for shared utility functions including worktree entry parsing and branch filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->