### PR TITLE
test(gen1): add pokered source citations to ruleset and ruleset-branches tests

### DIFF
--- a/packages/gen1/tests/unit/ruleset-branches.test.ts
+++ b/packages/gen1/tests/unit/ruleset-branches.test.ts
@@ -434,6 +434,7 @@ describe("Gen1Ruleset applyStatusDamage", () => {
     const state = makeBattleState();
     // Act
     const damage = ruleset.applyStatusDamage(pokemon, CORE_STATUS_IDS.burn, state);
+    // Source: pokered engine/battle/core.asm HandlePoisonBurnLeechSeed_DecreaseOwnHP — burn/poison damage = floor(maxHp/16), min 1
     // Assert: floor(160 / 16) = 10
     expect(damage).toBe(10);
   });
@@ -456,6 +457,7 @@ describe("Gen1Ruleset applyStatusDamage", () => {
     const state = makeBattleState();
     // Act
     const damage = ruleset.applyStatusDamage(pokemon, CORE_STATUS_IDS.poison, state);
+    // Source: pokered engine/battle/core.asm HandlePoisonBurnLeechSeed_DecreaseOwnHP — burn/poison damage = floor(maxHp/16), min 1
     // Assert: floor(160 / 16) = 10
     expect(damage).toBe(10);
   });
@@ -481,6 +483,7 @@ describe("Gen1Ruleset applyStatusDamage", () => {
     const state = makeBattleState();
     // Act
     const damage = ruleset.applyStatusDamage(pokemon, CORE_STATUS_IDS.badlyPoisoned, state);
+    // Source: pokered engine/battle/core.asm HandlePoisonBurnLeechSeed_DecreaseOwnHP — toxic damage = floor(maxHp * counter / 16), min 1; counter increments each turn
     // Assert: floor(160 * 1 / 16) = 10
     expect(damage).toBe(10);
   });
@@ -506,6 +509,7 @@ describe("Gen1Ruleset applyStatusDamage", () => {
     const state = makeBattleState();
     // Act
     const damage = ruleset.applyStatusDamage(pokemon, CORE_STATUS_IDS.badlyPoisoned, state);
+    // Source: pokered engine/battle/core.asm HandlePoisonBurnLeechSeed_DecreaseOwnHP — toxic damage = floor(maxHp * counter / 16), min 1
     // Assert: floor(160 * 3 / 16) = floor(30) = 30
     expect(damage).toBe(30);
   });
@@ -528,6 +532,7 @@ describe("Gen1Ruleset applyStatusDamage", () => {
     const state = makeBattleState();
     // Act
     const damage = ruleset.applyStatusDamage(pokemon, CORE_STATUS_IDS.badlyPoisoned, state);
+    // Source: pokered engine/battle/core.asm HandlePoisonBurnLeechSeed_DecreaseOwnHP — toxic damage = floor(maxHp * counter / 16), min 1
     // Assert: defaults to counter 1 -> floor(160 * 1 / 16) = 10
     expect(damage).toBe(10);
   });
@@ -580,6 +585,7 @@ describe("Gen1Ruleset applyStatusDamage", () => {
     const state = makeBattleState();
     // Act
     const damage = ruleset.applyStatusDamage(pokemon, CORE_STATUS_IDS.burn, state);
+    // Source: pokered engine/battle/core.asm HandlePoisonBurnLeechSeed_DecreaseOwnHP — minimum damage is 1; max(1, floor(15/16)) = max(1, 0) = 1
     // Assert: max(1, floor(15 / 16)) = max(1, 0) = 1
     expect(damage).toBe(1);
   });
@@ -818,6 +824,7 @@ describe("Gen1Ruleset executeMoveEffect", () => {
     const ctx = createMoveEffectContextFixture({ move, damage: 100 });
     // Act
     const result = ruleset.executeMoveEffect(ctx);
+    // Source: pokered engine/battle/move_effects/recoil.asm RecoilEffect_ — recoil = floor(damage * fraction), min 1
     // Assert: max(1, floor(100 * 0.25)) = 25
     expect(result.recoilDamage).toBe(25);
   });
@@ -830,6 +837,7 @@ describe("Gen1Ruleset executeMoveEffect", () => {
     const ctx = createMoveEffectContextFixture({ move, damage: 1 });
     // Act
     const result = ruleset.executeMoveEffect(ctx);
+    // Source: pokered engine/battle/move_effects/recoil.asm RecoilEffect_ — recoil = floor(damage * fraction), min 1
     // Assert: max(1, floor(1 * 0.25)) = max(1, 0) = 1
     expect(result.recoilDamage).toBe(1);
   });
