### PR TITLE
fix(gen2): correct move priority values for Roar and Whirlwind

### DIFF
--- a/.changeset/gen2-priority-fix.md
+++ b/.changeset/gen2-priority-fix.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/gen2": patch
+---
+
+Fix incorrect move priority values for Roar and Whirlwind in Gen 2 data. These were carrying Gen 3+ Showdown priority values (-6) instead of the correct Gen 2 value (-1). Sources: Showdown data/mods/gen2/moves.ts and pret/pokecrystal effects_priorities.asm (EFFECT_FORCE_SWITCH go-last mechanic).

--- a/packages/gen2/data/moves.json
+++ b/packages/gen2/data/moves.json
@@ -6633,7 +6633,7 @@
     "power": null,
     "accuracy": 100,
     "pp": 20,
-    "priority": -6,
+    "priority": -1,
     "target": "adjacent-foe",
     "flags": {
       "contact": false,
@@ -9599,7 +9599,7 @@
     "power": null,
     "accuracy": 100,
     "pp": 20,
-    "priority": -6,
+    "priority": -1,
     "target": "adjacent-foe",
     "flags": {
       "contact": false,

--- a/packages/gen2/tests/unit/data-loading.test.ts
+++ b/packages/gen2/tests/unit/data-loading.test.ts
@@ -158,6 +158,28 @@ describe("Gen 2 Data Loading", () => {
       expect(() => dm.getSpecies(999)).toThrow();
     });
 
+    it("given gen2 move data, when Roar priority is read, then it should be -1", () => {
+      // Source: Showdown references/pokemon-showdown/data/mods/gen2/moves.ts — roar/whirlwind priority: -1
+      // Source: gen2-ground-truth.md Priority Moves table
+      // Arrange
+      const dm = createGen2DataManager();
+      // Act
+      const move = dm.getMove(GEN2_MOVE_IDS.roar);
+      // Assert
+      expect(move.priority).toBe(-1);
+    });
+
+    it("given gen2 move data, when Whirlwind priority is read, then it should be -1", () => {
+      // Source: Showdown references/pokemon-showdown/data/mods/gen2/moves.ts — roar/whirlwind priority: -1
+      // Source: gen2-ground-truth.md Priority Moves table
+      // Arrange
+      const dm = createGen2DataManager();
+      // Act
+      const move = dm.getMove(GEN2_MOVE_IDS.whirlwind);
+      // Assert
+      expect(move.priority).toBe(-1);
+    });
+
     it("given Pikachu in Gen 2 data, when loaded by species id, then its split Special stats differ as expected", () => {
       // Arrange
       const dm = createGen2DataManager();

--- a/packages/gen2/tests/unit/mechanic-bug-fixes.test.ts
+++ b/packages/gen2/tests/unit/mechanic-bug-fixes.test.ts
@@ -4,7 +4,7 @@
  * Issues fixed:
  * - #214: Metal Powder unconditional (missing transform check)
  * - #251: Counter reflects wrong types (should only reflect Normal/Fighting)
- * - #252: Whirlwind/Roar wrong priority (-1 instead of -6)
+ * - #252: Whirlwind/Roar wrong priority (was -6, correct Gen 2 value is -1)
  * - #253: Hyper Beam recharge not skipped on miss (only on KO)
  * - #325: Attract and Nightmare volatile not cleared on switch-out
  * - #328: Baton Pass missing perish song counter, substitute, and curse transfer
@@ -478,21 +478,23 @@ describe("#251 — Counter reflects ALL physical-type damage in Gen 2", () => {
 // #252: Whirlwind/Roar priority
 // =========================================================================
 
-describe("#252 — Whirlwind/Roar should have priority -6", () => {
-  it("given Gen 2 moves.json, when loading Whirlwind, then priority is -6", () => {
-    // Source: pret/pokecrystal engine/battle/core.asm — Whirlwind/Roar always go last
-    // Source: Bulbapedia — Whirlwind has -6 priority in Gen 2+
+describe("#252 — Whirlwind/Roar should have priority -1 in Gen 2 (not the Gen 3+ -6 value)", () => {
+  it("given Gen 2 moves.json, when loading Whirlwind, then priority is -1", () => {
+    // JUSTIFICATION: Original assertions tested the wrong -6 value (Gen 3+ Showdown import).
+    // Correct Gen 2 value is -1 per Showdown data/mods/gen2/moves.ts and gen2-ground-truth.md.
+    // Source: references/pokemon-showdown/data/mods/gen2/moves.ts — whirlwind: { priority: -1 }
     const dm = createGen2DataManager();
     const move = dm.getMove(MOVE_IDS.whirlwind);
-    expect(move.priority).toBe(-6);
+    expect(move.priority).toBe(-1);
   });
 
-  it("given Gen 2 moves.json, when loading Roar, then priority is -6", () => {
-    // Source: pret/pokecrystal engine/battle/core.asm — Whirlwind/Roar always go last
-    // Source: Bulbapedia — Roar has -6 priority in Gen 2+
+  it("given Gen 2 moves.json, when loading Roar, then priority is -1", () => {
+    // JUSTIFICATION: Original assertions tested the wrong -6 value (Gen 3+ Showdown import).
+    // Correct Gen 2 value is -1 per Showdown data/mods/gen2/moves.ts and gen2-ground-truth.md.
+    // Source: references/pokemon-showdown/data/mods/gen2/moves.ts — roar: { priority: -1 }
     const dm = createGen2DataManager();
     const move = dm.getMove(MOVE_IDS.roar);
-    expect(move.priority).toBe(-6);
+    expect(move.priority).toBe(-1);
   });
 });
 

--- a/packages/gen2/tests/unit/ruleset.test.ts
+++ b/packages/gen2/tests/unit/ruleset.test.ts
@@ -3000,22 +3000,22 @@ describe("Gen2Ruleset", () => {
       expect(priority).toBe(1);
     });
 
-    it("given Gen 2 ruleset, when getting Roar move priority, then returns -6", () => {
-      // Source: pret/pokecrystal engine/battle/core.asm — Whirlwind/Roar always go last
-      // Priority -6 ensures they go after all other moves including Counter/Mirror Coat (-1)
-      // Reference: Bulbapedia — Roar has priority -6 in Gen 2+
+    it("given Gen 2 ruleset, when getting Roar move priority, then returns -1", () => {
+      // JUSTIFICATION: Original assertions tested the wrong -6 value (Gen 3+ Showdown import).
+      // Correct Gen 2 value is -1 per Showdown data/mods/gen2/moves.ts and gen2-ground-truth.md.
+      // Source: references/pokemon-showdown/data/mods/gen2/moves.ts — roar: { priority: -1 }
       const dm = createGen2DataManager();
       const move = dm.getMove(GEN2_MOVE_IDS.roar);
-      expect(move?.priority).toBe(-6);
+      expect(move?.priority).toBe(-1);
     });
 
-    it("given Gen 2 ruleset, when getting Whirlwind move priority, then returns -6", () => {
-      // Source: pret/pokecrystal engine/battle/core.asm — Whirlwind/Roar always go last
-      // Priority -6 ensures they go after all other moves including Counter/Mirror Coat (-1)
-      // Reference: Bulbapedia — Whirlwind has priority -6 in Gen 2+
+    it("given Gen 2 ruleset, when getting Whirlwind move priority, then returns -1", () => {
+      // JUSTIFICATION: Original assertions tested the wrong -6 value (Gen 3+ Showdown import).
+      // Correct Gen 2 value is -1 per Showdown data/mods/gen2/moves.ts and gen2-ground-truth.md.
+      // Source: references/pokemon-showdown/data/mods/gen2/moves.ts — whirlwind: { priority: -1 }
       const dm = createGen2DataManager();
       const move = dm.getMove(GEN2_MOVE_IDS.whirlwind);
-      expect(move?.priority).toBe(-6);
+      expect(move?.priority).toBe(-1);
     });
   });
 });

--- a/tools/oracle-validation/data/ground-truth/gen2-ground-truth.json
+++ b/tools/oracle-validation/data/ground-truth/gen2-ground-truth.json
@@ -107,6 +107,22 @@
       "expectedPriority": 3,
       "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_ENDURE priority 3",
       "note": "Endure has +3 priority on Gen 2 cartridge. Oracle @pkmn/data reports +2."
+    },
+    {
+      "id": "move-priority-roar",
+      "kind": "movePriorityCheck",
+      "moveId": "roar",
+      "expectedPriority": -1,
+      "source": "Showdown references/pokemon-showdown/data/mods/gen2/moves.ts — roar priority: -1",
+      "note": "Roar uses go-last mechanic in Gen 2 (EFFECT_FORCE_SWITCH). Source: pret/pokecrystal effects_priorities.asm + Showdown gen2 mod."
+    },
+    {
+      "id": "move-priority-whirlwind",
+      "kind": "movePriorityCheck",
+      "moveId": "whirlwind",
+      "expectedPriority": -1,
+      "source": "Showdown references/pokemon-showdown/data/mods/gen2/moves.ts — whirlwind priority: -1",
+      "note": "Whirlwind uses go-last mechanic in Gen 2 (EFFECT_FORCE_SWITCH). Source: pret/pokecrystal effects_priorities.asm + Showdown gen2 mod."
     }
   ]
 }

--- a/tools/oracle-validation/data/known-disagreements/gen2-known-disagreements.json
+++ b/tools/oracle-validation/data/known-disagreements/gen2-known-disagreements.json
@@ -221,32 +221,6 @@
     "addedDate": "2026-03-28"
   },
   {
-    "id": "gen2:mechanics:move-priority:roar",
-    "gen": 2,
-    "suite": "mechanics",
-    "description": "Roar/Whirlwind in Gen 2 have a special go-last mechanism (EFFECT_FORCE_SWITCH, priority 0 in effects_priorities.asm). Showdown and @pkmn/data model this as -1. Our data incorrectly carries the Gen 3+ value of -6. This is a data bug — correct Gen 2 value should be -1.",
-    "ourValue": -6,
-    "oracleValue": -1,
-    "resolution": "showdown-deviation",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_FORCE_SWITCH priority 0 (special go-last); Showdown data/mods/gen2/moves.ts — roar priority -1",
-    "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
-    "oracleVersion": "@pkmn/data@0.10.7",
-    "addedDate": "2026-03-28"
-  },
-  {
-    "id": "gen2:mechanics:move-priority:whirlwind",
-    "gen": 2,
-    "suite": "mechanics",
-    "description": "Whirlwind in Gen 2 has a special go-last mechanism (EFFECT_FORCE_SWITCH, priority 0 in effects_priorities.asm). Showdown and @pkmn/data model this as -1. Our data incorrectly carries the Gen 3+ value of -6. This is a data bug — correct Gen 2 value should be -1.",
-    "ourValue": -6,
-    "oracleValue": -1,
-    "resolution": "showdown-deviation",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_FORCE_SWITCH priority 0 (special go-last); Showdown data/mods/gen2/moves.ts — whirlwind priority -1",
-    "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
-    "oracleVersion": "@pkmn/data@0.10.7",
-    "addedDate": "2026-03-28"
-  },
-  {
     "id": "gen2:data:type-chart:electric-to-steel:effectiveness",
     "gen": 2,
     "suite": "data",


### PR DESCRIPTION
## Summary

- Gen 2 `moves.json` carried Gen 3+ priority values (-6) for Roar and Whirlwind
- Correct Gen 2 value is -1: Showdown's `data/mods/gen2/moves.ts` has explicit `-1` overrides; pokecrystal uses EFFECT_FORCE_SWITCH with go-last enforcement at execution time
- Updated 3 test files that were asserting the wrong -6 value (with documented JUSTIFICATION)
- Removed 2 known-disagreement entries (no longer needed)
- Added 2 `movePriorityCheck` ground-truth cases

Note: A pre-existing bug was discovered and filed as #1123 — the Gen2MoveEffects handler is missing a go-last check that should cause these moves to fail when the user moves first.

## Test plan

- [x] 2 new exact-value priority tests added (TDD: Red → Green verified)
- [x] All 768 gen2 tests pass
- [x] 2 known-disagreement entries removed (values now match oracle)
- [x] 2 `movePriorityCheck` ground-truth cases added
- [x] `npm run verify:local` passed

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected move priority values for Roar and Whirlwind in Generation 2 data (updated from `-6` to `-1`, reflecting accurate Gen 2 mechanics).

* **Tests**
  * Updated unit tests to validate the corrected move priority values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->