### PR TITLE
fix: address missed #1081 review findings

### DIFF
--- a/.changeset/1081-review-findings-fixes.md
+++ b/.changeset/1081-review-findings-fixes.md
@@ -1,0 +1,11 @@
+---
+"@pokemon-lib-ts/battle": patch
+"@pokemon-lib-ts/core": patch
+---
+
+fix(battle,core): address missed `#1081` review findings
+
+- reject unsupported battle formats before deeper config validation
+- reject singles configs that do not provide exactly two sides
+- preserve ruleset-only nature validation failures during battle preflight
+- normalize experience growth groups before the level-1 fast path so unsupported identifiers still throw

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -215,7 +215,9 @@ export class BattleEngine implements BattleEventEmitter {
 
   private static shouldSkipRulesetValidationMessage(message: string): boolean {
     return (
-      message.includes("is not available in Gen ") ||
+      (message.startsWith('Move "') && message.includes('" is not available in Gen ')) ||
+      (message.startsWith('Item "') && message.includes('" is not available in Gen ')) ||
+      (message.startsWith('Ability "') && message.includes('" is not available in Gen ')) ||
       message === "Pokemon ability is required" ||
       message === "Pokemon move slot is empty"
     );
@@ -231,6 +233,34 @@ export class BattleEngine implements BattleEventEmitter {
     dataManager: DataManager,
   ): BattleValidationResult {
     const errors: BattleValidationIssue[] = [];
+
+    if (config.format !== "singles") {
+      return {
+        valid: false,
+        errors: [
+          BattleEngine.createBattleValidationIssue(
+            "battle",
+            "unsupported-format",
+            "format",
+            `Battle format "${config.format}" is not supported`,
+          ),
+        ],
+      };
+    }
+
+    if (config.teams.length !== 2) {
+      return {
+        valid: false,
+        errors: [
+          BattleEngine.createBattleValidationIssue(
+            "team",
+            "teams-length",
+            "teams",
+            `Singles battles require exactly 2 sides, received ${config.teams.length}`,
+          ),
+        ],
+      };
+    }
 
     for (const [sideIndex, team] of config.teams.entries()) {
       const teamField = `teams[${sideIndex}]`;

--- a/packages/battle/tests/unit/battle-engine-surface.test.ts
+++ b/packages/battle/tests/unit/battle-engine-surface.test.ts
@@ -405,6 +405,91 @@ describe("BattleEngine surface", () => {
         message: "Side 0 must have at least 1 Pokemon for singles battles",
       });
     });
+
+    it("given a config without exactly two sides, when validateConfig is called, then it rejects the team count before side setup", () => {
+      const dataManager = createMockDataManager();
+      const result = BattleEngine.validateConfig(
+        {
+          generation: 1,
+          format: "singles",
+          teams: [[createTestPokemon(GEN1_SPECIES_IDS.charizard, 50)]],
+          seed: 12345,
+        },
+        new MockRuleset(),
+        dataManager,
+      );
+
+      expect(result).toEqual({
+        valid: false,
+        errors: [
+          {
+            entity: "team",
+            id: "teams-length",
+            field: "teams",
+            message: "Singles battles require exactly 2 sides, received 1",
+          },
+        ],
+      });
+    });
+
+    it("given an unsupported format, when validateConfig is called, then it rejects the config before team validation", () => {
+      const dataManager = createMockDataManager();
+      const result = BattleEngine.validateConfig(
+        {
+          generation: 1,
+          format: "doubles",
+          teams: [[createTestPokemon(GEN1_SPECIES_IDS.charizard, 50)]],
+          seed: 12345,
+        },
+        new MockRuleset(),
+        dataManager,
+      );
+
+      expect(result).toEqual({
+        valid: false,
+        errors: [
+          {
+            entity: "battle",
+            id: "unsupported-format",
+            field: "format",
+            message: 'Battle format "doubles" is not supported',
+          },
+        ],
+      });
+    });
+
+    it("given a ruleset-only nature error, when validateConfig is called, then the nature failure is preserved", () => {
+      const ruleset = new ValidatingRuleset();
+      ruleset.setInvalidPokemon("charizard-1", [
+        'Nature "sideways-nature" is not available in Gen 4',
+      ]);
+
+      const result = BattleEngine.validateConfig(
+        {
+          generation: 4,
+          format: "singles",
+          teams: [
+            [createTestPokemon(GEN1_SPECIES_IDS.charizard, 50, { uid: "charizard-1" })],
+            [createTestPokemon(GEN1_SPECIES_IDS.blastoise, 50, { uid: "blastoise-1" })],
+          ],
+          seed: 12345,
+        },
+        ruleset.setGenerationForTest(4),
+        createMockDataManager(),
+      );
+
+      expect(result).toEqual({
+        valid: false,
+        errors: [
+          {
+            entity: "pokemon",
+            id: "charizard-1",
+            field: "teams[0][0]",
+            message: 'Nature "sideways-nature" is not available in Gen 4',
+          },
+        ],
+      });
+    });
   });
 
   describe("getAvailableMoves", () => {
@@ -451,20 +536,23 @@ describe("BattleEngine surface", () => {
 
   describe("input isolation", () => {
     it("given caller-owned team members, when a full turn resolves, then the original pokemon objects stay unchanged", () => {
+      // Synthetic non-default values make accidental engine-side mutation visible in the caller copy.
+      const ORIGINAL_HP = 17;
+      const ORIGINAL_STAT_VALUE = 17;
       const originalMoveSlot = createMockMoveSlot(CORE_MOVE_IDS.tackle);
       const team1 = [
         createTestPokemon(GEN1_SPECIES_IDS.charizard, 50, {
           uid: "charizard-1",
           nickname: "Charizard",
-          currentHp: 17,
+          currentHp: ORIGINAL_HP,
           moves: [originalMoveSlot],
           calculatedStats: {
-            hp: 17,
-            attack: 17,
-            defense: 17,
-            spAttack: 17,
-            spDefense: 17,
-            speed: 17,
+            hp: ORIGINAL_STAT_VALUE,
+            attack: ORIGINAL_STAT_VALUE,
+            defense: ORIGINAL_STAT_VALUE,
+            spAttack: ORIGINAL_STAT_VALUE,
+            spDefense: ORIGINAL_STAT_VALUE,
+            speed: ORIGINAL_STAT_VALUE,
           },
         }),
       ];
@@ -479,7 +567,7 @@ describe("BattleEngine surface", () => {
       engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
       engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
 
-      expect(originalPokemon.currentHp).toBe(17);
+      expect(originalPokemon.currentHp).toBe(ORIGINAL_HP);
       expect(originalPokemon.moves).toEqual(originalMoves);
       expect(originalPokemon.calculatedStats).toEqual(originalCalculatedStats);
       expect(originalPokemon.timesAttacked).toBeUndefined();

--- a/packages/core/src/logic/experience.ts
+++ b/packages/core/src/logic/experience.ts
@@ -38,9 +38,9 @@ export function normalizeExperienceGroup(group: string): ExperienceGroup {
  * @returns Total cumulative EXP needed to reach this level
  */
 export function getExpForLevel(group: ExperienceGroupIdentifier | string, level: number): number {
+  const normalizedGroup = normalizeExperienceGroup(group);
   if (level <= 1) return 0;
   const n = level;
-  const normalizedGroup = normalizeExperienceGroup(group);
 
   switch (normalizedGroup) {
     case "erratic":

--- a/packages/core/tests/unit/logic/experience.test.ts
+++ b/packages/core/tests/unit/logic/experience.test.ts
@@ -111,6 +111,12 @@ describe("getExpForLevel", () => {
       'Unsupported experience growth group "sideways-growth"',
     );
   });
+
+  it("given an unsupported growth-rate identifier at level 1, when querying EXP totals, then it still throws clearly", () => {
+    expect(() => getExpForLevel("sideways-growth", 1)).toThrow(
+      'Unsupported experience growth group "sideways-growth"',
+    );
+  });
 });
 
 describe("getExpToNextLevel", () => {

--- a/tools/data-importer/src/import-gen.ts
+++ b/tools/data-importer/src/import-gen.ts
@@ -1057,7 +1057,6 @@ function buildTypeChart() {
     throw new Error(`No type list configured for generation ${GEN_NUM}`);
   }
 
-  const _validTypes = new Set(genTypes);
   const chart: Record<string, Record<string, number>> = {};
 
   for (const attackType of genTypes) {

--- a/tools/data-importer/tests/growth-rate.test.ts
+++ b/tools/data-importer/tests/growth-rate.test.ts
@@ -18,6 +18,7 @@ describe("normalizeImportedGrowthRate", () => {
   });
 
   it("given a canonical growth-rate name, when normalizing importer output, then it is preserved", () => {
+    // Source: core experience-group contract — medium-slow is one of the 6 canonical runtime groups.
     expect(normalizeImportedGrowthRate("medium-slow")).toBe("medium-slow");
   });
 


### PR DESCRIPTION
## Summary
Fix the legitimate code findings that were missed on `#1081` and keep this PR limited to those real code/test changes only.

Closes #1084

## Scope
- preserve ruleset-only nature validation failures in `BattleEngine.validateConfig()`
- reject unsupported battle formats before deeper validation
- reject singles configs that do not provide exactly two sides
- normalize EXP growth groups before the level-1 fast path so unsupported identifiers still throw
- keep the importer/test cleanup to the real in-scope nits only

## Explicitly Out of Scope
- no `.claude` changes
- no `CLAUDE.md` or `AGENTS.md` changes
- no workflow changes
- no review-process cleanup folded into this branch

## Verification
- `npx vitest run packages/battle/tests/unit/battle-engine-surface.test.ts packages/core/tests/unit/logic/experience.test.ts tools/data-importer/tests/growth-rate.test.ts`
- `npx @biomejs/biome check packages/battle/src/engine/BattleEngine.ts packages/battle/tests/unit/battle-engine-surface.test.ts packages/core/src/logic/experience.ts packages/core/tests/unit/logic/experience.test.ts tools/data-importer/src/import-gen.ts tools/data-importer/tests/growth-rate.test.ts .changeset/1081-review-findings-fixes.md`
- `npm run changeset:check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Battle validation now rejects unsupported formats before deeper configuration checks
  * Singles battles now require exactly 2 sides, validated early
  * Experience growth validation properly rejects unsupported identifiers at level 1
  * Improved Gen-availability validation message filtering

* **Tests**
  * Added validation tests for battle format and team configuration requirements
  * Added test for unsupported experience growth handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->