### PR TITLE
fix(replay-parser): remove globals:true to fix workspace vitest runner

### DIFF
--- a/tools/replay-parser/vitest.config.ts
+++ b/tools/replay-parser/vitest.config.ts
@@ -6,8 +6,6 @@ export default defineConfig({
     alias: workspaceTestAliases(),
   },
   test: {
-    globals: true,
-    environment: "node",
     include: ["tests/**/*.test.ts"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- Removes `globals: true` and `environment: "node"` from `tools/replay-parser/vitest.config.ts`
- Fixes the workspace runner (`npx vitest run --workspace vitest.workspace.ts`) which was failing with a "tried to load vitest.workspace.ts from tool directory" error
- Aligns replay-parser config with `tools/oracle-validation/vitest.config.ts` (same fix applied earlier for oracle-validation)

## Root Cause

vitest v1 ESM workspace config resolution is triggered by `globals: true` in a tool's `vitest.config.ts`. This causes vitest to try to load `vitest.workspace.ts` from the tool directory instead of the root workspace config.

## Test plan

- [ ] `npx vitest run tools/replay-parser/tests/` passes (131 tests)
- [ ] `npx vitest run --workspace vitest.workspace.ts` includes replay-parser without errors
- [ ] No changeset needed (tools only)

Closes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to use default environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->