### PR TITLE
feat(smoke): realistic team generation — items, abilities, natures, moves, size 6

### DIFF
--- a/tools/oracle-validation/src/smoke-runner.ts
+++ b/tools/oracle-validation/src/smoke-runner.ts
@@ -18,7 +18,7 @@ import {
   BattleEngine,
   RandomAI,
 } from "@pokemon-lib-ts/battle";
-import type { DataManager, Generation } from "@pokemon-lib-ts/core";
+import type { AbilitySlot, DataManager, Generation, NatureId } from "@pokemon-lib-ts/core";
 import {
   CORE_ABILITY_SLOTS,
   CORE_ITEM_IDS,
@@ -44,7 +44,7 @@ import type { ImplementedGeneration } from "./gen-discovery.js";
 import type { SuiteResult } from "./result-schema.js";
 
 const SMOKE_BATTLES_PER_GEN = 200;
-const TEAM_SIZE = 3;
+const TEAM_SIZE = 6;
 const MAX_TURNS = 200;
 const BASE_SEED = 0xbabe_cafe;
 
@@ -84,7 +84,7 @@ function createRuleset(gen: number): GenerationRuleset {
   return (factories[gen] ?? (() => new Gen1Ruleset()))();
 }
 
-function generateMinimalTeam(
+export function generateMinimalTeam(
   gen: number,
   dataManager: DataManager,
   rng: SeededRandom,
@@ -94,6 +94,12 @@ function generateMinimalTeam(
   const shuffled = rng.shuffle([...allSpecies]);
   const team = [];
   let nextUid = 0;
+
+  // Pre-build item pool and nature list once per team
+  // Items: Gen 2+ has held items in the DataManager (62 in Gen 2, growing in later gens)
+  // Natures: Gen 3+ only (Gen 1-2 have no nature mechanic)
+  const allItems = gen >= 2 ? dataManager.getAllItems() : [];
+  const allNatures = gen >= 3 ? dataManager.getAllNatures() : [];
 
   for (const species of shuffled) {
     if (team.length >= TEAM_SIZE) break;
@@ -105,7 +111,9 @@ function generateMinimalTeam(
     const uniqueIds = [...new Set(learnableMoveIds)];
     if (uniqueIds.length === 0) continue;
 
-    const moves = uniqueIds.slice(0, 4).flatMap((id) => {
+    // Shuffle the move pool and pick up to 4
+    const shuffledMoveIds = rng.shuffle([...uniqueIds]);
+    const moves = shuffledMoveIds.slice(0, 4).flatMap((id) => {
       try {
         const md = dataManager.getMove(id);
         return [{ moveId: id, currentPP: md.pp, maxPP: md.pp, ppUps: 0 }];
@@ -134,17 +142,57 @@ function generateMinimalTeam(
           });
     const evs = gen <= 2 ? createStatExp() : createEvs();
 
-    const abilitySlot = CORE_ABILITY_SLOTS.normal1;
+    // Randomly select an ability slot from available options
     let ability = "";
+    let abilitySlot: AbilitySlot = CORE_ABILITY_SLOTS.normal1;
     if (gen >= 3) {
-      const candidate = species.abilities.normal[0] ?? "";
-      if (!candidate) continue;
+      const candidates: [string, AbilitySlot][] = [];
+      if (species.abilities.normal[0])
+        candidates.push([species.abilities.normal[0], CORE_ABILITY_SLOTS.normal1]);
+      if (species.abilities.normal[1])
+        candidates.push([species.abilities.normal[1], CORE_ABILITY_SLOTS.normal2]);
+      if (species.abilities.hidden)
+        candidates.push([species.abilities.hidden, CORE_ABILITY_SLOTS.hidden]);
+
+      if (candidates.length === 0) continue;
+
+      // Pick a random slot
+      const pick = rng.pick(candidates);
+      const [candidateId, candidateSlot] = pick;
       try {
-        dataManager.getAbility(candidate);
-        ability = candidate;
+        dataManager.getAbility(candidateId);
+        ability = candidateId;
+        abilitySlot = candidateSlot;
       } catch {
-        continue;
+        // Fall back to first candidate (if the random pick happened to be candidates[0]
+        // and it failed, this re-tries the same entry — both will fail together, which is
+        // correct since a bad ability reference means the species should be skipped).
+        const first = candidates[0];
+        if (!first) continue;
+        try {
+          dataManager.getAbility(first[0]);
+          ability = first[0];
+          abilitySlot = first[1];
+        } catch {
+          continue;
+        }
       }
+    }
+
+    // Randomly pick a held item (Gen 2+)
+    let heldItem: string | null = null;
+    if (gen >= 2 && allItems.length > 0) {
+      heldItem = rng.pick(allItems).id;
+    }
+
+    // Randomly pick a nature (Gen 3+), or use neutral for Gen 1-2
+    let nature: NatureId;
+    if (gen <= 2) {
+      nature = CORE_NATURE_IDS.serious;
+    } else if (allNatures.length > 0) {
+      nature = rng.pick(allNatures).id;
+    } else {
+      nature = CORE_NATURE_IDS.hardy;
     }
 
     team.push({
@@ -153,14 +201,14 @@ function generateMinimalTeam(
       nickname: null,
       level: 50,
       experience: 0,
-      nature: gen <= 2 ? CORE_NATURE_IDS.serious : CORE_NATURE_IDS.hardy,
+      nature,
       ivs,
       evs,
       currentHp: 1,
       moves,
       ability,
       abilitySlot,
-      heldItem: null,
+      heldItem,
       status: null,
       friendship: 70,
       gender: "male" as const,

--- a/tools/oracle-validation/tests/smoke-runner.test.ts
+++ b/tools/oracle-validation/tests/smoke-runner.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for smoke runner team generation improvements.
+ *
+ * Validates that teams use realistic diversity: full 6-member teams, randomized
+ * items, varied natures, varied ability slots, and shuffled move selection.
+ */
+
+import { SeededRandom } from "@pokemon-lib-ts/core";
+import { createGen1DataManager } from "@pokemon-lib-ts/gen1";
+import { createGen3DataManager } from "@pokemon-lib-ts/gen3";
+import { createGen9DataManager } from "@pokemon-lib-ts/gen9";
+import { describe, expect, it } from "vitest";
+import { generateMinimalTeam } from "../src/smoke-runner.js";
+
+const gen1DataManager = createGen1DataManager();
+const gen3DataManager = createGen3DataManager();
+const gen9DataManager = createGen9DataManager();
+
+describe("smoke-runner generateMinimalTeam — realistic team diversity", () => {
+  // ---------------------------------------------------------------------------
+  // Team size
+  // ---------------------------------------------------------------------------
+
+  it("given gen9 with TEAM_SIZE=6, when generating a team, then team has 6 members", () => {
+    const rng = new SeededRandom(0xdead_beef);
+    const team = generateMinimalTeam(9, gen9DataManager, rng, "p1");
+    expect(team.length).toBe(6);
+  });
+
+  it("given gen3 with TEAM_SIZE=6, when generating a team, then team has 6 members", () => {
+    const rng = new SeededRandom(0xcafe_babe);
+    const team = generateMinimalTeam(3, gen3DataManager, rng, "p1");
+    expect(team.length).toBe(6);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Items
+  // ---------------------------------------------------------------------------
+
+  it("given gen9 across 5 different seeds, when generating teams, then at least one team has a non-null item", () => {
+    // Source: items should be randomly sampled from the gen's item pool
+    const seeds = [0x1111, 0x2222, 0x3333, 0x4444, 0x5555];
+    const allMembers = seeds.flatMap((seed) => {
+      const rng = new SeededRandom(seed);
+      return generateMinimalTeam(9, gen9DataManager, rng, "p1");
+    });
+    const hasItem = allMembers.some((m) => m.heldItem !== null);
+    expect(hasItem).toBe(true);
+  });
+
+  it("given gen9 across 5 different seeds, when generating teams, then items are not all the same", () => {
+    // Source: items should vary between teams/members
+    const seeds = [0xaaaa, 0xbbbb, 0xcccc, 0xdddd, 0xeeee];
+    const allItems = seeds.flatMap((seed) => {
+      const rng = new SeededRandom(seed);
+      return generateMinimalTeam(9, gen9DataManager, rng, "p1").map((m) => m.heldItem);
+    });
+    const nonNullItems = allItems.filter((i) => i !== null);
+    expect(nonNullItems.length).toBeGreaterThan(0);
+    const uniqueItems = new Set(nonNullItems);
+    expect(uniqueItems.size).toBeGreaterThan(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Natures
+  // ---------------------------------------------------------------------------
+
+  it("given gen9 across 10 different seeds, when generating teams, then natures are varied (not all serious/hardy)", () => {
+    // Source: 25 natures available since Gen 3; should be randomly selected
+    const seeds = Array.from({ length: 10 }, (_, i) => 0x1000 + i * 0x111);
+    const allNatures = seeds.flatMap((seed) => {
+      const rng = new SeededRandom(seed);
+      return generateMinimalTeam(9, gen9DataManager, rng, "p1").map((m) => m.nature);
+    });
+    const uniqueNatures = new Set(allNatures);
+    expect(uniqueNatures.size).toBeGreaterThan(2); // More than just serious/hardy
+  });
+
+  // ---------------------------------------------------------------------------
+  // Ability slot randomization
+  // ---------------------------------------------------------------------------
+
+  it("given gen9 across 10 different seeds, when generating teams, then ability slots are varied", () => {
+    // Source: ability slots should be randomly picked from available normal/hidden slots
+    const seeds = Array.from({ length: 10 }, (_, i) => 0x2000 + i * 0x111);
+    const allSlots = seeds.flatMap((seed) => {
+      const rng = new SeededRandom(seed);
+      return generateMinimalTeam(9, gen9DataManager, rng, "p1").map((m) => m.abilitySlot);
+    });
+    const uniqueSlots = new Set(allSlots);
+    expect(uniqueSlots.size).toBeGreaterThan(1); // Not all normal1
+  });
+
+  // ---------------------------------------------------------------------------
+  // Move randomization
+  // ---------------------------------------------------------------------------
+
+  it("given gen9 across 3 different seeds, when generating teams, then moves are shuffled (not always first 4)", () => {
+    // Source: moves should be randomly sampled from the full learnset, not always first 4
+    const teams = [0x3000, 0x4000, 0x5000].map((seed) => {
+      const rng = new SeededRandom(seed);
+      return generateMinimalTeam(9, gen9DataManager, rng, "p1");
+    });
+    // Collect all distinct first-move IDs across teams
+    const firstMoveIds = new Set(
+      teams.flatMap((team) => team.map((m) => m.moves[0]?.moveId ?? "")),
+    );
+    // With true randomization, different seeds should yield different first moves
+    expect(firstMoveIds.size).toBeGreaterThan(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Gen 1 invariants (different code path: no abilities, no items, neutral nature)
+  // ---------------------------------------------------------------------------
+
+  it("given gen1 with TEAM_SIZE=6, when generating a team, then team has 6 members", () => {
+    const rng = new SeededRandom(0xf00d_cafe);
+    const team = generateMinimalTeam(1, gen1DataManager, rng, "p1");
+    expect(team.length).toBe(6);
+  });
+
+  it("given gen1, when generating a team, then all members have null items", () => {
+    // Source: Gen 1 has no held item mechanic
+    const rng = new SeededRandom(0xabcd_1234);
+    const team = generateMinimalTeam(1, gen1DataManager, rng, "p1");
+    for (const member of team) {
+      expect(member.heldItem).toBeNull();
+    }
+  });
+
+  it("given gen1, when generating a team, then all members have neutral nature (serious)", () => {
+    // Source: Gen 1 has no nature mechanic — neutral nature avoids stat modifiers
+    const rng = new SeededRandom(0x1234_5678);
+    const team = generateMinimalTeam(1, gen1DataManager, rng, "p1");
+    for (const member of team) {
+      expect(member.nature).toBe("serious");
+    }
+  });
+
+  it("given gen1, when generating a team, then all members have empty ability string", () => {
+    // Source: Gen 1 has no ability mechanic
+    const rng = new SeededRandom(0x9abc_def0);
+    const team = generateMinimalTeam(1, gen1DataManager, rng, "p1");
+    for (const member of team) {
+      expect(member.ability).toBe("");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The smoke runner's `generateMinimalTeam()` previously gave zero coverage for held items (always null), ability slots beyond `normal1`, non-neutral natures, and non-first-4 moves. This PR makes teams realistic across all dimensions:

| Dimension | Before | After |
|-----------|--------|-------|
| Team size | 3 | 6 |
| Held items | always `null` | random from gen's item pool (Gen 2+) |
| Natures | always `serious`/`hardy` | random from 25 natures (Gen 3+) |
| Ability slots | always `normal1` | random pick from `normal1`/`normal2`/`hidden` |
| Move selection | first 4 from learnset | shuffled learnset, first 4 |

Also exports `generateMinimalTeam()` for direct unit testing.

## Test plan

- [x] 11 new tests in `tools/oracle-validation/tests/smoke-runner.test.ts` verify:
  - Team size is 6 for Gen 3 and Gen 9
  - Items vary across seeds (not all null, not all same)
  - Natures vary across seeds (>2 unique natures)
  - Ability slots vary across seeds (not all `normal1`)
  - Moves vary across seeds
  - Gen 1 invariants: no items, neutral nature, empty ability, team size 6
- [x] All 78 oracle-validation tests pass
- [x] `npm run verify:local` passes

Closes: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced smoke testing with larger generated teams (size increased from 3 to 6) for more realistic validation scenarios.
  * Added comprehensive test suite validating team diversity across different game generations, including randomization of items, natures, abilities, and movesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->