### PR TITLE
fix(gen1): correct 6 move values to match pret/pokered cartridge data

### DIFF
--- a/.changeset/pret-gen1-move-data-fixes.md
+++ b/.changeset/pret-gen1-move-data-fixes.md
@@ -1,0 +1,13 @@
+---
+"@pokemon-lib-ts/gen1": patch
+---
+
+Fix Gen 1 move data to match pret/pokered cartridge values.
+
+Six corrections per pret/pokered data/moves/moves.asm:
+- Gust type: flying → normal (pokered line 29)
+- Sand Attack type: ground → normal (pokered line 41)
+- Absorb PP: 25 → 20 (pokered line 84)
+- Mega Drain PP: 15 → 10 (pokered line 85)
+- Razor Wind accuracy: 100 → 75 (pokered line 26)
+- Whirlwind accuracy: 100 → 85 (pokered line 31)

--- a/packages/gen1/data/moves.json
+++ b/packages/gen1/data/moves.json
@@ -423,7 +423,7 @@
     "type": "normal",
     "category": "physical",
     "power": 80,
-    "accuracy": 100,
+    "accuracy": 75,
     "pp": 10,
     "priority": 0,
     "target": "all-adjacent-foes",
@@ -532,7 +532,7 @@
   {
     "id": "gust",
     "displayName": "Gust",
-    "type": "flying",
+    "type": "normal",
     "category": "physical",
     "power": 40,
     "accuracy": 100,
@@ -601,7 +601,7 @@
     "type": "normal",
     "category": "status",
     "power": null,
-    "accuracy": 100,
+    "accuracy": 85,
     "pp": 20,
     "priority": 0,
     "target": "adjacent-foe",
@@ -946,7 +946,7 @@
   {
     "id": "sand-attack",
     "displayName": "Sand Attack",
-    "type": "ground",
+    "type": "normal",
     "category": "status",
     "power": null,
     "accuracy": 100,
@@ -2525,7 +2525,7 @@
     "category": "special",
     "power": 20,
     "accuracy": 100,
-    "pp": 25,
+    "pp": 20,
     "priority": 0,
     "target": "adjacent-foe",
     "flags": {
@@ -2561,7 +2561,7 @@
     "category": "special",
     "power": 40,
     "accuracy": 100,
-    "pp": 15,
+    "pp": 10,
     "priority": 0,
     "target": "adjacent-foe",
     "flags": {

--- a/packages/gen1/tests/unit/data-loading.test.ts
+++ b/packages/gen1/tests/unit/data-loading.test.ts
@@ -549,6 +549,53 @@ describe("Gen 1 Data Loading", () => {
     expect(moveIds).toEqual(GEN1_CHARIZARD_LEVEL_UP_MOVES);
   });
 
+  // --- Pret cartridge-accurate move data (Gen 1) ---
+
+  it("given Gen 1 move data, when loading Gust, then type is normal (not flying)", () => {
+    // In Gen 1, Gust is a Normal-type move. The Flying typing was introduced in Gen 2.
+    // Source: pret/pokered data/moves/moves.asm line 29 — move GUST, type NORMAL
+    const dm = createGen1DataManager();
+    const gust = dm.getMove(GEN1_MOVE_IDS.gust);
+    expect(gust.type).toBe(typeIds.normal);
+  });
+
+  it("given Gen 1 move data, when loading Sand Attack, then type is normal (not ground)", () => {
+    // In Gen 1, Sand Attack is a Normal-type move. The Ground typing was introduced in Gen 2.
+    // Source: pret/pokered data/moves/moves.asm line 41 — move SAND_ATTACK, type NORMAL
+    const dm = createGen1DataManager();
+    const sandAttack = dm.getMove(GEN1_MOVE_IDS.sandAttack);
+    expect(sandAttack.type).toBe(typeIds.normal);
+  });
+
+  it("given Gen 1 move data, when loading Absorb, then PP is 20", () => {
+    // Source: pret/pokered data/moves/moves.asm line 84 — move ABSORB, pp 20
+    const dm = createGen1DataManager();
+    const absorb = dm.getMove(GEN1_MOVE_IDS.absorb);
+    expect(absorb.pp).toBe(20);
+  });
+
+  it("given Gen 1 move data, when loading Mega Drain, then PP is 10", () => {
+    // Source: pret/pokered data/moves/moves.asm line 85 — move MEGA_DRAIN, pp 10
+    const dm = createGen1DataManager();
+    const megaDrain = dm.getMove(GEN1_MOVE_IDS.megaDrain);
+    expect(megaDrain.pp).toBe(10);
+  });
+
+  it("given Gen 1 move data, when loading Razor Wind, then accuracy is 75", () => {
+    // Source: pret/pokered data/moves/moves.asm line 26 — move RAZOR_WIND, accuracy 75
+    const dm = createGen1DataManager();
+    const razorWind = dm.getMove(GEN1_MOVE_IDS.razorWind);
+    expect(razorWind.accuracy).toBe(75);
+  });
+
+  it("given Gen 1 move data, when loading Whirlwind, then accuracy is 85", () => {
+    // In Gen 1, Whirlwind has 85% accuracy and can miss.
+    // Source: pret/pokered data/moves/moves.asm line 31 — move WHIRLWIND, accuracy 85
+    const dm = createGen1DataManager();
+    const whirlwind = dm.getMove(GEN1_MOVE_IDS.whirlwind);
+    expect(whirlwind.accuracy).toBe(85);
+  });
+
   // --- Data Manager State ---
 
   it("given Gen 1 data manager, when created, then reports as loaded", () => {


### PR DESCRIPTION
## Summary

Six Gen 1 move data corrections, discovered via `discover-diffs` comparing our committed data against pret/pokered `data/moves/moves.asm`:

- **Gust** type: `flying` → `normal` (pokered line 29 — Gen 1 cartridge uses Normal type; Flying was added in Gen 2)
- **Sand Attack** type: `ground` → `normal` (pokered line 41 — same pattern, Ground type added in Gen 2)
- **Absorb** PP: `25` → `20` (pokered line 84)
- **Mega Drain** PP: `15` → `10` (pokered line 85)
- **Razor Wind** accuracy: `100` → `75` (pokered line 26)
- **Whirlwind** accuracy: `100` → `85` (pokered line 31)

Each fix has a corresponding test with the specific pret source citation.

## Test plan

- [x] 6 new unit tests in `data-loading.test.ts` covering each corrected value
- [x] All 785 gen1 tests pass
- [x] `npm run verify:local` passes
- [x] `npm run validate:pret` passes (no stale/missing overrides)

Closes: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Generation 1 move data with corrections to move types, power points, and accuracy values to align with official specifications. Changes include type adjustments for Gust and Sand Attack, reduced power point allocations for Absorb and Mega Drain, and accuracy corrections for Razor Wind and Whirlwind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->