### PR TITLE
docs: fix README install instructions for unpublished packages

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,8 +16,13 @@ Core Pokemon data types, entities, and shared game logic. Zero runtime dependenc
 
 ## Installation
 
+This package is not yet published to npm. Install from the monorepo:
+
 ```bash
-npm install @pokemon-lib-ts/core
+git clone https://github.com/uehlbran/pokemon-lib-ts.git
+cd pokemon-lib-ts
+npm install
+npm run build
 ```
 
 ## Usage

--- a/packages/gen1/README.md
+++ b/packages/gen1/README.md
@@ -12,8 +12,13 @@ Gen 1 (Red/Blue/Yellow) battle mechanics and complete Pokemon data.
 
 ## Installation
 
+This package is not yet published to npm. Install from the monorepo:
+
 ```bash
-npm install @pokemon-lib-ts/gen1 @pokemon-lib-ts/battle @pokemon-lib-ts/core
+git clone https://github.com/uehlbran/pokemon-lib-ts.git
+cd pokemon-lib-ts
+npm install
+npm run build
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- Update core and gen1 README installation sections to reflect that packages are not yet published to npm
- Direct users to clone the monorepo instead of `npm install`

## Test plan

- [x] Docs-only changes — no changeset needed

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to reflect monorepo-based setup process, replacing direct npm installation steps with local repository setup and build procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->