### PR TITLE
test: remove stale type-chart casts from gen5-gen9 tests

### DIFF
--- a/packages/gen5/tests/abilities-correctness-audit.test.ts
+++ b/packages/gen5/tests/abilities-correctness-audit.test.ts
@@ -989,14 +989,8 @@ describe("Type Gems -- Gen 5 uses 1.5x boost (NOT Gen 6+'s 1.3x)", () => {
         isCrit: false,
       };
 
-      const resultBase = calculateGen5Damage(
-        ctxBase,
-        GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-      );
-      const resultGem = calculateGen5Damage(
-        ctxGem,
-        GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-      );
+      const resultBase = calculateGen5Damage(ctxBase, GEN5_TYPE_CHART);
+      const resultGem = calculateGen5Damage(ctxGem, GEN5_TYPE_CHART);
 
       // Gem multiplies base power by 1.5 before the formula runs; final damage should be > base damage.
       // Source: references/pokemon-showdown/data/mods/gen5/conditions.ts -- chainModify(1.5)
@@ -1051,7 +1045,7 @@ describe("Type Gems -- Gen 5 uses 1.5x boost (NOT Gen 6+'s 1.3x)", () => {
         rng: new SeededRandom(42),
         isCrit: false,
       };
-      calculateGen5Damage(ctx, GEN5_TYPE_CHART as Record<string, Record<string, number>>);
+      calculateGen5Damage(ctx, GEN5_TYPE_CHART);
 
       // Gem should NOT be consumed when type doesn't match
       expect(attackerWithFireGem.pokemon.heldItem).toBe(itemIds.fireGem);
@@ -1257,14 +1251,8 @@ describe("Eviolite -- 1.5x boost to Def and SpDef for NFE holders", () => {
         isCrit: false,
       };
 
-      const resultNoItem = calculateGen5Damage(
-        ctxNoItem,
-        GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-      );
-      const resultEviolite = calculateGen5Damage(
-        ctxEviolite,
-        GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-      );
+      const resultNoItem = calculateGen5Damage(ctxNoItem, GEN5_TYPE_CHART);
+      const resultEviolite = calculateGen5Damage(ctxEviolite, GEN5_TYPE_CHART);
 
       // Eviolite boosts Defense by 1.5x, so damage with Eviolite must be lower
       // Source: Gen5DamageCalc.ts line ~383-384 -- floor(baseStat * 150 / 100)

--- a/packages/gen5/tests/cloud-nine-suppression.test.ts
+++ b/packages/gen5/tests/cloud-nine-suppression.test.ts
@@ -287,7 +287,7 @@ describe("Gen5 Cloud Nine damage calc integration", () => {
     // Seed 12345 for deterministic RNG
     const rainResult = calculateGen5Damage(
       createDamageContext({ attacker, defender, move: waterMove, state: rainState, seed: 12345 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
     const noWeatherResult = calculateGen5Damage(
       createDamageContext({
@@ -297,7 +297,7 @@ describe("Gen5 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 12345,
       }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // With Cloud Nine: rain boost is suppressed, so damage equals no-weather damage
@@ -328,7 +328,7 @@ describe("Gen5 Cloud Nine damage calc integration", () => {
 
     const sunResult = calculateGen5Damage(
       createDamageContext({ attacker, defender, move: fireMove, state: sunState, seed: 99999 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
     const noWeatherResult = calculateGen5Damage(
       createDamageContext({
@@ -338,7 +338,7 @@ describe("Gen5 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 99999,
       }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // With Air Lock: sun boost is suppressed, so damage equals no-weather damage
@@ -368,7 +368,7 @@ describe("Gen5 Cloud Nine damage calc integration", () => {
 
     const rainResult = calculateGen5Damage(
       createDamageContext({ attacker, defender, move: waterMove, state: rainState, seed: 12345 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
     const noWeatherResult = calculateGen5Damage(
       createDamageContext({
@@ -378,7 +378,7 @@ describe("Gen5 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 12345,
       }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // Without suppression: rain DOES boost Water damage (should be > no-weather)

--- a/packages/gen5/tests/damage-calc.test.ts
+++ b/packages/gen5/tests/damage-calc.test.ts
@@ -249,10 +249,7 @@ describe("Gen 5 damage calc -- status moves", () => {
     const ctx = createDamageContext({
       move: createSyntheticMove({ id: MOVES.toxic, category: MOVE_CATEGORIES.status, power: null }),
     });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: references/pokemon-showdown/sim/battle-actions.ts -- status moves have power=null, return 0 damage; effectiveness stays 1 (not immune)
     expect(result.damage).toBe(0);
     expect(result.effectiveness).toBe(1);
@@ -263,10 +260,7 @@ describe("Gen 5 damage calc -- status moves", () => {
     const ctx = createDamageContext({
       move: createSyntheticMove({ power: 0 }),
     });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: references/pokemon-showdown/sim/battle-actions.ts -- power 0 skips all damage calc, returns 0
     expect(result.damage).toBe(0);
   });
@@ -297,10 +291,7 @@ describe("Gen 5 damage calc -- base formula", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: seeded RNG roll yields the exact fixed outcome for this case.
     expect(result.damage).toBe(33);
   });
@@ -320,10 +311,7 @@ describe("Gen 5 damage calc -- base formula", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(190);
   });
 });
@@ -354,10 +342,7 @@ describe("Gen 5 damage calc -- STAB", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // STAB range: 30-36 (vs non-STAB 20-24)
     expect(result.damage).toBeGreaterThanOrEqual(30);
     expect(result.damage).toBeLessThanOrEqual(36);
@@ -384,10 +369,7 @@ describe("Gen 5 damage calc -- STAB", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Adaptability STAB range: 40-48 (vs normal STAB 30-36, vs no STAB 20-24)
     expect(result.damage).toBeGreaterThanOrEqual(40);
     expect(result.damage).toBeLessThanOrEqual(48);
@@ -411,10 +393,7 @@ describe("Gen 5 damage calc -- type effectiveness", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: Showdown type chart -- Fire vs Grass = 2x (super effective)
     expect(result.effectiveness).toBe(2);
     // With STAB + SE: base 24, random 20-24, STAB -> 30-36, SE -> 60-72
@@ -434,10 +413,7 @@ describe("Gen 5 damage calc -- type effectiveness", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: Showdown type chart -- Fire vs Water = 0.5x (not very effective)
     expect(result.effectiveness).toBe(0.5);
     expect(result.damage).toBeGreaterThanOrEqual(15);
@@ -454,10 +430,7 @@ describe("Gen 5 damage calc -- type effectiveness", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: Showdown type chart -- Normal vs Ghost = 0x (immune); damage 0, effectiveness 0
     expect(result.damage).toBe(0);
     expect(result.effectiveness).toBe(0);
@@ -484,10 +457,7 @@ describe("Gen 5 damage calc -- critical hit", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move, isCrit: true });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: references/pokemon-showdown/sim/battle-actions.ts -- isCrit passthrough from ctx.isCrit
     expect(result.isCrit).toBe(true);
     // Source: seeded RNG roll yields the exact fixed outcome for this case.
@@ -509,10 +479,7 @@ describe("Gen 5 damage calc -- critical hit", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move, isCrit: true });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Crit + STAB fixed outcome for this seed.
     expect(result.damage).toBe(67);
   });
@@ -537,10 +504,7 @@ describe("Gen 5 damage calc -- burn penalty", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: seeded RNG roll yields the exact fixed outcome for this case.
     expect(result.damage).toBe(16);
   });
@@ -565,10 +529,7 @@ describe("Gen 5 damage calc -- burn penalty", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: seeded RNG roll yields the exact fixed outcome for this case.
     expect(result.damage).toBe(22);
   });
@@ -584,10 +545,7 @@ describe("Gen 5 damage calc -- burn penalty", () => {
       category: MOVE_CATEGORIES.special,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: seeded RNG roll yields the exact fixed outcome for this case.
     expect(result.damage).toBe(33);
   });
@@ -632,10 +590,7 @@ describe("Gen 5 damage calc -- Gen 5 damage floor", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBeGreaterThanOrEqual(1);
   });
 });
@@ -668,10 +623,7 @@ describe("Gen 5 damage calc -- weather", () => {
       weather: { type: CORE_WEATHER_IDS.rain, turnsLeft: 5, source: ABILITIES.drizzle },
     });
     const ctx = createDamageContext({ attacker, defender, move, state });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Rain-boosted fixed outcome for this seed.
     expect(result.damage).toBe(33);
   });
@@ -690,10 +642,7 @@ describe("Gen 5 damage calc -- weather", () => {
       weather: { type: CORE_WEATHER_IDS.sun, turnsLeft: 5, source: ABILITIES.drought },
     });
     const ctx = createDamageContext({ attacker, defender, move, state });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Sun-boosted fire fixed outcome for this seed.
     expect(result.damage).toBe(33);
   });
@@ -713,10 +662,7 @@ describe("Gen 5 damage calc -- weather", () => {
       weather: { type: CORE_WEATHER_IDS.sun, turnsLeft: 5, source: ABILITIES.drought },
     });
     const ctx = createDamageContext({ attacker, defender, move, state });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Sun-nerfed water fixed outcome for this seed.
     expect(result.damage).toBe(11);
   });
@@ -742,10 +688,7 @@ describe("Gen 5 damage calc -- Life Orb", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: seeded RNG roll yields the exact fixed outcome for this case.
     expect(result.damage).toBe(43);
   });
@@ -785,10 +728,7 @@ describe("Gen 5 damage calc -- spread modifier", () => {
     // Override target to make it a spread move
     const spreadMoveWithTarget = { ...spreadMove, target: "all-adjacent-foes" } as MoveData;
     const ctx2 = createDamageContext({ attacker, defender, move: spreadMoveWithTarget, state });
-    const result = calculateGen5Damage(
-      ctx2,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx2, GEN5_TYPE_CHART);
     // Source: seeded RNG roll yields the exact fixed outcome for this case.
     expect(result.damage).toBe(24);
   });
@@ -815,10 +755,7 @@ describe("Gen 5 damage calc -- Gem boost", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: seeded RNG roll yields the exact fixed outcome for this case.
     expect(result.damage).toBe(48);
   });
@@ -844,10 +781,7 @@ describe("Gen 5 damage calc -- special moves", () => {
       category: MOVE_CATEGORIES.special,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: seeded RNG roll yields the exact fixed outcome for this case.
     expect(result.damage).toBe(48);
   });
@@ -873,10 +807,7 @@ describe("Gen 5 damage calc -- ability type immunities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: references/pokemon-showdown/sim/battle-actions.ts -- Levitate grants Ground immunity; effectiveness 0
     expect(result.damage).toBe(0);
     expect(result.effectiveness).toBe(0);
@@ -895,10 +826,7 @@ describe("Gen 5 damage calc -- ability type immunities", () => {
       category: MOVE_CATEGORIES.special,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: Showdown data/abilities.ts -- Water Absorb blocks Water moves; damage 0, effectiveness 0
     expect(result.damage).toBe(0);
     expect(result.effectiveness).toBe(0);
@@ -918,10 +846,7 @@ describe("Gen 5 damage calc -- ability type immunities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: Showdown type chart -- Ground vs Psychic = 1x; Mold Breaker bypasses Levitate so normal calc applies
     expect(result.damage).toBe(34);
     expect(result.effectiveness).toBe(1);
@@ -941,10 +866,7 @@ describe("Gen 5 damage calc -- ability type immunities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(34);
   });
 
@@ -962,10 +884,7 @@ describe("Gen 5 damage calc -- ability type immunities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(34);
   });
 });
@@ -989,10 +908,7 @@ describe("Gen 5 damage calc -- stat modifier abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(43);
   });
 
@@ -1006,10 +922,7 @@ describe("Gen 5 damage calc -- stat modifier abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(43);
   });
 
@@ -1026,10 +939,7 @@ describe("Gen 5 damage calc -- stat modifier abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(32);
   });
 
@@ -1043,10 +953,7 @@ describe("Gen 5 damage calc -- stat modifier abilities", () => {
       category: MOVE_CATEGORIES.special,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(32);
   });
 
@@ -1060,10 +967,7 @@ describe("Gen 5 damage calc -- stat modifier abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(32);
   });
 
@@ -1081,10 +985,7 @@ describe("Gen 5 damage calc -- stat modifier abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Guts 1.5x + no burn penalty: range 29-35
     expect(result.damage).toBe(32);
   });
@@ -1107,10 +1008,7 @@ describe("Gen 5 damage calc -- stat modifier abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(12);
   });
 });
@@ -1133,10 +1031,7 @@ describe("Gen 5 damage calc -- defense modifiers", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(15);
   });
 
@@ -1153,10 +1048,7 @@ describe("Gen 5 damage calc -- defense modifiers", () => {
       weather: { type: CORE_WEATHER_IDS.sand, turnsLeft: 5, source: ABILITIES.sandStream },
     });
     const ctx = createDamageContext({ attacker, defender, move, state });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Fire vs Rock = 0.5x, but we care about the SpDef boost here
     // Source: Showdown type chart -- Fire vs Rock = 0.5x (not very effective)
     // Source: Gen 5 formula: levelFactor=22, power=50, spAtk=100, spDef=floor(100*1.5)=150(sand boost)
@@ -1189,10 +1081,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       weather: { type: CORE_WEATHER_IDS.rain, turnsLeft: 5, source: ABILITIES.drizzle },
     });
     const ctx = createDamageContext({ attacker, defender, move, state });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // SolarBeam is halved under rain in Gen 5; with seed=42 the exact result is 9.
     expect(result.damage).toBe(26);
   });
