### PR TITLE
fix: address missed #1081 review findings

### DIFF
--- a/.changeset/missed-1081-findings.md
+++ b/.changeset/missed-1081-findings.md
@@ -1,0 +1,6 @@
+---
+"@pokemon-lib-ts/core": patch
+"@pokemon-lib-ts/battle": patch
+---
+
+Add nature validation and two-side config check to BattleEngine.validateConfig(). Normalize EXP growth groups before the level-1 fast path.

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -232,6 +232,20 @@ export class BattleEngine implements BattleEventEmitter {
   ): BattleValidationResult {
     const errors: BattleValidationIssue[] = [];
 
+    // Singles requires exactly 2 sides. The TypeScript type already enforces a 2-tuple at
+    // compile time, but runtime callers using type assertions or JS interop can bypass this.
+    if (config.teams.length !== 2) {
+      errors.push(
+        BattleEngine.createBattleValidationIssue(
+          "team",
+          "config",
+          "teams",
+          `Singles battles require exactly 2 sides; got ${config.teams.length}`,
+        ),
+      );
+      return { valid: false, errors };
+    }
+
     for (const [sideIndex, team] of config.teams.entries()) {
       const teamField = `teams[${sideIndex}]`;
       if (team.length < 1) {
@@ -302,6 +316,25 @@ export class BattleEngine implements BattleEventEmitter {
                 pokemon.heldItem,
                 `${pokemonField}.heldItem`,
                 `Item "${pokemon.heldItem}" is not available in Gen ${config.generation}`,
+              ),
+            );
+          }
+        }
+
+        // Gen 3+ introduced natures. Validate that the nature is a recognized ID when the
+        // battle generation supports them, the pokemon carries a nature field, and the
+        // DataManager has natures loaded. Skip the check when the DataManager has no natures
+        // (e.g. Gen 1-2 data managers or minimal test fixtures that omit natures intentionally).
+        if (config.generation >= 3 && pokemon.nature && dataManager.getAllNatures().length > 0) {
+          try {
+            dataManager.getNature(pokemon.nature);
+          } catch {
+            errors.push(
+              BattleEngine.createBattleValidationIssue(
+                "pokemon",
+                pokemon.uid,
+                `${pokemonField}.nature`,
+                `Nature "${pokemon.nature}" is not a recognized nature`,
               ),
             );
           }

--- a/packages/battle/tests/unit/battle-engine-surface.test.ts
+++ b/packages/battle/tests/unit/battle-engine-surface.test.ts
@@ -405,6 +405,138 @@ describe("BattleEngine surface", () => {
         message: "Side 0 must have at least 1 Pokemon for singles battles",
       });
     });
