### PR TITLE
refactor: replace remaining raw weather/type strings with constants

### DIFF
--- a/.changeset/remaining-string-literals.md
+++ b/.changeset/remaining-string-literals.md
@@ -1,0 +1,6 @@
+---
+"@pokemon-lib-ts/core": patch
+"@pokemon-lib-ts/gen2": patch
+---
+
+Replace remaining raw weather and type string literals with CORE_WEATHER_IDS and CORE_TYPE_IDS constants in damage-utils.ts and Gen2Weather.ts.

--- a/packages/core/src/logic/damage-utils.ts
+++ b/packages/core/src/logic/damage-utils.ts
@@ -1,3 +1,4 @@
+import { CORE_TYPE_IDS, CORE_WEATHER_IDS } from "../constants/reference-ids";
 import type { PokemonType } from "../entities/types";
 import type { WeatherType } from "../entities/weather";
 
@@ -72,14 +73,14 @@ export function getWeatherDamageModifier(
 ): number {
   if (!weather) return 1.0;
 
-  if (weather === "rain" || weather === "heavy-rain") {
-    if (moveType === "water") return 1.5;
-    if (moveType === "fire") return weather === "heavy-rain" ? 0 : 0.5;
+  if (weather === CORE_WEATHER_IDS.rain || weather === CORE_WEATHER_IDS.heavyRain) {
+    if (moveType === CORE_TYPE_IDS.water) return 1.5;
+    if (moveType === CORE_TYPE_IDS.fire) return weather === CORE_WEATHER_IDS.heavyRain ? 0 : 0.5;
   }
 
-  if (weather === "sun" || weather === "harsh-sun") {
-    if (moveType === "fire") return 1.5;
-    if (moveType === "water") return weather === "harsh-sun" ? 0 : 0.5;
+  if (weather === CORE_WEATHER_IDS.sun || weather === CORE_WEATHER_IDS.harshSun) {
+    if (moveType === CORE_TYPE_IDS.fire) return 1.5;
+    if (moveType === CORE_TYPE_IDS.water) return weather === CORE_WEATHER_IDS.harshSun ? 0 : 0.5;
   }
 
   return 1.0;

--- a/packages/gen2/src/Gen2Weather.ts
+++ b/packages/gen2/src/Gen2Weather.ts
@@ -1,8 +1,13 @@
 import type { BattleState, WeatherEffectResult } from "@pokemon-lib-ts/battle";
 import type { PokemonType, WeatherType } from "@pokemon-lib-ts/core";
+import { CORE_TYPE_IDS, CORE_WEATHER_IDS } from "@pokemon-lib-ts/core";
 
 /** Types immune to sandstorm damage in Gen 2 */
-const SANDSTORM_IMMUNE_TYPES: readonly PokemonType[] = ["rock", "ground", "steel"];
+const SANDSTORM_IMMUNE_TYPES: readonly PokemonType[] = [
+  CORE_TYPE_IDS.rock,
+  CORE_TYPE_IDS.ground,
+  CORE_TYPE_IDS.steel,
+];
 
 /**
  * Get the weather-based damage modifier for a move type.
@@ -23,14 +28,14 @@ const SANDSTORM_IMMUNE_TYPES: readonly PokemonType[] = ["rock", "ground", "steel
  * @returns The damage multiplier (1.5, 0.5, or 1)
  */
 export function getWeatherDamageModifier(moveType: PokemonType, weather: WeatherType): number {
-  if (weather === "rain") {
-    if (moveType === "water") return 1.5;
-    if (moveType === "fire") return 0.5;
+  if (weather === CORE_WEATHER_IDS.rain) {
+    if (moveType === CORE_TYPE_IDS.water) return 1.5;
+    if (moveType === CORE_TYPE_IDS.fire) return 0.5;
   }
 
-  if (weather === "sun") {
-    if (moveType === "fire") return 1.5;
-    if (moveType === "water") return 0.5;
+  if (weather === CORE_WEATHER_IDS.sun) {
+    if (moveType === CORE_TYPE_IDS.fire) return 1.5;
+    if (moveType === CORE_TYPE_IDS.water) return 0.5;
   }
 
   return 1;
@@ -49,7 +54,7 @@ export function getWeatherDamageModifier(moveType: PokemonType, weather: Weather
  */
 export function isWeatherImmune(types: readonly PokemonType[], weather: WeatherType): boolean {
   // Only sandstorm has immunities (because only sandstorm deals end-of-turn damage)
-  if (weather !== "sand") return false;
+  if (weather !== CORE_WEATHER_IDS.sand) return false;
 
   return types.some((type) => SANDSTORM_IMMUNE_TYPES.includes(type));
 }
@@ -68,7 +73,7 @@ export function applyGen2WeatherEffects(state: BattleState): WeatherEffectResult
   const results: WeatherEffectResult[] = [];
 
   // No weather or non-damaging weather
-  if (!state.weather || state.weather.type !== "sand") {
+  if (!state.weather || state.weather.type !== CORE_WEATHER_IDS.sand) {
     return results;
   }
 
@@ -78,7 +83,7 @@ export function applyGen2WeatherEffects(state: BattleState): WeatherEffectResult
       if (!active) continue;
 
       // Check immunity
-      if (isWeatherImmune(active.types, "sand")) continue;
+      if (isWeatherImmune(active.types, CORE_WEATHER_IDS.sand)) continue;
 
       // Calculate 1/8 max HP damage (minimum 1)
       const maxHp = active.pokemon.calculatedStats?.hp ?? active.pokemon.currentHp;


### PR DESCRIPTION
## Summary

- Replace raw weather strings (`"rain"`, `"sun"`, `"sand"`, `"heavy-rain"`, `"harsh-sun"`) with `CORE_WEATHER_IDS.*` in `core/logic/damage-utils.ts` and `gen2/Gen2Weather.ts`
- Replace raw type strings (`"water"`, `"fire"`, `"rock"`, `"ground"`, `"steel"`) with `CORE_TYPE_IDS.*`
- Completes the string-literal-to-constant migration started in PR #1088

## Test plan

- [x] Core package tests pass
- [x] Gen2 package tests pass
- [x] `npm run typecheck` passes
- [x] Biome clean
- [x] Zero remaining raw weather/type string comparisons in any src/ file

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal constants for weather and type identifiers across packages to improve code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->