@@ -844,6 +852,7 @@ describe("Gen1Ruleset executeMoveEffect", () => {
     const ctx = createMoveEffectContextFixture({ move, damage: 80 });
     // Act
     const result = ruleset.executeMoveEffect(ctx);
+    // Source: pokered engine/battle/move_effects/drain_hp.asm DrainHPEffect_ — heal = floor(damage / 2), min 1
     // Assert: max(1, floor(80 * 0.5)) = 40
     expect(result.healAmount).toBe(40);
   });
@@ -856,6 +865,7 @@ describe("Gen1Ruleset executeMoveEffect", () => {
     const ctx = createMoveEffectContextFixture({ move, damage: 1 });
     // Act
     const result = ruleset.executeMoveEffect(ctx);
+    // Source: pokered engine/battle/move_effects/drain_hp.asm DrainHPEffect_ — heal = floor(damage / 2), min 1
     // Assert: max(1, floor(1 * 0.5)) = max(1, 0) = 1
     expect(result.healAmount).toBe(1);
   });
@@ -883,6 +893,7 @@ describe("Gen1Ruleset executeMoveEffect", () => {
     const ctx = createMoveEffectContextFixture({ attacker, move });
     // Act
     const result = ruleset.executeMoveEffect(ctx);
+    // Source: pokered engine/battle/move_effects/heal.asm HealEffect_ — Recover/Softboiled: srl b; rr c (divide maxHp by 2)
     // Assert: max(1, floor(200 * 0.5)) = 100
     expect(result.healAmount).toBe(100);
   });
@@ -1922,6 +1933,7 @@ describe("Gen1Ruleset checkFreezeThaw (Gen 1 quirk: permanent freeze)", () => {
       } as PokemonInstance,
     });
     const rng = new SeededRandom(42);