+
+    it("given a config with only one team side, when validateConfig is called, then it returns a team count error", () => {
+      // Singles battles require exactly 2 sides. A 1-side config is invalid at runtime
+      // even if the TypeScript type requires a 2-tuple (callers using type assertions can bypass).
+      const dataManager = createMockDataManager();
+      const result = BattleEngine.validateConfig(
+        {
+          generation: 1,
+          format: "singles",
+          teams: [[createTestPokemon(GEN1_SPECIES_IDS.charizard, 50)]] as any,
+          seed: 12345,
+        },
+        new MockRuleset(),
+        dataManager,
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        entity: "team",
+        id: "config",
+        field: "teams",
+        message: "Singles battles require exactly 2 sides; got 1",
+      });
+    });
+
+    it("given a config with three team sides, when validateConfig is called, then it returns a team count error", () => {
+      // Over-specified configs (3+ sides) are also invalid for singles format.
+      const dataManager = createMockDataManager();
+      const result = BattleEngine.validateConfig(
+        {
+          generation: 1,
+          format: "singles",
+          teams: [
+            [createTestPokemon(GEN1_SPECIES_IDS.charizard, 50)],
+            [createTestPokemon(GEN1_SPECIES_IDS.blastoise, 50)],
+            [createTestPokemon(GEN1_SPECIES_IDS.pikachu, 50)],
+          ] as any,
+          seed: 12345,
+        },
+        new MockRuleset(),
+        dataManager,
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        entity: "team",
+        id: "config",
+        field: "teams",
+        message: "Singles battles require exactly 2 sides; got 3",
+      });
+    });
+
+    it("given a Gen 3 pokemon with an unrecognized nature, when validateConfig is called, then it returns a nature error", () => {
+      // Gen 3+ introduced natures. An invalid nature string should be caught at validation time.
+      // Source: Bulbapedia — natures were introduced in Generation III.
+      const dataManager = createMockDataManager();
+      const result = BattleEngine.validateConfig(
+        {
+          generation: 3,
+          format: "singles",
+          teams: [
+            [
+              createTestPokemon(GEN1_SPECIES_IDS.charizard, 50, {
+                uid: "charizard-1",
+                nature: "super-brave" as any,
+              }),
+            ],
+            [createTestPokemon(GEN1_SPECIES_IDS.blastoise, 50)],
+          ],
+          seed: 12345,
+        },
+        new MockRuleset().setGenerationForTest(3),
+        dataManager,
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        entity: "pokemon",
+        id: "charizard-1",
+        field: "teams[0][0].nature",
+        message: 'Nature "super-brave" is not a recognized nature',
+      });
+    });
+
+    it("given a Gen 3 pokemon with a valid recognized nature, when validateConfig is called, then no nature error is reported", () => {
+      // A pokemon with a standard nature (e.g. adamant) should pass nature validation.
+      // Source: Bulbapedia — adamant is one of the 25 recognized Gen 3+ natures.
+      const dataManager = createMockDataManager();
+      const result = BattleEngine.validateConfig(
+        {
+          generation: 3,
+          format: "singles",
+          teams: [
+            [
+              createTestPokemon(GEN1_SPECIES_IDS.charizard, 50, {
+                uid: "charizard-1",
+                nature: "adamant",
+              }),
+            ],
+            [createTestPokemon(GEN1_SPECIES_IDS.blastoise, 50)],
+          ],
+          seed: 12345,
+        },
+        new MockRuleset().setGenerationForTest(3),
+        dataManager,
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("given a Gen 1 pokemon with no nature concept, when validateConfig is called, then no nature error is reported", () => {
+      // Gen 1-2 have no natures. The nature field defaults to 'adamant' in createTestPokemon
+      // but nature validation should be skipped for Gen 1-2.
+      const dataManager = createMockDataManager();
+      const result = BattleEngine.validateConfig(
+        {
+          generation: 1,
+          format: "singles",
+          teams: [
+            [createTestPokemon(GEN1_SPECIES_IDS.charizard, 50, { uid: "charizard-1" })],
+            [createTestPokemon(GEN1_SPECIES_IDS.blastoise, 50)],
+          ],
+          seed: 12345,
+        },
+        new MockRuleset(),
+        dataManager,
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
   });
 
   describe("getAvailableMoves", () => {

--- a/packages/core/src/logic/experience.ts
+++ b/packages/core/src/logic/experience.ts
@@ -38,9 +38,12 @@ export function normalizeExperienceGroup(group: string): ExperienceGroup {
  * @returns Total cumulative EXP needed to reach this level
  */
 export function getExpForLevel(group: ExperienceGroupIdentifier | string, level: number): number {
+  // Normalize first so alias validation (e.g. "slow-then-very-fast", "medium") runs
+  // even for the level-1 fast path. Without this ordering, an unrecognized alias at
+  // level 1 would silently return 0 instead of throwing.
+  const normalizedGroup = normalizeExperienceGroup(group);
   if (level <= 1) return 0;
   const n = level;
-  const normalizedGroup = normalizeExperienceGroup(group);
 
   switch (normalizedGroup) {
     case "erratic":

--- a/packages/core/tests/unit/logic/experience.test.ts
+++ b/packages/core/tests/unit/logic/experience.test.ts
@@ -111,6 +111,23 @@ describe("getExpForLevel", () => {
       'Unsupported experience growth group "sideways-growth"',
     );
   });
+
+  it("given an unsupported growth-rate identifier at level 1, when querying EXP, then normalization runs before the fast path and throws", () => {
+    // Source: The level-1 fast path (return 0) must not skip alias normalization.
+    // Prior to this fix, an unrecognized alias at level 1 would silently return 0
+    // instead of throwing. normalizeExperienceGroup must be called first.
+    expect(() => getExpForLevel("bad-alias", 1)).toThrow(
+      'Unsupported experience growth group "bad-alias"',
+    );
+  });
+
+  it("given the PokeAPI slow-then-very-fast alias at level 1, when querying EXP, then normalization runs before the fast path and returns 0", () => {
+    // Source: Bulbapedia — level 1 always requires 0 EXP.
+    // Alias normalization must still fire at level 1 (no silent bypass).
+    expect(getExpForLevel("slow-then-very-fast", 1)).toBe(0);
+    expect(getExpForLevel("medium", 1)).toBe(0);
+    expect(getExpForLevel("fast-then-very-slow", 1)).toBe(0);
+  });
 });
 
 describe("getExpToNextLevel", () => {


### PR DESCRIPTION
## Summary

- Add nature validation to `BattleEngine.validateConfig()` for Gen 3+ — rejects unrecognized natures when DataManager has natures loaded
- Reject non-two-side singles configs at runtime (TypeScript tuple enforces at compile time, but runtime callers can bypass)
- Move `normalizeExperienceGroup()` before the level-1 fast path so alias validation fires at every level
- Add 7 tests covering all three fixes

## Test plan

- [x] Core: 399 tests pass (2 new EXP tests)
- [x] Battle: 684 tests pass (5 new validation tests)
- [x] `npm run typecheck` passes
- [x] Biome clean

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced battle configuration validation to ensure singles battles have exactly 2 sides and validate Pokémon natures for Gen 3+.

* **Bug Fixes**
  * Fixed experience calculation to properly validate growth group aliases at all levels, ensuring consistent error handling instead of silently returning 0 for invalid aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->