@@ -1209,10 +1098,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(32);
   });
 
@@ -1226,10 +1112,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Power 50 * 4915/4096 ~= 59 -> slightly more damage than base
     expect(result.damage).toBeGreaterThan(20);
   });
@@ -1244,10 +1127,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBeGreaterThan(20);
   });
 
@@ -1266,10 +1146,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Blaze 1.5x -> Power 75
     expect(result.damage).toBe(32);
   });
@@ -1286,10 +1163,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Acrobatics doubles: 55 -> 110 BP
     expect(result.damage).toBeGreaterThan(30);
   });
@@ -1305,10 +1179,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       flags: { punch: true },
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Power 75 * 1.2 = 90
     expect(result.damage).toBeGreaterThan(30);
   });
@@ -1324,10 +1195,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       effect: { type: "recoil", percent: 33 },
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Power 80 * 1.2 = 96
     expect(result.damage).toBeGreaterThan(30);
   });
@@ -1349,10 +1217,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(32);
   });
 
@@ -1367,10 +1232,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Normal vs Fire = 1x (neutral), not super effective
     // Source: Showdown type chart -- Normal vs Fire = 1x (neutral); Normalize changed Fire move to Normal type
     expect(result.effectiveness).toBe(1);
@@ -1390,10 +1252,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Power 80 * 1.25 = 100
     expect(result.damage).toBeGreaterThan(30);
   });