+    // Source: pokered engine/battle/core.asm .FrozenCheck — no natural thaw roll; frozen Pokemon simply cannot move; only opponent Fire-type move thaws
     // Act / Assert: Run 100 checks to confirm it never thaws
     for (let i = 0; i < 100; i++) {
       expect(ruleset.checkFreezeThaw(pokemon, rng)).toBe(false);
@@ -1937,6 +1949,7 @@ describe("Gen1Ruleset rollSleepTurns", () => {
   it("given Gen 1 ruleset, when rolling sleep turns, then returns value between 1 and 7", () => {
     // Arrange
     const rng = new SeededRandom(42);
+    // Source: pokered engine/battle/effects.asm SleepEffect .setSleepCounter — BattleRandom() & SLP_MASK (0b111), retry if 0; yields 1-7
     // Act / Assert
     for (let i = 0; i < 100; i++) {
       const turns = ruleset.rollSleepTurns(rng);
@@ -2015,6 +2028,7 @@ describe("Gen1Ruleset applyStatusDamage (toxic escalation)", () => {
     const state = makeBattleState();
     // Act
     const damage = ruleset.applyStatusDamage(pokemon, CORE_STATUS_IDS.badlyPoisoned, state);
+    // Source: pokered engine/battle/core.asm HandlePoisonBurnLeechSeed_DecreaseOwnHP — toxic damage = floor(maxHp * counter / 16), min 1
     // Assert: with counter=1 (default), damage = floor(160 * 1 / 16) = 10
     expect(damage).toBe(10);
   });
@@ -2563,6 +2577,7 @@ describe("Gen1Ruleset rollCritical", () => {
     const move = createScenarioMove({ category: MOVE_CATEGORIES.physical });
     const state = makeBattleState();
 
+    // Source: pokered engine/battle/core.asm CriticalHitTest — threshold = floor(baseSpeed/2) for normal moves; BattleRandom() × 8 mod 256 < threshold → crit
     // Act: Run many trials, crit rate should be roughly baseSpeed/512
     // Pikachu base speed = 90, so crit rate = floor(90/2)/256 = 45/256 ~ 17.6%
     let crits = 0;
@@ -2700,6 +2715,7 @@ describe("Gen1Ruleset checkFullParalysis (63/256 Gen 1 rate)", () => {
     // Act
     const result = ruleset.checkFullParalysis(pokemon, rng);
 
+    // Source: pokered engine/battle/core.asm CheckPlayerStatusConditions .ParalysisCheck — BattleRandom() < 63 (25*$ff/100) → paralyzed
     // Assert
     expect(result).toBe(true);
   });
@@ -2722,6 +2738,7 @@ describe("Gen1Ruleset checkFullParalysis (63/256 Gen 1 rate)", () => {
     // Act
     const result = ruleset.checkFullParalysis(pokemon, rng);
 
+    // Source: pokered engine/battle/core.asm CheckPlayerStatusConditions .ParalysisCheck — BattleRandom() < 63 → paralyzed; 63 is not < 63 → not paralyzed
     // Assert
     expect(result).toBe(false);
   });
@@ -2742,6 +2759,7 @@ describe("Gen1Ruleset checkFullParalysis (63/256 Gen 1 rate)", () => {
       if (ruleset.checkFullParalysis(pokemon, rng)) paralyzed++;
     }
 
+    // Source: pokered engine/battle/core.asm CheckPlayerStatusConditions .ParalysisCheck — BattleRandom() < 25*$ff/100 = 63 → fully paralyzed (63/256 ≈ 24.6%)
     // Assert — ~63/256 ≈ 24.6%, allow tolerance
     expect(paralyzed).toBeGreaterThan(180);
     expect(paralyzed).toBeLessThan(310);
@@ -2766,6 +2784,7 @@ describe("Gen1Ruleset processSleepTurn (Gen 1: cannot act on wake turn)", () => 
     // Act
     const canAct = ruleset.processSleepTurn(pokemon, makeBattleState());
 
+    // Source: pokered engine/battle/core.asm CheckPlayerStatusConditions .WakeUp — on wake (counter=0), still jumps to ExecutePlayerMoveDone; cannot act on wake turn
     // Assert — Gen 1: cannot act on the wake turn (returns false even on wake)
     expect(canAct).toBe(false);
     expect(pokemon.pokemon.status).toBeNull();
@@ -2804,6 +2823,7 @@ describe("Gen1Ruleset processSleepTurn (Gen 1: cannot act on wake turn)", () => 
     // Act
     const canAct = ruleset.processSleepTurn(pokemon, makeBattleState());
 
+    // Source: pokered engine/battle/core.asm CheckPlayerStatusConditions .WakeUp — on wake (counter=0), still jumps to ExecutePlayerMoveDone; cannot act on wake turn
     // Assert — Gen 1: wakes up but still cannot act this turn
     expect(canAct).toBe(false);
     expect(pokemon.pokemon.status).toBeNull();

--- a/packages/gen1/tests/unit/ruleset.test.ts
+++ b/packages/gen1/tests/unit/ruleset.test.ts
@@ -164,6 +164,7 @@ describe("Gen1Ruleset", () => {
     // Arrange
     const ruleset = new Gen1Ruleset();
     const rng = new SeededRandom(42);
+    // Source: pokered engine/battle/core.asm .FrozenCheck — no thaw roll in Gen 1; frozen Pokemon simply cannot move each turn
     // Act / Assert: In Gen 1, frozen Pokemon NEVER thaw naturally
     // They can only be thawed by a Fire-type move hitting them or items
     // Run many checks to verify it always returns false
@@ -179,6 +180,7 @@ describe("Gen1Ruleset", () => {
     // Arrange
     const ruleset = new Gen1Ruleset();
     const rng = new SeededRandom(42);
+    // Source: pokered engine/battle/effects.asm SleepEffect .setSleepCounter — BattleRandom() & SLP_MASK (0b111), retry if 0; yields 1-7
     // Act / Assert: Gen 1 sleep lasts 1-7 turns
     const results = new Set<number>();
     for (let i = 0; i < 1000; i++) {
@@ -214,6 +216,7 @@ describe("Gen1Ruleset", () => {
     const ruleset = new Gen1Ruleset();
     // Act
     const multiplier = ruleset.getCritMultiplier();
+    // Source: pokered engine/battle/core.asm CriticalHitTest — on crit, `sla e ; double level` directly in damage formula; no separate multiplier step
     // Assert: Gen 1 implements crits by doubling the attacker's level in the damage formula
     // (effectiveLevel = level * 2), not by applying a flat 2x multiplier after the fact.
     // The BattleEngine does not call getCritMultiplier() for Gen 1 — the boost is internal.
@@ -236,6 +239,7 @@ describe("Gen1Ruleset", () => {
     const ruleset = new Gen1Ruleset();
     // Act
     const order = ruleset.getEndOfTurnOrder();
+    // Source: pokered engine/battle/core.asm HandlePoisonBurnLeechSeed — status damage then leech seed drain; disable countdown at end-of-turn block
     // Assert: Gen 1 has a simpler set of end-of-turn effects than later gens
     expect(order).toEqual([
       CORE_END_OF_TURN_EFFECT_IDS.statusDamage,
@@ -298,6 +302,7 @@ describe("Gen1Ruleset", () => {
       const mockAttacker = createOnFieldPokemon();
       // Act
       const recoil = ruleset.calculateStruggleRecoil(mockAttacker, 100);
+      // Source: pokered engine/battle/move_effects/recoil.asm RecoilEffect_ — Struggle: srl b; rr c (÷2); all other moves ÷4; min 1
       // Assert: floor(100 / 2) = 50
       expect(recoil).toBe(50);
     });
@@ -308,6 +313,7 @@ describe("Gen1Ruleset", () => {
       const mockAttacker = createOnFieldPokemon();
       // Act
       const recoil = ruleset.calculateStruggleRecoil(mockAttacker, 1);
+      // Source: pokered engine/battle/move_effects/recoil.asm RecoilEffect_ — min recoil is 1 (`inc c` when result=0)
       // Assert: max(1, floor(1/2)) = max(1, 0) = 1
       expect(recoil).toBe(1);
     });
@@ -318,6 +324,7 @@ describe("Gen1Ruleset", () => {
       const mockAttacker = createOnFieldPokemon();
       // Act
       const recoil = ruleset.calculateStruggleRecoil(mockAttacker, 0);
+      // Source: pokered engine/battle/move_effects/recoil.asm RecoilEffect_ — min recoil is 1 (`inc c` when result=0)
       // Assert: max(1, floor(0/2)) = max(1, 0) = 1
       expect(recoil).toBe(1);
     });
@@ -328,6 +335,7 @@ describe("Gen1Ruleset", () => {
       const mockAttacker = createOnFieldPokemon();
       // Act
       const recoil = ruleset.calculateStruggleRecoil(mockAttacker, 101);
+      // Source: pokered engine/battle/move_effects/recoil.asm RecoilEffect_ — Struggle: floor(damage/2)
       // Assert: floor(101 / 2) = 50
       expect(recoil).toBe(50);
     });
@@ -343,6 +351,7 @@ describe("Gen1Ruleset", () => {
       const mockAttacker = createOnFieldPokemon();
       // Act
       const count = ruleset.rollMultiHitCount(mockAttacker, rng);
+      // Source: pokered engine/battle/effects.asm TWO_TO_FIVE_ATTACKS_EFFECT — 3/8 for 2 hits, 3/8 for 3 hits, 1/8 for 4 hits, 1/8 for 5 hits
       // Assert: must be one of the values in the weighted array
       expect([2, 3, 4, 5]).toContain(count);
     });
@@ -369,6 +378,7 @@ describe("Gen1Ruleset", () => {
       for (let i = 0; i < 100; i++) {
         counts.add(ruleset.rollMultiHitCount(mockAttacker, rng));
       }
+      // Source: pokered engine/battle/effects.asm TWO_TO_FIVE_ATTACKS_EFFECT — 3/8 chance each for 2 and 3; weighted [2,2,2,3,3,3,4,5]
       // Assert: weighted array has 3 twos and 3 threes out of 8, so both should appear
       expect(counts.has(2)).toBe(true);
       expect(counts.has(3)).toBe(true);


### PR DESCRIPTION
## Summary

- Adds `// Source: pokered ...` comments to all formula-based assertions in `packages/gen1/tests/unit/ruleset-branches.test.ts` and `packages/gen1/tests/unit/ruleset.test.ts`
- Cites specific pret/pokered routines: `HandlePoisonBurnLeechSeed_DecreaseOwnHP`, `RecoilEffect_`, `DrainHPEffect_`, `HealEffect_`, `CriticalHitTest`, `CheckPlayerStatusConditions`, `SleepEffect`, `TWO_TO_FIVE_ATTACKS_EFFECT`
- 30 source comment lines added; zero assertions changed

Closes: N/A

## Test plan

- [x] All 787 gen1 tests pass (`npx vitest run packages/gen1`)
- [x] `npm run verify:local` passes
- [x] No test logic or assertions modified — source comment lines only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced unit test documentation with inline comments explaining game mechanics and behavior calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->