### PR TITLE
chore: update CLAUDE.md generation status table with accurate test counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,17 +103,17 @@ See `.claude/rules/testing-rules.md` and `.claude/rules/test-integrity.md` for d
 
 | Package | Status | Tests | Open Bugs |
 |---------|--------|-------|-----------|
-| core | 100% | 342 | 0 |
-| battle | 100% (singles) | 596 | 0 |
-| gen1 | 100% | 800 | 1 (#530) |
-| gen2 | 100% | 757 | 0 |
-| gen3 | 100% | 847 | 1 (#141) |
-| gen4 | 100% | 1,225 | 0 |
-| gen5 | 100% | 1,225 | 0 |
-| gen6 | 100% | 1,135 | 0 |
-| gen7 | 100% | 1,144 | 0 |
-| gen8 | 100% | 1,208 | 0 |
-| gen9 | 100% | 1,053 | 0 |
+| core | 100% | 399 | 0 |
+| battle | 100% (singles) | 688 | 0 |
+| gen1 | 100% | 787 | 0 |
+| gen2 | 100% | 771 | 0 |
+| gen3 | 100% | 882 | 1 (#141) |
+| gen4 | 100% | 1,231 | 0 |
+| gen5 | 100% | 1,233 | 0 |
+| gen6 | 100% | 1,154 | 0 |
+| gen7 | 100% | 1,219 | 0 |
+| gen8 | 100% | 1,254 | 0 |
+| gen9 | 100% | 1,108 | 0 |
 
 Full per-gen details: `specs/reference/genN-status.md`
 


### PR DESCRIPTION
## Summary

- Updates all test counts in the Generation Status table to match actual current counts (total: 10,726, up from stale ~10,332)
- Removes `#530` from gen1 open bugs (badge-boost glitch issue is already closed — was implemented and verified)
- Gen3 open bug `#141` (Plus/Minus doubles) remains — blocked on doubles engine support

No code changes, no changeset needed.

## Test plan

- [x] Docs-only change — biome check passes, no test changes

Closes: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated generation status table with current test and open bug metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->