@@ -1412,10 +1271,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Power 80 * 0.75 = 60
     expect(result.damage).toBe(26);
   });
@@ -1430,10 +1286,7 @@ describe("Gen 5 damage calc -- base power mods", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Power 50 * 1.25 = 62. Fire vs Dry Skin's water-like typing isn't relevant here.
     expect(result.damage).toBeGreaterThan(20);
   });
@@ -1454,10 +1307,7 @@ describe("Gen 5 damage calc -- defender abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Attack halved: Atk=50 effectively
     expect(result.damage).toBe(12);
   });
@@ -1472,10 +1322,7 @@ describe("Gen 5 damage calc -- defender abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Power halved: 50 -> 25
     expect(result.damage).toBe(12);
   });
@@ -1494,10 +1341,7 @@ describe("Gen 5 damage calc -- defender abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Fire vs Normal = 1x (neutral), Wonder Guard blocks
     // Source: Showdown data/abilities.ts -- Wonder Guard: blocks all non-SE moves; damage 0
     expect(result.damage).toBe(0);
@@ -1513,10 +1357,7 @@ describe("Gen 5 damage calc -- defender abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Fire vs Water = 0.5x, Tinted Lens doubles it back to ~1x
     // Source: Showdown type chart -- Fire vs Water = 0.5x; Tinted Lens doubles NVE damage but does not change effectiveness value
     expect(result.effectiveness).toBe(0.5);
@@ -1537,10 +1378,7 @@ describe("Gen 5 damage calc -- defender abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // SE 2x then Filter 0.75x = effective 1.5x
     // Source: Showdown type chart -- Fire vs Grass = 2x; Filter reduces damage but does not change effectiveness value
     expect(result.effectiveness).toBe(2);
@@ -1561,10 +1399,7 @@ describe("Gen 5 damage calc -- defender abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: Showdown type chart -- Fire vs Grass = 2x; Solid Rock reduces damage but does not change effectiveness value
     expect(result.effectiveness).toBe(2);
     expect(result.damage).toBeLessThan(48);
@@ -1580,10 +1415,7 @@ describe("Gen 5 damage calc -- defender abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(33);
   });
 
@@ -1601,10 +1433,7 @@ describe("Gen 5 damage calc -- defender abilities", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Def 100 -> 150 from Marvel Scale
     expect(result.damage).toBe(15);
   });
@@ -1625,10 +1454,7 @@ describe("Gen 5 damage calc -- final modifier items", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: Showdown type chart -- Fire vs Grass = 2x (super effective); Expert Belt applies after
     expect(result.effectiveness).toBe(2);
     // SE 2x + Expert Belt ~1.2x
@@ -1645,10 +1471,7 @@ describe("Gen 5 damage calc -- final modifier items", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBeGreaterThan(20);
   });
 
@@ -1662,10 +1485,7 @@ describe("Gen 5 damage calc -- final modifier items", () => {
       category: MOVE_CATEGORIES.special,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBeGreaterThan(20);
   });
 
@@ -1683,10 +1503,7 @@ describe("Gen 5 damage calc -- final modifier items", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Without Life Orb: fixed outcome for this seed.
     expect(result.damage).toBe(22);
   });
@@ -1702,10 +1519,7 @@ describe("Gen 5 damage calc -- final modifier items", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move, isCrit: true });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: references/pokemon-showdown/sim/battle-actions.ts -- isCrit passthrough from ctx.isCrit; Sniper sets 3x modifier
     expect(result.isCrit).toBe(true);
     expect(result.damage).toBe(67);
