### PR TITLE
fix(data): add SpeciesType alias and correct Curse type to unknown in Gen 2-4

### DIFF
--- a/.changeset/fix-curse-type-mystery-unknown.md
+++ b/.changeset/fix-curse-type-mystery-unknown.md
@@ -1,0 +1,20 @@
+---
+"@pokemon-lib-ts/core": minor
+"@pokemon-lib-ts/gen2": patch
+"@pokemon-lib-ts/gen3": patch
+"@pokemon-lib-ts/gen4": patch
+"@pokemon-lib-ts/gen8": patch
+---
+
+fix(data): Correct Curse type to unknown (TYPE_MYSTERY) in Gen 2-4
+
+Curse uses a distinct TYPE_MYSTERY/CURSE_TYPE in Gen 2-4 ROM data, not Ghost type.
+- Gen 2 (pokecrystal): CURSE_TYPE = 19 (constants/type_constants.asm)
+- Gen 3 (pokeemerald): TYPE_MYSTERY = 9 (include/constants/pokemon.h)
+- Gen 4 (pokeplatinum): TYPE_MYSTERY = 9 (include/constants/pokemon.h)
+
+Adds "unknown" to PokemonType union and CORE_TYPE_IDS. TypeChart is now a sparse
+Partial<Record<...>> so gen-specific charts do not need to carry "unknown" rows/columns.
+Gen8MaxMoves MAX_MOVE_NAMES updated to use Partial type accordingly.
+
+Source: pret/pokecrystal constants/type_constants.asm, pret/pokeemerald include/constants/pokemon.h

