### PR TITLE
fix: add bounds validation to BattleEngine.deserialize()

### DIFF
--- a/.changeset/deserialize-validation.md
+++ b/.changeset/deserialize-validation.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/battle": patch
+---
+
+Add bounds validation to BattleEngine.deserialize() for turnNumber and Pokemon currentHp values.

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -1440,6 +1440,7 @@ export class BattleEngine implements BattleEventEmitter {
     );
     BattleEngine.assertDeserializablePhase(parsed.state.phase);
     BattleEngine.assertSinglesOnlyFormat("BattleEngine.deserialize", parsed.state.format);
+    BattleEngine.validateRestoredState(parsed.state);
     BattleEngine.relinkRestoredActivePokemon(parsed.state);
 
     const restoredSwitchPromptState = BattleEngine.restoreSwitchPromptState(
@@ -1538,6 +1539,24 @@ export class BattleEngine implements BattleEventEmitter {
     throw new Error(
       `BattleEngine.deserialize cannot restore phase ${phase}; save only from stable checkpoint phases`,
     );
+  }
+
+  private static validateRestoredState(state: BattleState): void {
+    if (typeof state.turnNumber !== "number" || state.turnNumber < 0) {
+      throw new Error(
+        `BattleEngine.deserialize: turnNumber must be a non-negative number, got ${state.turnNumber}`,
+      );
+    }
+
+    for (const side of state.sides) {
+      for (const pokemon of side.team) {
+        if (typeof pokemon.currentHp !== "number" || pokemon.currentHp < 0) {
+          throw new Error(
+            `BattleEngine.deserialize: Pokemon ${pokemon.uid} has invalid currentHp ${pokemon.currentHp}`,
+          );
+        }
+      }
+    }
   }
 
   private static relinkRestoredActivePokemon(state: BattleState): void {

--- a/packages/battle/tests/integration/engine/deserialize.test.ts
+++ b/packages/battle/tests/integration/engine/deserialize.test.ts
@@ -68,6 +68,21 @@ function createTestEngine(overrides?: {
   return { engine, ruleset, events };
 }
 
+function createSerializableEngine(): {
+  engine: BattleEngine;
+  ruleset: MockRuleset;
+  dataManager: DataManager;
+} {
+  const ruleset = new MockRuleset();
+  const dataManager = createMockDataManager();
+  const { engine } = createTestEngine({ ruleset, dataManager });
+  engine.start();
+  // Run one turn to move to action-select (a stable checkpoint phase)
+  engine.submitAction(0, { type: "move", side: 0, moveIndex: 0 });
+  engine.submitAction(1, { type: "move", side: 1, moveIndex: 0 });
+  return { engine, ruleset, dataManager };
+}
+
 function createSwitchPromptBattleWithBench(): {
   dataManager: DataManager;
   engine: BattleEngine;
@@ -946,5 +961,29 @@ describe("BattleEngine.deserialize", () => {
     expect(events.length).toBeGreaterThanOrEqual(1);
     const hasDamageEvent = events.some((e) => e.type === "damage");
     expect(hasDamageEvent).toBe(true);
+  });
+
+  it("given a serialized battle state with negative currentHp, when deserialized, then it rejects the invalid HP value", () => {
+    const { engine, ruleset, dataManager } = createSerializableEngine();
+
+    const serialized = engine.serialize();
+    const tampered = JSON.parse(serialized);
+    tampered.state.sides[0].team[0].currentHp = -5;
+
+    expect(() => BattleEngine.deserialize(JSON.stringify(tampered), ruleset, dataManager)).toThrow(
+      "invalid currentHp",
+    );
+  });
+
+  it("given a serialized battle state with negative turnNumber, when deserialized, then it rejects the invalid turn count", () => {
+    const { engine, ruleset, dataManager } = createSerializableEngine();
+
+    const serialized = engine.serialize();
+    const tampered = JSON.parse(serialized);
+    tampered.state.turnNumber = -1;
+
+    expect(() => BattleEngine.deserialize(JSON.stringify(tampered), ruleset, dataManager)).toThrow(
+      "turnNumber must be a non-negative number",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add `validateRestoredState()` check in `deserialize()` that rejects negative `turnNumber` and negative `currentHp` values
- Add 2 new tests for these validation edge cases
- Lightweight hardening — rejects clearly invalid state without being overly strict

## Test plan

- [x] All 26 deserialize tests pass (24 existing + 2 new)
- [x] `npm run typecheck` passes
- [x] Biome clean

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation when restoring saved battles to prevent loading corrupted or invalid data. The system now rejects invalid turn numbers and out-of-range health values, protecting against compromised save files affecting gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->