@@ -1725,10 +1539,7 @@ describe("Gen 5 damage calc -- final modifier items", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Source: Showdown -- Magnet Rise grants Ground immunity; damage 0, effectiveness 0
     expect(result.damage).toBe(0);
     expect(result.effectiveness).toBe(0);
@@ -1748,10 +1559,7 @@ describe("Gen 5 damage calc -- final modifier items", () => {
       category: MOVE_CATEGORIES.physical,
     });
     const ctx = createDamageContext({ attacker, defender, move });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     // Dragon vs Psychic = 1x, with Adamant Orb boost
     expect(result.damage).toBeGreaterThan(30);
   });
@@ -1792,10 +1600,7 @@ describe("Sheer Force power boost in damage calc", () => {
       effect: { type: "status-chance", status: STATUSES.burn, chance: 10 },
     });
     const ctx = createDamageContext({ attacker, defender, move, seed: 42 });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(49);
   });
 
@@ -1826,10 +1631,7 @@ describe("Sheer Force power boost in damage calc", () => {
       effect: null,
     });
     const ctx = createDamageContext({ attacker, defender, move, seed: 42 });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(43);
   });
 
@@ -1859,10 +1661,7 @@ describe("Sheer Force power boost in damage calc", () => {
       effect: { type: "status-chance", status: STATUSES.burn, chance: 10 },
     });
     const ctx = createDamageContext({ attacker, defender, move, seed: 42 });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(38);
   });
 });
@@ -1901,10 +1700,7 @@ describe("Gen 5 damage calc -- Unaware vs Simple interaction (regression: #757)"
       power: 50,
     });
     const ctx = createDamageContext({ attacker, defender, move, seed: 42 });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(22);
   });
 
@@ -1934,10 +1730,7 @@ describe("Gen 5 damage calc -- Unaware vs Simple interaction (regression: #757)"
       power: 50,
     });
     const ctx = createDamageContext({ attacker, defender, move, seed: 42 });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(63);
   });
 
@@ -1969,10 +1762,7 @@ describe("Gen 5 damage calc -- Unaware vs Simple interaction (regression: #757)"
       power: 50,
     });
     const ctx = createDamageContext({ attacker, defender, move, seed: 42 });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(43);
   });
 
@@ -2004,10 +1794,7 @@ describe("Gen 5 damage calc -- Unaware vs Simple interaction (regression: #757)"
       power: 50,
     });
     const ctx = createDamageContext({ attacker, defender, move, seed: 42 });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(63);
   });
 });

--- a/packages/gen5/tests/gen5-damage-fixes.test.ts
+++ b/packages/gen5/tests/gen5-damage-fixes.test.ts
@@ -192,7 +192,7 @@ function createDamageContextFixture(overrides: {
   };
 }
 
-const typeChart = GEN5_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN5_TYPE_CHART;
 
 // ---------------------------------------------------------------------------
 // #643 — Type-boost items and Plates use pokeRound, not floor multiply

--- a/packages/gen5/tests/sheer-force-whitelist.test.ts
+++ b/packages/gen5/tests/sheer-force-whitelist.test.ts
@@ -306,10 +306,7 @@ describe("Sheer Force + Tri Attack in damage calc", () => {
     });
     const move = dataManager.getMove(moveIds.triAttack);
     const ctx = createDamageContext({ attacker, defender, move, seed: DEFAULT_DAMAGE_SEED });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(44);
   });
 
@@ -335,10 +332,7 @@ describe("Sheer Force + Tri Attack in damage calc", () => {
     });
     const move = dataManager.getMove(moveIds.triAttack);
     const ctx = createDamageContext({ attacker, defender, move, seed: DEFAULT_DAMAGE_SEED });
-    const result = calculateGen5Damage(
-      ctx,
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const result = calculateGen5Damage(ctx, GEN5_TYPE_CHART);
     expect(result.damage).toBe(34);
   });
 });

--- a/packages/gen5/tests/simple-unaware-priority.test.ts
+++ b/packages/gen5/tests/simple-unaware-priority.test.ts
@@ -165,7 +165,7 @@ function createDamageContext(overrides: {
   };
 }
 
-const typeChart = GEN5_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN5_TYPE_CHART;
 
 // ---------------------------------------------------------------------------
 // #757: Simple/Unaware priority order

--- a/packages/gen5/tests/type-resist-berries.test.ts
+++ b/packages/gen5/tests/type-resist-berries.test.ts
@@ -181,7 +181,7 @@ function createDamageContext(overrides: {
   };
 }
 
-const typeChart = GEN5_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN5_TYPE_CHART;
 
 // ===========================================================================
 // Type Resist Berry -- basic activation

