### PR TITLE
fix(gen2): add go-last guard to Roar/Whirlwind — fail when user moves first

### DIFF
--- a/.changeset/fix-gen2-roar-whirlwind-go-last.md
+++ b/.changeset/fix-gen2-roar-whirlwind-go-last.md
@@ -1,0 +1,8 @@
+---
+"@pokemon-lib-ts/gen2": patch
+---
+
+fix(gen2): add go-last guard to Roar/Whirlwind — fail when user moves first
+
+Source: pret/pokecrystal engine/battle/effect_commands.asm BattleCommand_ForceSwitch
+lines 5008-5010 — wEnemyGoesFirst check fails the move when user moved first.

--- a/packages/gen2/src/Gen2MoveEffects.ts
+++ b/packages/gen2/src/Gen2MoveEffects.ts
@@ -466,9 +466,15 @@ export function handleCustomEffect(
     case "whirlwind":
     case "roar": {
       // Force the opponent to switch to a random party member.
-      // Source: pret/pokecrystal engine/battle/effect_commands.asm BattleCommand_Whirlwind
-      // In Gen 2, Whirlwind/Roar work (unlike Gen 1 where they always fail in trainer battles).
-      // These are -1 priority in Gen 2 data. No ability checks needed (Gen 2 has no abilities).
+      // Source: pret/pokecrystal engine/battle/effect_commands.asm BattleCommand_ForceSwitch
+      //   Lines 5008-5010: ld a, [wEnemyGoesFirst]; and a; jr z, .switch_fail
+      //   Fails if wEnemyGoesFirst == 0 (user moved first this turn).
+      // Go-last guard: if the defender has NOT yet moved this turn, the user went first
+      // and the move should fail. This is the Gen 2 phazing go-last mechanic.
+      if (!defender.movedThisTurn) {
+        result.messages.push("But it failed!");
+        break;
+      }
       result.switchOut = true;
       result.forcedSwitch = true;
       break;

--- a/packages/gen2/tests/unit/combat-moves.test.ts
+++ b/packages/gen2/tests/unit/combat-moves.test.ts
@@ -716,13 +716,16 @@ describe("Gen 2 Combat Moves", () => {
   // =========================================================================
 
   describe("Whirlwind/Roar", () => {
-    it("given Whirlwind is used, when executeMoveEffect is called, then sets switchOut and forcedSwitch", () => {
+    it("given Whirlwind is used and defender already moved this turn, when executeMoveEffect is called, then sets switchOut and forcedSwitch", () => {
       // Arrange
-      // Source: pret/pokecrystal engine/battle/effect_commands.asm BattleCommand_Whirlwind
-      // In Gen 2, Whirlwind forces the opponent to switch to a random party member.
-      // The forcedSwitch flag tells the engine that the DEFENDER is forced to switch.
+      // Source: pret/pokecrystal engine/battle/effect_commands.asm BattleCommand_ForceSwitch lines 5008-5010
+      //   ld a, [wEnemyGoesFirst] ; nonzero = enemy went first (user is slower)
+      //   and a
+      //   jr z, .switch_fail      ; fail if wEnemyGoesFirst == 0 (user went first)
+      // Whirlwind succeeds when the defender (enemy) has already moved this turn.
       const attacker = createMockActive();
       const defender = createMockActive();
+      defender.movedThisTurn = true; // defender went first → user is slower → should succeed
       const state = createMockState(createMockSide(0, attacker), createMockSide(1, defender));
 
       // Act
@@ -740,12 +743,13 @@ describe("Gen 2 Combat Moves", () => {
       expect(result.forcedSwitch).toBe(true);
     });
 
-    it("given Roar is used, when executeMoveEffect is called, then sets switchOut and forcedSwitch", () => {
+    it("given Roar is used and defender already moved this turn, when executeMoveEffect is called, then sets switchOut and forcedSwitch", () => {
       // Arrange
-      // Source: pret/pokecrystal engine/battle/effect_commands.asm BattleCommand_Whirlwind
-      // Roar has the same phazing effect as Whirlwind.
+      // Source: pret/pokecrystal engine/battle/effect_commands.asm BattleCommand_ForceSwitch lines 5008-5010
+      // Roar succeeds when the defender has already moved (user went second).
       const attacker = createMockActive();
       const defender = createMockActive();
+      defender.movedThisTurn = true; // defender went first → user is slower → should succeed
       const state = createMockState(createMockSide(0, attacker), createMockSide(1, defender));
 
       // Act
@@ -761,6 +765,60 @@ describe("Gen 2 Combat Moves", () => {
       // Assert
       expect(result.switchOut).toBe(true);
       expect(result.forcedSwitch).toBe(true);
+    });
+
+    it("given Whirlwind is used and user moved first this turn, when executeMoveEffect is called, then fails", () => {
+      // Arrange
+      // Source: pret/pokecrystal engine/battle/effect_commands.asm BattleCommand_ForceSwitch lines 5008-5010
+      //   ld a, [wEnemyGoesFirst] ; 0 = player went first (user is faster than enemy)
+      //   and a
+      //   jr z, .switch_fail      ; jump to fail because user went first
+      // Whirlwind fails when the user is faster and moved first this turn.
+      // This is the go-last mechanic introduced in Gen 2.
+      const attacker = createMockActive();
+      const defender = createMockActive();
+      // defender.movedThisTurn defaults to false → user went first
+      const state = createMockState(createMockSide(0, attacker), createMockSide(1, defender));
+
+      // Act
+      const result = ruleset.executeMoveEffect({
+        attacker,
+        defender,
+        move: WHIRLWIND_MOVE,
+        damage: 0,
+        state,
+        rng: new SeededRandom(42),
+      });
+
+      // Assert
+      expect(result.switchOut).toBe(false);
+      expect(result.forcedSwitch).toBeUndefined();
+      expect(result.messages).toContain("But it failed!");
+    });
+
+    it("given Roar is used and user moved first this turn, when executeMoveEffect is called, then fails", () => {
+      // Arrange
+      // Source: pret/pokecrystal engine/battle/effect_commands.asm BattleCommand_ForceSwitch lines 5008-5010
+      // Roar fails when the user is faster and moved first this turn (go-last mechanic).
+      const attacker = createMockActive();
+      const defender = createMockActive();
+      // defender.movedThisTurn defaults to false → user went first
+      const state = createMockState(createMockSide(0, attacker), createMockSide(1, defender));
+
+      // Act
+      const result = ruleset.executeMoveEffect({
+        attacker,
+        defender,
+        move: ROAR_MOVE,
+        damage: 0,
+        state,
+        rng: new SeededRandom(42),
+      });
+
+      // Assert
+      expect(result.switchOut).toBe(false);
+      expect(result.forcedSwitch).toBeUndefined();
+      expect(result.messages).toContain("But it failed!");
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds go-last guard to the Roar/Whirlwind handler in `Gen2MoveEffects.ts`
- Roar and Whirlwind now fail with "But it failed!" when the user moved first this turn (i.e., the defender has not yet moved)
- Updated 2 existing Roar/Whirlwind tests to set `defender.movedThisTurn = true` (the success scenario)
- Added 2 new tests for the failure scenario (user went first)

## Source

`pret/pokecrystal engine/battle/effect_commands.asm` — `BattleCommand_ForceSwitch` lines 5008-5010:
```asm
ld a, [wEnemyGoesFirst]  ; 0 = user went first
and a
jr z, .switch_fail       ; fail if wEnemyGoesFirst == 0
```

When `wEnemyGoesFirst == 0` (user is faster and moved first), the switch is blocked.  
Our implementation: `if (!defender.movedThisTurn) { fail }`.

## Test plan

- [ ] `npm run verify:local` passes
- [ ] Gen 2 Roar/Whirlwind "fail when user goes first" tests pass (2 new tests)
- [ ] Gen 2 Roar/Whirlwind "succeed when defender went first" tests pass (2 updated tests)
- [ ] No regressions in gen2 test suite (771 tests total)
- [ ] Changeset: patch for `@pokemon-lib-ts/gen2`

Closes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Gen 2 Roar/Whirlwind mechanics to correctly fail when the user moves first, aligning with classic game behavior.

* **Tests**
  * Updated test coverage for Roar/Whirlwind to validate new failure conditions and existing success scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->