--- a/packages/core/src/constants/reference-ids.ts
+++ b/packages/core/src/constants/reference-ids.ts
@@ -474,6 +474,11 @@ export const CORE_TYPE_IDS = {
   rock: "rock",
   steel: "steel",
   water: "water",
+  // Move-type-only sentinel: TYPE_MYSTERY/CURSE_TYPE used by Curse in Gen 2-4.
+  // No Pokemon has "unknown" as a species type.
+  // Source: pret/pokecrystal constants/type_constants.asm — CURSE_TYPE EQU 19
+  //         pret/pokeemerald include/constants/pokemon.h — TYPE_MYSTERY = 9
+  unknown: "unknown",
 } as const;
 
 export const CORE_STAT_IDS = {

--- a/packages/core/src/entities/species.ts
+++ b/packages/core/src/entities/species.ts
@@ -1,7 +1,7 @@
 import type { ExperienceGroupIdentifier } from "./experience";
 import type { Gender } from "./gender";
 import type { StatBlock } from "./stats";
-import type { Generation, PokemonType } from "./types";
+import type { Generation, PokemonType, SpeciesType } from "./types";
 
 export interface PokemonSpeciesData {
   /** National Pokedex number */
@@ -13,8 +13,8 @@ export interface PokemonSpeciesData {
   /** Display name (e.g., "Charizard") */
   readonly displayName: string;
 
-  /** One or two types */
-  readonly types: readonly [PokemonType] | readonly [PokemonType, PokemonType];
+  /** One or two types — species types only (never "unknown") */
+  readonly types: readonly [SpeciesType] | readonly [SpeciesType, SpeciesType];
 
   /** Base stats (Gen 3+ model with SpAtk/SpDef split) */
   readonly baseStats: StatBlock;
@@ -175,8 +175,8 @@ export interface MegaEvolutionData {
   /** Required held Mega Stone item ID */
   readonly item: string;
 
-  /** Types in Mega form */
-  readonly types: readonly [PokemonType] | readonly [PokemonType, PokemonType];
+  /** Types in Mega form — species types only (never "unknown") */
+  readonly types: readonly [SpeciesType] | readonly [SpeciesType, SpeciesType];
 
   /** Base stats in Mega form */
   readonly baseStats: StatBlock;
@@ -213,8 +213,8 @@ export interface RegionalFormData {
    */
   readonly formSpeciesId: number;
 
-  /** Types of the regional form */
-  readonly types: readonly [PokemonType] | readonly [PokemonType, PokemonType];
+  /** Types of the regional form — species types only (never "unknown") */
+  readonly types: readonly [SpeciesType] | readonly [SpeciesType, SpeciesType];
 
   /** Base stats of the regional form */
   readonly baseStats: StatBlock;

--- a/packages/core/src/entities/type-chart.ts
+++ b/packages/core/src/entities/type-chart.ts
@@ -14,8 +14,12 @@ import type { PokemonType } from "./types";
  *
  * The core library provides the full Gen 6+ chart.
  * Battle library gen plugins can provide their own charts.
+ *
+ * Sparse chart: entries missing from the outer or inner map default to 1.0 (neutral).
+ * This allows "unknown" (TYPE_MYSTERY/CURSE_TYPE used by Curse in Gen 2-4) to be
+ * a valid PokemonType without requiring every chart to carry its row and column.
  */
-export type TypeChart = Record<PokemonType, Record<PokemonType, number>>;
+export type TypeChart = Partial<Record<PokemonType, Partial<Record<PokemonType, number>>>>;
 
 /**
  * Broader lookup shape used by damage-calculation helpers and synthetic tests.

--- a/packages/core/src/entities/types.ts
+++ b/packages/core/src/entities/types.ts
@@ -1,8 +1,13 @@
 /**
- * All 18 Pokemon types (as of Gen 6+).
+ * All 18 Pokemon types (as of Gen 6+), plus the special "unknown" sentinel.
  * Gen 1 had 15 (no Dark, Steel, Fairy).
  * Gen 2 added Dark and Steel.
  * Gen 6 added Fairy.
+ * "unknown" represents TYPE_MYSTERY/CURSE_TYPE used exclusively by Curse in Gen 2-4.
+ *   - Gen 2 (pokecrystal): CURSE_TYPE = 19 (constants/type_constants.asm)
+ *   - Gen 3 (pokeemerald): TYPE_MYSTERY = 9 (include/constants/pokemon.h)
+ *   - Gen 4 (pokeplatinum): TYPE_MYSTERY = 9 (include/constants/pokemon.h)
+ * It is a move type only — no Pokemon has "unknown" as a species type.
  * Generation plugins in the battle library filter this list as needed.
  */
 export type PokemonType =
@@ -23,7 +28,15 @@ export type PokemonType =
   | "dragon"
   | "dark"
   | "steel"
-  | "fairy";
+  | "fairy"
+  | "unknown"; // TYPE_MYSTERY/CURSE_TYPE (Gen 2-4 only, move type sentinel)
+
+/**
+ * Types valid as a Pokemon species type (excludes move-only sentinels like "unknown").
+ * Use this for species.types, mega types, and regional form types.
+ * No Pokemon in any generation has "unknown" as a species type.
+ */
+export type SpeciesType = Exclude<PokemonType, "unknown">;
 
 /** Number of types per generation — used by battle gen plugins to validate data */
 export const TYPES_BY_GEN: Record<number, readonly PokemonType[]> = {

--- a/packages/gen2/data/moves.json
+++ b/packages/gen2/data/moves.json
@@ -1431,7 +1431,7 @@
   {
     "id": "curse",
     "displayName": "Curse",
-    "type": "ghost",
+    "type": "unknown",
     "category": "status",
     "power": null,
     "accuracy": null,

--- a/packages/gen2/tests/unit/data-loading.test.ts
+++ b/packages/gen2/tests/unit/data-loading.test.ts
@@ -67,6 +67,19 @@ describe("Gen 2 Data Loading", () => {
       expect(bite.power).toBe(60);
     });
 
+    it("given Curse in Gen 2 move data, when loaded by move id, then its type is unknown (TYPE_MYSTERY / CURSE_TYPE)", () => {
+      // Arrange
+      const dm = createGen2DataManager();
+      // Act
+      const curse = dm.getMove(GEN2_MOVE_IDS.curse);
+      // Assert
+      // Source: pret/pokecrystal constants/type_constants.asm — CURSE_TYPE EQU 19
+      // Curse uses CURSE_TYPE (not TYPE_GHOST) in Gen 2. The type determines Curse's
+      // behavior (Ghost-type user vs. non-Ghost user) based on the user's type, not the move's.
+      expect(curse.id).toBe(GEN2_MOVE_IDS.curse);
+      expect(curse.type).toBe(CORE_TYPE_IDS.unknown);
+    });
+
     it("given the Gen 2 type chart, when loaded, then it exposes the 17 pre-Fairy types", () => {
       // Arrange
       const dm = createGen2DataManager();

--- a/packages/gen3/data/moves.json
+++ b/packages/gen3/data/moves.json
@@ -2140,7 +2140,7 @@
   {
     "id": "curse",
     "displayName": "Curse",
-    "type": "ghost",
+    "type": "unknown",
     "category": "status",
     "power": null,
     "accuracy": null,

--- a/packages/gen3/tests/unit/data-loading.test.ts
+++ b/packages/gen3/tests/unit/data-loading.test.ts
@@ -1,5 +1,6 @@
+import { CORE_TYPE_IDS } from "@pokemon-lib-ts/core";
 import { describe, expect, it } from "vitest";
-import { createGen3DataManager } from "../../src/data";
+import { createGen3DataManager, GEN3_MOVE_IDS } from "../../src";
 
 describe("Gen 3 DataManager — data loading", () => {
   it("given gen3 data files, when loading DataManager, then loads 386 Pokemon", () => {
@@ -54,5 +55,17 @@ describe("Gen 3 DataManager — data loading", () => {
     const dm = createGen3DataManager();
     const blaziken = dm.getSpeciesByName("blaziken");
     expect(blaziken.baseStats.speed).toBe(80);
+  });
+
+  it("given Curse in Gen 3 move data, when loaded by move id, then its type is unknown (TYPE_MYSTERY)", () => {
+    // Arrange
+    const dm = createGen3DataManager();
+    // Act
+    const curse = dm.getMove(GEN3_MOVE_IDS.curse);
+    // Assert
+    // Source: pret/pokeemerald include/constants/pokemon.h — TYPE_MYSTERY = 9
+    //         src/data/battle_moves.h — Curse .type = TYPE_MYSTERY (not TYPE_GHOST)
+    expect(curse.id).toBe(GEN3_MOVE_IDS.curse);
+    expect(curse.type).toBe(CORE_TYPE_IDS.unknown);
   });
 });

--- a/packages/gen4/data/moves.json
+++ b/packages/gen4/data/moves.json
@@ -2903,7 +2903,7 @@
   {
     "id": "curse",
     "displayName": "Curse",
-    "type": "ghost",
+    "type": "unknown",
     "category": "status",
     "power": null,
     "accuracy": null,

--- a/packages/gen4/tests/data-loading.test.ts
+++ b/packages/gen4/tests/data-loading.test.ts
@@ -1,6 +1,6 @@
 import { CORE_TYPE_IDS } from "@pokemon-lib-ts/core";
 import { describe, expect, it } from "vitest";
-import { GEN4_SPECIES_IDS } from "../src";
+import { GEN4_MOVE_IDS, GEN4_SPECIES_IDS } from "../src";
 import { createGen4DataManager } from "../src/data";
 
 describe("Gen 4 DataManager -- data loading", () => {
@@ -69,5 +69,17 @@ describe("Gen 4 DataManager -- data loading", () => {
     const dm = createGen4DataManager();
     const lucario = dm.getSpecies(GEN4_SPECIES_IDS.lucario);
     expect(lucario.types).toEqual([CORE_TYPE_IDS.fighting, CORE_TYPE_IDS.steel]);
+  });
+
+  it("given Curse in Gen 4 move data, when loaded by move id, then its type is unknown (TYPE_MYSTERY)", () => {
+    // Arrange
+    const dm = createGen4DataManager();
+    // Act
+    const curse = dm.getMove(GEN4_MOVE_IDS.curse);
+    // Assert
+    // Source: pret/pokeplatinum include/constants/pokemon.h — TYPE_MYSTERY = 9
+    // Curse uses TYPE_MYSTERY in Gen 4. Starting in Gen 5, Curse is correctly Ghost type.
+    expect(curse.id).toBe(GEN4_MOVE_IDS.curse);
+    expect(curse.type).toBe(CORE_TYPE_IDS.unknown);
   });
 });

--- a/packages/gen8/src/Gen8MaxMoves.ts
+++ b/packages/gen8/src/Gen8MaxMoves.ts
@@ -59,7 +59,9 @@ export type MaxMoveEffect =
  *
  * Source: Showdown sim/battle-actions.ts lines 9-29 -- MAX_MOVES table
  */
-const MAX_MOVE_NAMES: Readonly<Record<PokemonType, string>> = {
+// "unknown" (TYPE_MYSTERY) is a move-type sentinel for Curse in Gen 2-4 only.
+// No Dynamax move exists for "unknown" type since Curse is "ghost" from Gen 5+.
+const MAX_MOVE_NAMES: Readonly<Partial<Record<PokemonType, string>>> = {
   [CORE_TYPE_IDS.normal]: "Max Strike",
   [CORE_TYPE_IDS.fire]: "Max Flare",
   [CORE_TYPE_IDS.water]: "Max Geyser",
@@ -171,7 +173,7 @@ const MAX_MOVE_EFFECTS: Readonly<Record<string, MaxMoveEffect>> = {
  */
 export function getMaxMoveName(moveType: PokemonType, isStatus: boolean): string {
   if (isStatus) return "Max Guard";
-  return MAX_MOVE_NAMES[moveType];
+  return MAX_MOVE_NAMES[moveType] ?? "Max Strike";
 }
 
 /**

--- a/packages/gen8/tests/max-moves.test.ts
+++ b/packages/gen8/tests/max-moves.test.ts
@@ -47,6 +47,14 @@ describe("Gen8MaxMoves", () => {
       expect(getMaxMoveName(CORE_TYPE_IDS.psychic, true)).toBe("Max Guard");
     });
 
+    it("given unknown type (TYPE_MYSTERY sentinel) damage move, when getting Max Move name, then falls back to Max Strike", () => {
+      // Source: Gen8MaxMoves.ts -- "unknown" has no MAX_MOVE_NAMES entry; falls back to ?? "Max Strike"
+      // "unknown" (TYPE_MYSTERY) only exists in Gen 2-4 for Curse and cannot reach Gen 8 in normal
+      // operation. The fallback guards against defensive exhaustiveness.
+      const result = getMaxMoveName(CORE_TYPE_IDS.unknown, false);
+      expect(result).toBe("Max Strike");
+    });
+
     it("given all 18 types, when getting Max Move name for damage moves, then returns unique names", () => {
       // Source: core/entities/types.ts -- Gen 8 uses the full 18-type chart
       const types = TYPES_BY_GEN[8];

--- a/tools/data-importer/src/pret-overrides/gen2-overrides.ts
+++ b/tools/data-importer/src/pret-overrides/gen2-overrides.ts
@@ -93,4 +93,15 @@ export const gen2Overrides: readonly PretOverride[] = [
     source:
       "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_VITAL_THROW priority 0 (1-based scale)",
   },
+
+  // ── Curse type correction ──────────────────────────────────────────────────
+  {
+    target: "move",
+    moveId: "curse",
+    field: "type",
+    value: "unknown",
+    showdownValue: "ghost",
+    source:
+      "pret/pokecrystal constants/type_constants.asm — CURSE_TYPE EQU 19; data/moves/moves.asm — Curse uses CURSE_TYPE not TYPE_GHOST",
+  },
 ];

--- a/tools/data-importer/src/pret-overrides/gen3-overrides.ts
+++ b/tools/data-importer/src/pret-overrides/gen3-overrides.ts
@@ -17,4 +17,15 @@ export const gen3Overrides: readonly PretOverride[] = [
     showdownValue: 4,
     source: "pret/pokeemerald src/data/battle_moves.h — endure: .priority = 3",
   },
+
+  // Curse type: pokeemerald uses TYPE_MYSTERY (value 9), not TYPE_GHOST
+  {
+    target: "move",
+    moveId: "curse",
+    field: "type",
+    value: "unknown",
+    showdownValue: "ghost",
+    source:
+      "pret/pokeemerald include/constants/pokemon.h — TYPE_MYSTERY = 9; src/data/battle_moves.h — Curse .type = TYPE_MYSTERY",
+  },
 ];

--- a/tools/data-importer/src/pret-overrides/gen4-overrides.ts
+++ b/tools/data-importer/src/pret-overrides/gen4-overrides.ts
@@ -17,4 +17,15 @@ export const gen4Overrides: readonly PretOverride[] = [
     showdownValue: 4,
     source: "pret/pokeplatinum res/battle/moves/endure/data.json — priority: 3",
   },
+
+  // Curse type: pokeplatinum uses TYPE_MYSTERY (value 9), not TYPE_GHOST
+  {
+    target: "move",
+    moveId: "curse",
+    field: "type",
+    value: "unknown",
+    showdownValue: "ghost",
+    source:
+      "pret/pokeplatinum include/constants/pokemon.h — TYPE_MYSTERY = 9; move Curse uses TYPE_MYSTERY not TYPE_GHOST",
+  },
 ];

--- a/tools/oracle-validation/data/known-disagreements/gen2-known-disagreements.json
+++ b/tools/oracle-validation/data/known-disagreements/gen2-known-disagreements.json
@@ -189,7 +189,7 @@
     "ourValue": 3,
     "oracleValue": 2,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_PROTECT priority 3",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_PROTECT priority 3",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
@@ -202,7 +202,7 @@
     "ourValue": 3,
     "oracleValue": 2,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_PROTECT priority 3; data/moves/moves.asm \u2014 DETECT uses EFFECT_PROTECT",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_PROTECT priority 3; data/moves/moves.asm — DETECT uses EFFECT_PROTECT",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
@@ -215,7 +215,7 @@
     "ourValue": 3,
     "oracleValue": 2,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_ENDURE priority 3",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_ENDURE priority 3",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
@@ -228,7 +228,7 @@
     "ourValue": 2,
     "oracleValue": 1,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_QUICK_ATTACK priority 2",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_QUICK_ATTACK priority 2",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
@@ -241,7 +241,7 @@
     "ourValue": 2,
     "oracleValue": 1,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_QUICK_ATTACK priority 2; data/moves/moves.asm \u2014 Mach Punch uses EFFECT_QUICK_ATTACK",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_QUICK_ATTACK priority 2; data/moves/moves.asm — Mach Punch uses EFFECT_QUICK_ATTACK",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
@@ -254,7 +254,7 @@
     "ourValue": 2,
     "oracleValue": 1,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_QUICK_ATTACK priority 2; data/moves/moves.asm \u2014 Extreme Speed uses EFFECT_QUICK_ATTACK",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_QUICK_ATTACK priority 2; data/moves/moves.asm — Extreme Speed uses EFFECT_QUICK_ATTACK",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
@@ -267,7 +267,7 @@
     "ourValue": 0,
     "oracleValue": -1,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_FORCE_SWITCH priority 0 (1-based scale)",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_FORCE_SWITCH priority 0 (1-based scale)",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
@@ -280,7 +280,7 @@
     "ourValue": 0,
     "oracleValue": -1,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_FORCE_SWITCH priority 0 (1-based scale)",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_FORCE_SWITCH priority 0 (1-based scale)",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
@@ -293,7 +293,7 @@
     "ourValue": 0,
     "oracleValue": -1,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_COUNTER priority 0 (1-based scale)",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_COUNTER priority 0 (1-based scale)",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
@@ -306,7 +306,7 @@
     "ourValue": 0,
     "oracleValue": -1,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_MIRROR_COAT priority 0 (1-based scale)",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_MIRROR_COAT priority 0 (1-based scale)",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
@@ -319,9 +319,22 @@
     "ourValue": 0,
     "oracleValue": -1,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokecrystal data/moves/effects_priorities.asm \u2014 EFFECT_VITAL_THROW priority 0 (1-based scale)",
+    "source": "pret/pokecrystal data/moves/effects_priorities.asm — EFFECT_VITAL_THROW priority 0 (1-based scale)",
     "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/data/moves/effects_priorities.asm",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
+  },
+  {
+    "id": "gen2:move:curse:type",
+    "gen": 2,
+    "suite": "moves",
+    "description": "Curse type is TYPE_MYSTERY (CURSE_TYPE=19) in pokecrystal, not Ghost. @pkmn/data reports ghost.",
+    "ourValue": "unknown",
+    "oracleValue": "ghost",
+    "resolution": "cartridge-accurate",
+    "source": "pret/pokecrystal constants/type_constants.asm — CURSE_TYPE EQU 19; data/moves/moves.asm",
+    "sourceUrl": "https://github.com/pret/pokecrystal/blob/master/constants/type_constants.asm",
+    "oracleVersion": "@pkmn/data",
+    "addedDate": "2026-03-29"
   }
 ]

--- a/tools/oracle-validation/data/known-disagreements/gen3-known-disagreements.json
+++ b/tools/oracle-validation/data/known-disagreements/gen3-known-disagreements.json
@@ -7,9 +7,22 @@
     "ourValue": 3,
     "oracleValue": 4,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokeemerald src/data/battle_moves.h \u2014 endure: .priority = 3",
+    "source": "pret/pokeemerald src/data/battle_moves.h — endure: .priority = 3",
     "sourceUrl": "https://github.com/pret/pokeemerald/blob/master/src/data/battle_moves.h",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
+  },
+  {
+    "id": "gen3:move:curse:type",
+    "gen": 3,
+    "suite": "moves",
+    "description": "Curse type is TYPE_MYSTERY=9 in pokeemerald, not Ghost. @pkmn/data reports ghost.",
+    "ourValue": "unknown",
+    "oracleValue": "ghost",
+    "resolution": "cartridge-accurate",
+    "source": "pret/pokeemerald include/constants/pokemon.h — TYPE_MYSTERY = 9; src/data/battle_moves.h",
+    "sourceUrl": "https://github.com/pret/pokeemerald/blob/master/include/constants/pokemon.h",
+    "oracleVersion": "@pkmn/data",
+    "addedDate": "2026-03-29"
   }
 ]

--- a/tools/oracle-validation/data/known-disagreements/gen4-known-disagreements.json
+++ b/tools/oracle-validation/data/known-disagreements/gen4-known-disagreements.json
@@ -7,9 +7,22 @@
     "ourValue": 3,
     "oracleValue": 4,
     "resolution": "cartridge-accurate",
-    "source": "pret/pokeplatinum res/battle/moves/endure/data.json \u2014 priority: 3",
+    "source": "pret/pokeplatinum res/battle/moves/endure/data.json — priority: 3",
     "sourceUrl": "https://github.com/BluRosie/pokeplatinum/blob/main/res/battle/moves/endure/data.json",
     "oracleVersion": "@pkmn/data@0.10.7",
     "addedDate": "2026-03-28"
+  },
+  {
+    "id": "gen4:move:curse:type",
+    "gen": 4,
+    "suite": "moves",
+    "description": "Curse type is TYPE_MYSTERY=9 in pokeplatinum, not Ghost. @pkmn/data reports ghost.",
+    "ourValue": "unknown",
+    "oracleValue": "ghost",
+    "resolution": "cartridge-accurate",
+    "source": "pret/pokeplatinum include/constants/pokemon.h — TYPE_MYSTERY = 9; move Curse uses TYPE_MYSTERY",
+    "sourceUrl": "https://github.com/pret/pokeplatinum",
+    "oracleVersion": "@pkmn/data",
+    "addedDate": "2026-03-29"
   }
 ]


### PR DESCRIPTION
## Summary

- Adds `"unknown"` to `PokemonType` union as a move-type-only sentinel for `TYPE_MYSTERY`/`CURSE_TYPE` used by Curse in Gen 2-4 cartridge ROMs
- Adds `SpeciesType = Exclude<PokemonType, "unknown">` type alias and narrows `PokemonSpeciesData.types`, `MegaEvolutionData.types`, and `RegionalFormData.types` to use it
- Changes `TypeChart` to `Partial<Record<PokemonType, Partial<Record<PokemonType, number>>>>` — canonical lookup via `getTypeMultiplier()` already handles missing entries with `?? 1`
- Corrects Curse `type` field from `"ghost"` to `"unknown"` in `gen2/gen3/gen4` data files (pret cartridge authority)
- Adds pret override entries for Gen 2-4 Curse with full source citations
- Adds known-disagreement entries for gen2/gen3/gen4 Curse type vs `@pkmn/data` oracle
- Adds data-loading tests asserting `curse.type === CORE_TYPE_IDS.unknown` for Gen 2, 3, 4
- Adds defensive fallback test: `getMaxMoveName("unknown", false) === "Max Strike"` for gen8

## Sources

- `pret/pokecrystal constants/type_constants.asm` — `CURSE_TYPE EQU 19`
- `pret/pokeemerald include/constants/pokemon.h` — `TYPE_MYSTERY = 9`; `src/data/battle_moves.h` — Curse `.type = TYPE_MYSTERY`
- `pret/pokeplatinum include/constants/pokemon.h` — `TYPE_MYSTERY = 9`

## Test plan

- [ ] `npm run verify:local` passes (19 typecheck, all tests green)
- [ ] Gen 2 data-loading: `curse.type === "unknown"` test passes
- [ ] Gen 3 data-loading: `curse.type === "unknown"` test passes
- [ ] Gen 4 data-loading: `curse.type === "unknown"` test passes
- [ ] Gen 8 max-moves: `getMaxMoveName("unknown", false) === "Max Strike"` test passes
- [ ] Changeset: minor for `@pokemon-lib-ts/core`, patch for gen2/gen3/gen4/gen8

Closes #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected Curse move's type from Ghost to unknown/TYPE_MYSTERY in Generations 2, 3, and 4 to match cartridge behavior.

* **Chores**
  * Enhanced type system to properly support TYPE_MYSTERY as a special sentinel type and validate data accuracy across generations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->