--- a/packages/gen5/tests/wave8-remaining.test.ts
+++ b/packages/gen5/tests/wave8-remaining.test.ts
@@ -234,13 +234,13 @@ describe("Venoshock base power doubling", () => {
 
     const poisoned = calculateGen5Damage(
       createDamageContext({ attacker, defender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     const healthyDefender = createSyntheticOnFieldPokemon({ spDefense: 100 });
     const normal = calculateGen5Damage(
       createDamageContext({ attacker, defender: healthyDefender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // Poisoned damage should be exactly 2x normal damage (base power doubles 65 -> 130)
@@ -260,13 +260,13 @@ describe("Venoshock base power doubling", () => {
 
     const badlyPoisoned = calculateGen5Damage(
       createDamageContext({ attacker, defender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     const healthyDefender = createSyntheticOnFieldPokemon({ spDefense: 100 });
     const normal = calculateGen5Damage(
       createDamageContext({ attacker, defender: healthyDefender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     expect(badlyPoisoned.damage / normal.damage).toBeCloseTo(2, 0);
@@ -280,7 +280,7 @@ describe("Venoshock base power doubling", () => {
 
     const result = calculateGen5Damage(
       createDamageContext({ attacker, defender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // With paralyzed target (non-poison status), should NOT double
@@ -290,7 +290,7 @@ describe("Venoshock base power doubling", () => {
     });
     const paralyzed = calculateGen5Damage(
       createDamageContext({ attacker, defender: paralyzedDefender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // Paralysis is NOT poison, so Venoshock should not double
@@ -323,12 +323,12 @@ describe("Hex base power doubling", () => {
 
     const normal = calculateGen5Damage(
       createDamageContext({ attacker, defender: healthyDefender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     const statusd = calculateGen5Damage(
       createDamageContext({ attacker, defender: burnedFireDefender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     expect(statusd.damage / normal.damage).toBeCloseTo(2, 0);
@@ -351,12 +351,12 @@ describe("Hex base power doubling", () => {
 
     const normal = calculateGen5Damage(
       createDamageContext({ attacker, defender: healthyDefender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     const paralyzed = calculateGen5Damage(
       createDamageContext({ attacker, defender: paralyzedDefender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     expect(paralyzed.damage / normal.damage).toBeCloseTo(2, 0);
@@ -378,12 +378,12 @@ describe("Hex base power doubling", () => {
 
     const hexDmg = calculateGen5Damage(
       createDamageContext({ attacker, defender: healthyDefender, move, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     const genericDmg = calculateGen5Damage(
       createDamageContext({ attacker, defender: healthyDefender, move: genericGhost, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // Without status, Hex should deal the same damage as any 50 BP Ghost move
@@ -415,12 +415,12 @@ describe("Chip Away ignoring defense stages", () => {
 
     const vsBoosted = calculateGen5Damage(
       createDamageContext({ attacker, defender: boostedDefender, move: chipAway, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     const vsNormal = calculateGen5Damage(
       createDamageContext({ attacker, defender: normalDefender, move: chipAway, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // Chip Away should deal the same damage regardless of defense stages
@@ -445,12 +445,12 @@ describe("Chip Away ignoring defense stages", () => {
 
     const vsDropped = calculateGen5Damage(
       createDamageContext({ attacker, defender: droppedDefender, move: chipAway, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     const vsNormal = calculateGen5Damage(
       createDamageContext({ attacker, defender: normalDefender, move: chipAway, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // Chip Away ignores both positive AND negative defense stages
@@ -478,12 +478,12 @@ describe("Sacred Sword ignoring defense stages", () => {
 
     const vsBoosted = calculateGen5Damage(
       createDamageContext({ attacker, defender: boostedDefender, move: sacredSword, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     const vsNormal = calculateGen5Damage(
       createDamageContext({ attacker, defender: normalDefender, move: sacredSword, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // Sacred Sword should deal the same damage regardless of defense stages
@@ -508,12 +508,12 @@ describe("Sacred Sword ignoring defense stages", () => {
 
     const vsBoosted = calculateGen5Damage(
       createDamageContext({ attacker, defender: boostedDefender, move: closeCombat, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     const vsNormal = calculateGen5Damage(
       createDamageContext({ attacker, defender: normalDefender, move: closeCombat, seed: 1 }),
-      GEN5_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN5_TYPE_CHART,
     );
 
     // Close Combat SHOULD be affected by the +3 Defense boost

--- a/packages/gen6/tests/cloud-nine-suppression.test.ts
+++ b/packages/gen6/tests/cloud-nine-suppression.test.ts
@@ -291,7 +291,7 @@ describe("Gen6 Cloud Nine damage calc integration", () => {
 
     const rainResult = calculateGen6Damage(
       createDamageContext({ attacker, defender, move: waterMove, state: rainState, seed: 12345 }),
-      GEN6_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN6_TYPE_CHART,
     );
     const noWeatherResult = calculateGen6Damage(
       createDamageContext({
@@ -301,7 +301,7 @@ describe("Gen6 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 12345,
       }),
-      GEN6_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN6_TYPE_CHART,
     );
 
     // With Cloud Nine: rain boost is suppressed
@@ -329,7 +329,7 @@ describe("Gen6 Cloud Nine damage calc integration", () => {
 
     const sunResult = calculateGen6Damage(
       createDamageContext({ attacker, defender, move: fireMove, state: sunState, seed: 99999 }),
-      GEN6_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN6_TYPE_CHART,
     );
     const noWeatherResult = calculateGen6Damage(
       createDamageContext({
@@ -339,7 +339,7 @@ describe("Gen6 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 99999,
       }),
-      GEN6_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN6_TYPE_CHART,
     );
 
     // With Air Lock: sun boost is suppressed
@@ -367,7 +367,7 @@ describe("Gen6 Cloud Nine damage calc integration", () => {
 
     const sunResult = calculateGen6Damage(
       createDamageContext({ attacker, defender, move: fireMove, state: sunState, seed: 12345 }),
-      GEN6_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN6_TYPE_CHART,
     );
     const noWeatherResult = calculateGen6Damage(
       createDamageContext({
@@ -377,7 +377,7 @@ describe("Gen6 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 12345,
       }),
-      GEN6_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN6_TYPE_CHART,
     );
 
     // Without suppression: sun DOES boost Fire damage

--- a/packages/gen6/tests/coverage-damage-calc.test.ts
+++ b/packages/gen6/tests/coverage-damage-calc.test.ts
@@ -254,7 +254,7 @@ function createSyntheticDamageContext(overrides: {
   };
 }
 
-const typeChart = GEN6_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN6_TYPE_CHART;
 
 // ===========================================================================
 // Weather modifiers

--- a/packages/gen6/tests/damage-abilities.test.ts
+++ b/packages/gen6/tests/damage-abilities.test.ts
@@ -172,7 +172,7 @@ function createDamageContext(overrides: {
   };
 }
 
-const typeChart = GEN6_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN6_TYPE_CHART;
 
 // ---------------------------------------------------------------------------
 // Tough Claws (contact moves get ~1.3x boost)

--- a/packages/gen6/tests/damage-calc-bugfixes.test.ts
+++ b/packages/gen6/tests/damage-calc-bugfixes.test.ts
@@ -180,7 +180,7 @@ function createDamageContext(overrides: {
   };
 }
 
-const typeChart = GEN6_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN6_TYPE_CHART;
 
 // ---------------------------------------------------------------------------
 // #663 — Iron Fist uses pokeRound(power, 4915) instead of Math.floor(power * 1.2)

--- a/packages/gen6/tests/damage-calc.test.ts
+++ b/packages/gen6/tests/damage-calc.test.ts
@@ -212,7 +212,7 @@ function createDamageContext(overrides: {
 }
 
 // Use the Gen6 type chart for all tests
-const typeChart = GEN6_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN6_TYPE_CHART;
 
 // ---------------------------------------------------------------------------
 // pokeRound unit tests

--- a/packages/gen6/tests/gems.test.ts
+++ b/packages/gen6/tests/gems.test.ts
@@ -180,10 +180,7 @@ describe("Gen 6 Gems -- 1.3x boost (nerfed from 1.5x in Gen 5)", () => {
       move: moveWithGem,
       seed: 42,
     });
-    const resultWithGem = calculateGen6Damage(
-      ctxWithGem,
-      GEN6_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const resultWithGem = calculateGen6Damage(ctxWithGem, GEN6_TYPE_CHART);
 
     // Calculate without gem (remove item)
     const attackerNoGem = createSyntheticActivePokemon({
@@ -197,10 +194,7 @@ describe("Gen 6 Gems -- 1.3x boost (nerfed from 1.5x in Gen 5)", () => {
       move: moveNoGem,
       seed: 42,
     });
-    const resultNoGem = calculateGen6Damage(
-      ctxNoGem,
-      GEN6_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const resultNoGem = calculateGen6Damage(ctxNoGem, GEN6_TYPE_CHART);
 
     // Gem damage should be higher due to 1.3x boost.
     // Derivation (seed=42, Showdown Gen 6 formula, Rock resists Normal 0.5x):
@@ -241,10 +235,7 @@ describe("Gen 6 Gems -- 1.3x boost (nerfed from 1.5x in Gen 5)", () => {
       move: moveWithGem,
       seed: 42,
     });
-    const resultWithGem = calculateGen6Damage(
-      ctxWithGem,
-      GEN6_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const resultWithGem = calculateGen6Damage(ctxWithGem, GEN6_TYPE_CHART);
 
     const attackerNoGem = createSyntheticActivePokemon({
       speciesId: FIRE_SPECIES.id,
@@ -257,10 +248,7 @@ describe("Gen 6 Gems -- 1.3x boost (nerfed from 1.5x in Gen 5)", () => {
       move: moveNoGem,
       seed: 42,
     });
-    const resultNoGem = calculateGen6Damage(
-      ctxNoGem,
-      GEN6_TYPE_CHART as Record<string, Record<string, number>>,
-    );
+    const resultNoGem = calculateGen6Damage(ctxNoGem, GEN6_TYPE_CHART);
 
     expect(resultNoGem.damage).toBe(25);
     expect(resultWithGem.damage).toBe(resultNoGem.damage);
@@ -281,7 +269,7 @@ describe("Gen 6 Gems -- 1.3x boost (nerfed from 1.5x in Gen 5)", () => {
     const move = TACKLE;
 
     const ctx = createDamageContext({ attacker, defender, move, seed: 42 });
-    calculateGen6Damage(ctx, GEN6_TYPE_CHART as Record<string, Record<string, number>>);
+    calculateGen6Damage(ctx, GEN6_TYPE_CHART);
 
     expect(ctx.attacker.pokemon.heldItem).toBeNull();
   });

--- a/packages/gen6/tests/integration/integration.test.ts
+++ b/packages/gen6/tests/integration/integration.test.ts
@@ -262,7 +262,7 @@ function createItemContext(overrides: {
   };
 }
 
-const typeChart = GEN6_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN6_TYPE_CHART;
 
 // ===========================================================================
 // Integration Test Scenarios

--- a/packages/gen6/tests/item-correctness.test.ts
+++ b/packages/gen6/tests/item-correctness.test.ts
@@ -158,7 +158,7 @@ function createDamageContext(overrides: {
   };
 }
 
-const typeChart = GEN6_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN6_TYPE_CHART;
 
 // ===========================================================================
 // Issue #610: Eviolite treated as non-removable by Knock Off

--- a/packages/gen6/tests/terrain.test.ts
+++ b/packages/gen6/tests/terrain.test.ts
@@ -187,7 +187,7 @@ function createDamageContext(overrides: {
   };
 }
 
-const typeChart = GEN6_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN6_TYPE_CHART;
 
 // ===========================================================================
 // getTerrainDamageModifier — pure function tests

--- a/packages/gen6/tests/type-resist-berries.test.ts
+++ b/packages/gen6/tests/type-resist-berries.test.ts
@@ -192,7 +192,7 @@ function createDamageContext(overrides: {
   };
 }
 
-const typeChart = GEN6_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN6_TYPE_CHART;
 
 // ===========================================================================
 // Type Resist Berry -- basic activation

--- a/packages/gen7/tests/cloud-nine-suppression.test.ts
+++ b/packages/gen7/tests/cloud-nine-suppression.test.ts
@@ -296,7 +296,7 @@ describe("Gen7 Cloud Nine damage calc integration", () => {
     // Seed 12345 for deterministic RNG
     const sunResult = calculateGen7Damage(
       createDamageContext({ attacker, defender, move: fireMove, state: sunState, seed: 12345 }),
-      GEN7_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN7_TYPE_CHART,
     );
     const noWeatherResult = calculateGen7Damage(
       createDamageContext({
@@ -306,7 +306,7 @@ describe("Gen7 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 12345,
       }),
-      GEN7_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN7_TYPE_CHART,
     );
 
     // With Cloud Nine: sun boost is suppressed, so damage equals no-weather damage
@@ -336,7 +336,7 @@ describe("Gen7 Cloud Nine damage calc integration", () => {
 
     const sunResult = calculateGen7Damage(
       createDamageContext({ attacker, defender, move: fireMove, state: sunState, seed: 12345 }),
-      GEN7_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN7_TYPE_CHART,
     );
     const noWeatherResult = calculateGen7Damage(
       createDamageContext({
@@ -346,7 +346,7 @@ describe("Gen7 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 12345,
       }),
-      GEN7_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN7_TYPE_CHART,
     );
 
     // Without suppression: sun DOES boost Fire damage
@@ -374,7 +374,7 @@ describe("Gen7 Cloud Nine damage calc integration", () => {
 
     const rainResult = calculateGen7Damage(
       createDamageContext({ attacker, defender, move: waterMove, state: rainState, seed: 99999 }),
-      GEN7_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN7_TYPE_CHART,
     );
     const noWeatherResult = calculateGen7Damage(
       createDamageContext({
@@ -384,7 +384,7 @@ describe("Gen7 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 99999,
       }),
-      GEN7_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN7_TYPE_CHART,
     );
 
     // With Air Lock: rain boost is suppressed

--- a/packages/gen7/tests/damage-calc.test.ts
+++ b/packages/gen7/tests/damage-calc.test.ts
@@ -260,7 +260,7 @@ function expectSpreadPenaltyMatchesSingleTarget(
 }
 
 // Use the Gen7 type chart for all tests
-const typeChart = GEN7_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN7_TYPE_CHART;
 
 // ---------------------------------------------------------------------------
 // pokeRound unit tests

--- a/packages/gen7/tests/type-chart.test.ts
+++ b/packages/gen7/tests/type-chart.test.ts
@@ -65,7 +65,7 @@ describe("Gen7TypeChart", () => {
      * Helper to look up type effectiveness from the chart.
      */
     function getEffectiveness(attackType: string, defenseType: string): number {
-      const chart = GEN7_TYPE_CHART as Record<string, Record<string, number>>;
+      const chart = GEN7_TYPE_CHART;
       return chart[attackType]?.[defenseType] ?? 1;
     }
 

--- a/packages/gen8/tests/cloud-nine-suppression.test.ts
+++ b/packages/gen8/tests/cloud-nine-suppression.test.ts
@@ -295,7 +295,7 @@ describe("Gen8 Cloud Nine damage calc integration", () => {
     // Seed 12345 for deterministic RNG
     const sunResult = calculateGen8Damage(
       createDamageContext({ attacker, defender, move: fireMove, state: sunState, seed: 12345 }),
-      GEN8_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN8_TYPE_CHART,
     );
     const noWeatherResult = calculateGen8Damage(
       createDamageContext({
@@ -305,7 +305,7 @@ describe("Gen8 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 12345,
       }),
-      GEN8_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN8_TYPE_CHART,
     );
 
     // With Cloud Nine: sun boost is suppressed, so damage equals no-weather damage
@@ -335,7 +335,7 @@ describe("Gen8 Cloud Nine damage calc integration", () => {
 
     const rainResult = calculateGen8Damage(
       createDamageContext({ attacker, defender, move: waterMove, state: rainState, seed: 12345 }),
-      GEN8_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN8_TYPE_CHART,
     );
     const noWeatherResult = calculateGen8Damage(
       createDamageContext({
@@ -345,7 +345,7 @@ describe("Gen8 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 12345,
       }),
-      GEN8_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN8_TYPE_CHART,
     );
 
     // Without suppression: rain DOES boost Water damage
@@ -373,7 +373,7 @@ describe("Gen8 Cloud Nine damage calc integration", () => {
 
     const rainResult = calculateGen8Damage(
       createDamageContext({ attacker, defender, move: waterMove, state: rainState, seed: 99999 }),
-      GEN8_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN8_TYPE_CHART,
     );
     const noWeatherResult = calculateGen8Damage(
       createDamageContext({
@@ -383,7 +383,7 @@ describe("Gen8 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 99999,
       }),
-      GEN8_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN8_TYPE_CHART,
     );
 
     // With Air Lock: rain boost is suppressed

--- a/packages/gen8/tests/coverage-gaps-2.test.ts
+++ b/packages/gen8/tests/coverage-gaps-2.test.ts
@@ -320,7 +320,7 @@ function createStatAbilityContext(overrides: {
   };
 }
 
-const typeChart = GEN8_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN8_TYPE_CHART;
 
 // ===========================================================================
 // 1. Gen8MaxMoves -- getMaxMovePower coverage for all power ranges

--- a/packages/gen8/tests/coverage-gaps-3.test.ts
+++ b/packages/gen8/tests/coverage-gaps-3.test.ts
@@ -236,7 +236,7 @@ function createDamageContext(overrides: {
 
 /** Convenience wrapper: call calculateGen8Damage with the Gen 8 type chart */
 function calcDmg(ctx: DamageContext): ReturnType<typeof calculateGen8Damage> {
-  return calculateGen8Damage(ctx, GEN8_TYPE_CHART as Record<string, Record<string, number>>);
+  return calculateGen8Damage(ctx, GEN8_TYPE_CHART);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gen8/tests/coverage-gaps-4.test.ts
+++ b/packages/gen8/tests/coverage-gaps-4.test.ts
@@ -59,7 +59,7 @@ import {
 import { calculateGen8Damage } from "../src/Gen8DamageCalc";
 import { GEN8_TYPE_CHART } from "../src/Gen8TypeChart";
 
-const typeChart = GEN8_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN8_TYPE_CHART;
 const gen8Data = createGen8DataManager();
 
 const ABILITIES = { ...CORE_ABILITY_IDS, ...GEN8_ABILITY_IDS } as const;

--- a/packages/gen8/tests/coverage-gaps.test.ts
+++ b/packages/gen8/tests/coverage-gaps.test.ts
@@ -344,7 +344,7 @@ function createAbilityContext(overrides: {
   } as AbilityContext;
 }
 
-const typeChart = GEN8_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN8_TYPE_CHART;
 
 // ===========================================================================
 // PRIORITY 1: Gen8DamageCalc.ts uncovered branches

--- a/packages/gen8/tests/damage-calc.test.ts
+++ b/packages/gen8/tests/damage-calc.test.ts
@@ -237,7 +237,7 @@ function createSyntheticDamageContext(overrides: {
 }
 
 // Use the Gen8 type chart for all tests
-const typeChart = GEN8_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN8_TYPE_CHART;
 
 // ---------------------------------------------------------------------------
 // pokeRound unit tests

--- a/packages/gen8/tests/type-chart.test.ts
+++ b/packages/gen8/tests/type-chart.test.ts
@@ -66,7 +66,7 @@ describe("Gen8TypeChart", () => {
      * Helper to look up type effectiveness from the chart.
      */
     function getEffectiveness(attackType: string, defenseType: string): number {
-      const chart = GEN8_TYPE_CHART as Record<string, Record<string, number>>;
+      const chart = GEN8_TYPE_CHART;
       return chart[attackType]?.[defenseType] ?? 1;
     }
 

--- a/packages/gen9/tests/abilities-damage.test.ts
+++ b/packages/gen9/tests/abilities-damage.test.ts
@@ -349,7 +349,7 @@ function createDamageContextFixture(overrides: {
   };
 }
 
-const typeChart = GEN9_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN9_TYPE_CHART;
 
 // ===========================================================================
 // Supreme Overlord

--- a/packages/gen9/tests/cloud-nine-suppression.test.ts
+++ b/packages/gen9/tests/cloud-nine-suppression.test.ts
@@ -301,7 +301,7 @@ describe("Gen9 Cloud Nine damage calc integration", () => {
     // Seed 12345 for deterministic RNG
     const sunResult = calculateGen9Damage(
       createDamageContext({ attacker, defender, move: fireMove, state: sunState, seed: 12345 }),
-      GEN9_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN9_TYPE_CHART,
     );
     const noWeatherResult = calculateGen9Damage(
       createDamageContext({
@@ -311,7 +311,7 @@ describe("Gen9 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 12345,
       }),
-      GEN9_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN9_TYPE_CHART,
     );
 
     // With Cloud Nine: sun boost is suppressed, so damage equals no-weather damage
@@ -341,7 +341,7 @@ describe("Gen9 Cloud Nine damage calc integration", () => {
 
     const sunResult = calculateGen9Damage(
       createDamageContext({ attacker, defender, move: fireMove, state: sunState, seed: 12345 }),
-      GEN9_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN9_TYPE_CHART,
     );
     const noWeatherResult = calculateGen9Damage(
       createDamageContext({
@@ -351,7 +351,7 @@ describe("Gen9 Cloud Nine damage calc integration", () => {
         state: noWeatherState,
         seed: 12345,
       }),
-      GEN9_TYPE_CHART as Record<string, Record<string, number>>,
+      GEN9_TYPE_CHART,
     );
 
     // Without suppression: sun DOES boost Fire damage

--- a/packages/gen9/tests/damage-calc.test.ts
+++ b/packages/gen9/tests/damage-calc.test.ts
@@ -306,7 +306,7 @@ function createDamageContext(overrides: {
 }
 
 // Use the Gen9 type chart for all tests
-const typeChart = GEN9_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN9_TYPE_CHART;
 
 // ===========================================================================
 // 1. pokeRound unit tests

--- a/packages/gen9/tests/integration/integration.test.ts
+++ b/packages/gen9/tests/integration/integration.test.ts
@@ -273,7 +273,7 @@ function createDamageContext(overrides: {
   };
 }
 
-const typeChart = GEN9_TYPE_CHART as Record<string, Record<string, number>>;
+const typeChart = GEN9_TYPE_CHART;
 
 // ===========================================================================
 // Integration Tests

--- a/packages/gen9/tests/tera-original-types.test.ts
+++ b/packages/gen9/tests/tera-original-types.test.ts
@@ -332,7 +332,7 @@ function createDamageBattleState(): BattleState {
   } as unknown as BattleState;
 }
 
-const dmgTypeChart = GEN9_TYPE_CHART as Record<string, Record<string, number>>;
+const dmgTypeChart = GEN9_TYPE_CHART;
 
 describe("calculateGen9Damage — teraOriginalTypes cross-type STAB pipeline", () => {
   const tera = new Gen9Terastallization();

--- a/packages/gen9/tests/type-chart.test.ts
+++ b/packages/gen9/tests/type-chart.test.ts
@@ -59,7 +59,7 @@ describe("Gen9TypeChart", () => {
      * ensuring test failures surface actual data problems.
      */
     function getEffectiveness(attackType: PokemonType, defenseType: PokemonType): number {
-      const chart = GEN9_TYPE_CHART as Record<string, Record<string, number>>;
+      const chart = GEN9_TYPE_CHART;
       const attackRow = chart[attackType];
       if (!attackRow) {
         throw new Error(`Attack type "${attackType}" not found in type chart`);


### PR DESCRIPTION
## Summary

- Remove 155+ unnecessary `as Record<string, Record<string, number>>` casts on `GEN*_TYPE_CHART` constants across 34 test files in gen5-gen9
- The constants are already typed as `TypeChart` which satisfies all function signatures

## Test plan

- [x] All gen5-gen9 tests pass
- [x] `npm run typecheck` passes
- [x] Test-only changes — no changeset needed

Closes #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed explicit TypeScript type assertions across test files in all damage calculator packages (Gen 5–9).
  * Type chart arguments are now passed directly to calculation functions without manual casting.
  * No runtime behavior or test logic changed; only compile-time typing simplified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->