### PR TITLE
feat(gen7): eliminate 136 as-any casts in test files

### DIFF
--- a/packages/gen7/tests/abilities-damage.test.ts
+++ b/packages/gen7/tests/abilities-damage.test.ts
@@ -14,6 +14,7 @@ import {
   type MoveData,
   type MoveEffect,
   type PokemonType,
+  type PrimaryStatus,
   SeededRandom,
 } from "@pokemon-lib-ts/core";
 import { describe, expect, it } from "vitest";
@@ -94,9 +95,9 @@ function createOnFieldPokemon(overrides: {
       ability: overrides.ability ?? abilityIds.none,
       abilitySlot: CORE_ABILITY_SLOTS.normal1,
       heldItem: overrides.heldItem ?? null,
-      status: (overrides.status ?? null) as any,
+      status: (overrides.status ?? null) as PrimaryStatus | null,
       friendship: 0,
-      gender: CORE_GENDERS.male as any,
+      gender: CORE_GENDERS.male,
       isShiny: false,
       metLocation: "",
       metLevel: 1,

--- a/packages/gen7/tests/abilities-nerfs.test.ts
+++ b/packages/gen7/tests/abilities-nerfs.test.ts
@@ -16,6 +16,7 @@ import {
   type MoveCategory,
   type MoveData,
   type PokemonType,
+  type PrimaryStatus,
   SeededRandom,
 } from "@pokemon-lib-ts/core";
 import { describe, expect, it } from "vitest";
@@ -116,7 +117,7 @@ function createSyntheticOnFieldPokemon(overrides: {
   pokemon.currentHp = overrides.currentHp ?? hp;
   pokemon.ability = overrides.ability ?? NONE_ABILITY;
   pokemon.heldItem = overrides.heldItem ?? null;
-  pokemon.status = (overrides.status ?? null) as any;
+  pokemon.status = (overrides.status ?? null) as PrimaryStatus | null;
   pokemon.nickname = overrides.nickname ?? DEFAULT_NICKNAME;
   pokemon.calculatedStats = { hp, attack, defense, spAttack, spDefense, speed };
 

--- a/packages/gen7/tests/abilities-new.test.ts
+++ b/packages/gen7/tests/abilities-new.test.ts
@@ -284,7 +284,7 @@ function createAbilityContext(opts: {
     pokemon,
     opponent: opts.opponent,
     state,
-    rng: state.rng as any,
+    rng: state.rng,
     trigger: opts.trigger,
     move: opts.move,
   };

--- a/packages/gen7/tests/abilities-switch-contact.test.ts
+++ b/packages/gen7/tests/abilities-switch-contact.test.ts
@@ -1,5 +1,11 @@
 import type { AbilityContext, BattleSide, BattleState } from "@pokemon-lib-ts/battle";
-import type { Gender, MoveData, PokemonType, WeatherType } from "@pokemon-lib-ts/core";
+import type {
+  AbilityTrigger,
+  Gender,
+  MoveData,
+  PokemonType,
+  WeatherType,
+} from "@pokemon-lib-ts/core";
 import {
   CORE_ABILITY_IDS,
   CORE_ABILITY_SLOTS,
@@ -277,7 +283,7 @@ function createAbilityContext(opts: {
 }): AbilityContext {
   const state = createBattleState();
   if (opts.rng) {
-    (state as any).rng = { ...state.rng, ...opts.rng };
+    (state as Record<string, unknown>).rng = { ...state.rng, ...opts.rng };
   }
   const pokemon = createOnFieldPokemon({
     ability: opts.ability,
@@ -296,8 +302,8 @@ function createAbilityContext(opts: {
     pokemon,
     opponent: opts.opponent,
     state,
-    rng: (opts.rng ?? state.rng) as any,
-    trigger: opts.trigger as any,
+    rng: (opts.rng ?? state.rng) as unknown as SeededRandom,
+    trigger: opts.trigger as AbilityTrigger,
     move: opts.move,
   };
 }

--- a/packages/gen7/tests/bugfix-phase2.test.ts
+++ b/packages/gen7/tests/bugfix-phase2.test.ts
@@ -1,9 +1,11 @@
 import type {
   AbilityContext,
+  AbilityEffect,
   ActivePokemon,
   BattleSide,
   BattleState,
   ItemContext,
+  MegaEvolveEvent,
 } from "@pokemon-lib-ts/battle";
 import { BATTLE_ABILITY_EFFECT_TYPES, BATTLE_ITEM_EFFECT_TYPES } from "@pokemon-lib-ts/battle";
 import type { MoveData, MoveSlot, PokemonType } from "@pokemon-lib-ts/core";
@@ -348,7 +350,7 @@ describe("#701 — Rayquaza Mega Evolution via Dragon Ascent", () => {
     // Should emit a mega-evolve event
     expect(events.length).toBe(1);
     expect(events[0].type).toBe("mega-evolve");
-    expect((events[0] as any).form).toBe("mega-rayquaza");
+    expect((events[0] as MegaEvolveEvent).form).toBe("mega-rayquaza");
 
     // Types should be updated
     expect(pokemon.types).toEqual([TYPES.dragon, TYPES.flying]);
@@ -498,8 +500,12 @@ describe("#688 — Beast Boost raises highest stat after KO", () => {
     expect(result.activated).toBe(true);
     expect(result.effects.length).toBe(1);
     expect(result.effects[0].effectType).toBe(ABILITY_EFFECT_TYPES.statChange);
-    expect((result.effects[0] as any).stat).toBe(STATS.attack);
-    expect((result.effects[0] as any).stages).toBe(1);
+    expect((result.effects[0] as Extract<AbilityEffect, { effectType: "stat-change" }>).stat).toBe(
+      STATS.attack,
+    );
+    expect(
+      (result.effects[0] as Extract<AbilityEffect, { effectType: "stat-change" }>).stages,
+    ).toBe(1);
   });
 
   it("given Pokemon with beast-boost and highest stat = spAttack, when opponent faints, then +1 Sp. Atk boost effect returned", () => {
@@ -522,7 +528,9 @@ describe("#688 — Beast Boost raises highest stat after KO", () => {
 
     expect(result.activated).toBe(true);
     expect(result.effects[0].effectType).toBe(ABILITY_EFFECT_TYPES.statChange);
-    expect((result.effects[0] as any).stat).toBe(STATS.spAttack);
+    expect((result.effects[0] as Extract<AbilityEffect, { effectType: "stat-change" }>).stat).toBe(
+      STATS.spAttack,
+    );
   });
 
   it("given Pokemon with beast-boost, when opponent is still alive, then no activation", () => {
@@ -561,8 +569,12 @@ describe("#688 — Moxie raises Attack after KO", () => {
     expect(result.activated).toBe(true);
     expect(result.effects.length).toBe(1);
     expect(result.effects[0].effectType).toBe(ABILITY_EFFECT_TYPES.statChange);
-    expect((result.effects[0] as any).stat).toBe(STATS.attack);
-    expect((result.effects[0] as any).stages).toBe(1);
+    expect((result.effects[0] as Extract<AbilityEffect, { effectType: "stat-change" }>).stat).toBe(
+      STATS.attack,
+    );
+    expect(
+      (result.effects[0] as Extract<AbilityEffect, { effectType: "stat-change" }>).stages,
+    ).toBe(1);
   });
 
   it("given Pokemon with moxie, when opponent survives, then no activation", () => {
@@ -606,7 +618,9 @@ describe("#688 — Battle Bond transforms Greninja after KO", () => {
     });
 
     const firstResult = handleGen7NewAbility(firstCtx);
-    const transformedVolatile = (firstResult.effects[0] as any).volatile;
+    const transformedVolatile = (
+      firstResult.effects[0] as Extract<AbilityEffect, { effectType: "volatile-inflict" }>
+    ).volatile;
     const ctx = createAbilityContext({
       trigger: ABILITY_TRIGGERS.onAfterMoveUsed,
       ability: ABILITIES.battleBond,

--- a/packages/gen7/tests/coverage-gaps.test.ts
+++ b/packages/gen7/tests/coverage-gaps.test.ts
@@ -8,6 +8,7 @@
 
 import type {
   AbilityContext,
+  AbilityEffect,
   ActivePokemon,
   BattleState,
   ItemContext,
@@ -16,8 +17,12 @@ import { BATTLE_ITEM_EFFECT_TYPES } from "@pokemon-lib-ts/battle";
 import { createOnFieldPokemon as createBattleOnFieldPokemon } from "@pokemon-lib-ts/battle/utils";
 import type {
   MoveData,
+  MultiHitEffect,
+  OhkoEffect,
   PokemonType,
   PrimaryStatus,
+  RecoilEffect,
+  StatusChanceEffect,
   TerrainType,
   WeatherType,
 } from "@pokemon-lib-ts/core";
@@ -325,7 +330,7 @@ function createAbilityContext(overrides: {
     rng: new SeededRandom(42),
     trigger: overrides.trigger,
     move: overrides.move,
-    statChange: overrides.statChange as any,
+    statChange: overrides.statChange,
   };
 }
 
@@ -613,11 +618,17 @@ describe("Gen7AbilitiesStat coverage gaps", () => {
       expect(result.activated).toBe(true);
       // Should have 2 effects: one +2 and one -1
       expect(result.effects).toHaveLength(2);
-      const raise = result.effects.find((e: any) => e.stages > 0);
-      const lower = result.effects.find((e: any) => e.stages < 0);
+      const raise = result.effects.find(
+        (e): e is Extract<AbilityEffect, { effectType: "stat-change" }> =>
+          (e as Extract<AbilityEffect, { effectType: "stat-change" }>).stages > 0,
+      );
+      const lower = result.effects.find(
+        (e): e is Extract<AbilityEffect, { effectType: "stat-change" }> =>
+          (e as Extract<AbilityEffect, { effectType: "stat-change" }>).stages < 0,
+      );
       // Source: Showdown -- Moody: +2 for raised stat, -1 for lowered stat
-      expect((raise as any)?.stages).toBe(2);
-      expect((lower as any)?.stages).toBe(-1);
+      expect(raise?.stages).toBe(2);
+      expect(lower?.stages).toBe(-1);
     });
   });
 
@@ -880,7 +891,7 @@ describe("Gen7AbilitiesDamage coverage gaps", () => {
         move: createSyntheticMove({
           id: MOVE_IDS.doubleEdge,
           type: TYPE_IDS.normal,
-          effect: { type: "recoil", percent: 33 } as any,
+          effect: { type: "recoil", amount: 33 } satisfies RecoilEffect,
         }),
       });
       const result = handleGen7DamageCalcAbility(ctx);
@@ -1286,7 +1297,9 @@ describe("Gen7AbilitiesDamage coverage gaps", () => {
       const ctx = createAbilityContext({
         ability: ABILITY_IDS.sturdy,
         trigger: TRIGGER_IDS.onDamageCalc,
-        move: createSyntheticMove({ effect: { type: MOVE_EFFECT_TYPES.ohko } as any }),
+        move: createSyntheticMove({
+          effect: { type: MOVE_EFFECT_TYPES.ohko } satisfies OhkoEffect,
+        }),
       });
       const result = handleGen7DamageImmunityAbility(ctx);
       expect(result.activated).toBe(true);
@@ -1307,7 +1320,9 @@ describe("Gen7AbilitiesDamage coverage gaps", () => {
       const ctx = createAbilityContext({
         ability: ABILITY_IDS.none,
         trigger: TRIGGER_IDS.onDamageCalc,
-        move: createSyntheticMove({ effect: { type: MOVE_EFFECT_TYPES.ohko } as any }),
+        move: createSyntheticMove({
+          effect: { type: MOVE_EFFECT_TYPES.ohko } satisfies OhkoEffect,
+        }),
       });
       const result = handleGen7DamageImmunityAbility(ctx);
       expect(result.activated).toBe(false);
@@ -1350,7 +1365,7 @@ describe("Gen7AbilitiesDamage coverage gaps", () => {
         trigger: TRIGGER_IDS.onDamageCalc,
         move: createSyntheticMove({
           power: 80,
-          effect: { type: "multi-hit", minHits: 2, maxHits: 5 } as any,
+          effect: { type: "multi-hit", min: 2, max: 5 } satisfies MultiHitEffect,
         }),
       });
       const result = handleGen7DamageCalcAbility(ctx);
@@ -1540,8 +1555,7 @@ describe("Gen7Items coverage gaps", () => {
         state: createBattleState(),
       });
       // Need sides with active for getOpponentMaxHp
-      const state = ctx.state as any;
-      state.sides = [
+      (ctx.state as Record<string, unknown>).sides = [
         { index: 0, active: [ctx.pokemon] },
         { index: 1, active: [opponent] },
       ];
@@ -1576,8 +1590,7 @@ describe("Gen7Items coverage gaps", () => {
         opponent,
         state: createBattleState(),
       });
-      const state = ctx.state as any;
-      state.sides = [
+      (ctx.state as Record<string, unknown>).sides = [
         { index: 0, active: [ctx.pokemon] },
         { index: 1, active: [opponent] },
       ];
@@ -1878,8 +1891,7 @@ describe("Gen7Items coverage gaps", () => {
         opponent,
         state: createBattleState(),
       });
-      const state = ctx.state as any;
-      state.sides = [
+      (ctx.state as Record<string, unknown>).sides = [
         { index: 0, active: [ctx.pokemon] },
         { index: 1, active: [opponent] },
       ];
@@ -1925,7 +1937,11 @@ describe("Gen7Items coverage gaps", () => {
           id: MOVE_IDS.flamethrower,
           type: TYPE_IDS.fire,
           category: MOVE_CATEGORIES.special,
-          effect: { type: "status-chance", status: STATUS_IDS.burn, chance: 10 } as any,
+          effect: {
+            type: "status-chance",
+            status: STATUS_IDS.burn,
+            chance: 10,
+          } satisfies StatusChanceEffect,
         }),
       });
       const result = applyGen7HeldItem(ITEM_TRIGGERS.onHit, ctx);
@@ -2225,7 +2241,7 @@ describe("Gen7AbilitiesSwitch coverage gaps", () => {
         ability: ABILITY_IDS.none,
         trigger: TRIGGER_IDS.onDamageCalc,
       });
-      const result = handleGen7SwitchAbility(TRIGGER_IDS.onDamageCalc as any, ctx);
+      const result = handleGen7SwitchAbility(TRIGGER_IDS.onDamageCalc, ctx);
       expect(result.activated).toBe(false);
     });
   });

--- a/packages/gen7/tests/crit-calc.test.ts
+++ b/packages/gen7/tests/crit-calc.test.ts
@@ -1,3 +1,4 @@
+import type { CritContext } from "@pokemon-lib-ts/battle";
 import {
   CORE_TYPE_IDS,
   CORE_VOLATILE_IDS,
@@ -149,7 +150,7 @@ describe("Gen 7 critical hit roll behavior", () => {
         critRatio: overrides.moveCritRatio ?? 0,
       },
       rng: fakeRng,
-    } as any;
+    } as unknown as CritContext;
   }
 
   it("given defender has Battle Armor ability, when rolling crit, then crit is prevented", () => {

--- a/packages/gen7/tests/damage-calc.test.ts
+++ b/packages/gen7/tests/damage-calc.test.ts
@@ -1,5 +1,13 @@
 import type { ActivePokemon, BattleState, DamageContext } from "@pokemon-lib-ts/battle";
-import type { Gender, MoveData, PokemonType, TerrainType, WeatherType } from "@pokemon-lib-ts/core";
+import type {
+  Gender,
+  MoveData,
+  MoveEffect,
+  PokemonType,
+  PrimaryStatus,
+  TerrainType,
+  WeatherType,
+} from "@pokemon-lib-ts/core";
 import {
   CORE_ABILITY_IDS,
   CORE_ABILITY_SLOTS,
@@ -129,7 +137,7 @@ function createOnFieldPokemon(overrides: {
   });
 
   pokemon.currentHp = overrides.currentHp ?? hp;
-  pokemon.status = (overrides.status ?? null) as any;
+  pokemon.status = (overrides.status ?? null) as PrimaryStatus | null;
   pokemon.heldItem = overrides.heldItem ?? null;
   pokemon.ability = overrides.ability ?? ABILITY_IDS.none;
   pokemon.moves = [createMoveSlot(DEFAULT_MOVE.id, DEFAULT_MOVE.pp)];
@@ -3504,7 +3512,7 @@ describe("Gen 7 isGen7Grounded coverage", () => {
         }),
         // Source: Showdown Gen 7 — Gravity grounds all Pokemon (terrain boost applies)
         gravity: { active: true, turnsLeft: 5 },
-      } as any,
+      } as BattleState,
     });
     const airborne = calculateGen7Damage(airborneCtx, typeChart);
     const result = calculateGen7Damage(ctx, typeChart);
@@ -3732,7 +3740,7 @@ describe("Gen 7 getEffectiveStatStage coverage", () => {
   it("given attacker with Simple ability and +2 attack, when calculating, then effective stage is +4", () => {
     // Source: Showdown data/abilities.ts -- Simple: doubles stat stages
     const atk = createOnFieldPokemon({ attack: 100, ability: ABILITY_IDS.simple });
-    (atk.statStages as any).attack = 2;
+    atk.statStages.attack = 2;
     const ctx = createDamageContext({
       attacker: atk,
       defender: createOnFieldPokemon({}),
@@ -3743,7 +3751,7 @@ describe("Gen 7 getEffectiveStatStage coverage", () => {
     const result = calculateGen7Damage(ctx, typeChart);
     // Compare vs no Simple at +2
     const atk2 = createOnFieldPokemon({ attack: 100, ability: ABILITY_IDS.none });
-    (atk2.statStages as any).attack = 2;
+    atk2.statStages.attack = 2;
     const ctx2 = createDamageContext({
       // Source: Showdown Gen 7 — Simple doubles stat stages
       attacker: atk2,
@@ -3758,7 +3766,7 @@ describe("Gen 7 getEffectiveStatStage coverage", () => {
   it("given defender with Unaware, when attacker has +6 attack, then stat stages ignored", () => {
     // Source: Showdown data/abilities.ts -- Unaware: ignores opponent's stat stages
     const atk = createOnFieldPokemon({ attack: 100 });
-    (atk.statStages as any).attack = 6;
+    atk.statStages.attack = 6;
     const ctxUnaware = createDamageContext({
       attacker: atk,
       defender: createOnFieldPokemon({ ability: ABILITY_IDS.unaware }),
@@ -3957,14 +3965,14 @@ describe("Gen 7 crit stat stage interaction", () => {
   it("given attacker with -2 attack and crit, then negative stages ignored (treated as 0)", () => {
     // Source: Showdown sim/battle-actions.ts -- crit ignores negative attack stages
     const atk = createOnFieldPokemon({ attack: 100 });
-    (atk.statStages as any).attack = -2;
+    atk.statStages.attack = -2;
     const ctxCrit = createDamageContext({
       attacker: atk,
       move: createSyntheticMove({ power: 50, category: MOVE_CATEGORIES.physical }),
       isCrit: true,
     });
     const atk2 = createOnFieldPokemon({ attack: 100 });
-    (atk2.statStages as any).attack = -2;
+    atk2.statStages.attack = -2;
     const ctxNoCrit = createDamageContext({
       attacker: atk2,
       move: createSyntheticMove({ power: 50, category: MOVE_CATEGORIES.physical }),
@@ -3981,14 +3989,14 @@ describe("Gen 7 crit stat stage interaction", () => {
   it("given defender with +2 defense and crit, then positive def stages ignored (treated as 0)", () => {
     // Source: Showdown sim/battle-actions.ts -- crit ignores positive def stages
     const def_ = createOnFieldPokemon({ defense: 100 });
-    (def_.statStages as any).defense = 2;
+    def_.statStages.defense = 2;
     const ctxCrit = createDamageContext({
       defender: def_,
       move: createSyntheticMove({ power: 50, category: MOVE_CATEGORIES.physical }),
       isCrit: true,
     });
     const def2 = createOnFieldPokemon({ defense: 100 });
-    (def2.statStages as any).defense = 2;
+    def2.statStages.defense = 2;
     const ctxNoCrit = createDamageContext({
       defender: def2,
       move: createSyntheticMove({ power: 50, category: MOVE_CATEGORIES.physical }),
@@ -4373,7 +4381,7 @@ describe("Gen 7 Gravity + Ground vs Flying", () => {
         ...createBattleState(),
         // Source: Showdown Gen 7 — without Gravity, Ground is immune to Flying
         gravity: { active: true, turnsLeft: 5 },
-      } as any,
+      } as BattleState,
     });
     const control = calculateGen7Damage(controlCtx, typeChart);
     const result = calculateGen7Damage(ctx, typeChart);
@@ -4484,7 +4492,7 @@ describe("Gen 7 Magic Room", () => {
       state: {
         ...createBattleState(),
         magicRoom: { active: true, turnsLeft: 3 },
-      } as any,
+      } as BattleState,
     });
     const ctxNoRoom = createDamageContext({
       attacker: createOnFieldPokemon({ types: [TYPE_IDS.fire] }),
@@ -4555,7 +4563,7 @@ describe("Gen 7 hasSheerForceEligibleEffect branches", () => {
           chance: 30,
           stats: { defense: -1 },
           fromSecondary: false,
-        } as any,
+        } as unknown as MoveEffect,
       }),
     });
     const ctxNo = createDamageContext({
@@ -4571,7 +4579,7 @@ describe("Gen 7 hasSheerForceEligibleEffect branches", () => {
           stats: { defense: -1 },
           fromSecondary: false,
           // Source: Showdown Gen 7 — Sheer Force ~1.3× stat-change targeting foe
-        } as any,
+        } as unknown as MoveEffect,
       }),
     });
     const with_ = calculateGen7Damage(ctx, typeChart);
@@ -4592,7 +4600,7 @@ describe("Gen 7 hasSheerForceEligibleEffect branches", () => {
           type: "volatile-status",
           volatileStatus: VOLATILE_IDS.flinch,
           chance: 30,
-        } as any,
+        } as unknown as MoveEffect,
       }),
     });
     const ctxNo = createDamageContext({
@@ -4606,7 +4614,7 @@ describe("Gen 7 hasSheerForceEligibleEffect branches", () => {
           volatileStatus: VOLATILE_IDS.flinch,
           chance: 30,
           // Source: Showdown Gen 7 — Sheer Force ~1.3× volatile-status secondaries
-        } as any,
+        } as unknown as MoveEffect,
       }),
     });
     const with_ = calculateGen7Damage(ctx, typeChart);
@@ -4629,7 +4637,7 @@ describe("Gen 7 hasSheerForceEligibleEffect branches", () => {
           chance: 100,
           stats: { attack: 1 },
           fromSecondary: true,
-        } as any,
+        } as unknown as MoveEffect,
       }),
     });
     const ctxNo = createDamageContext({
@@ -4645,7 +4653,7 @@ describe("Gen 7 hasSheerForceEligibleEffect branches", () => {
           stats: { attack: 1 },
           fromSecondary: true,
           // Source: Showdown Gen 7 — Sheer Force ~1.3× self stat-change from secondary
-        } as any,
+        } as unknown as MoveEffect,
       }),
     });
     const with_ = calculateGen7Damage(ctx, typeChart);
@@ -4665,7 +4673,7 @@ describe("Gen 7 hasSheerForceEligibleEffect branches", () => {
         effect: {
           type: "multi",
           effects: [{ type: "status-chance", status: "burn", chance: 10 }],
-        } as any,
+        } as unknown as MoveEffect,
       }),
     });
     const ctxNo = createDamageContext({
@@ -4678,7 +4686,7 @@ describe("Gen 7 hasSheerForceEligibleEffect branches", () => {
           type: "multi",
           effects: [{ type: "status-chance", status: "burn", chance: 10 }],
           // Source: Showdown Gen 7 — Sheer Force ~1.3× multi effects with status-chance
-        } as any,
+        } as unknown as MoveEffect,
       }),
     });
     const with_ = calculateGen7Damage(ctx, typeChart);
@@ -5069,14 +5077,16 @@ describe("Z-Move through Protect (hitThroughProtect)", () => {
 
     const attacker = createOnFieldPokemon({ attack: 100, types: [TYPE_IDS.psychic] });
     const defender = createOnFieldPokemon({ defense: 100, types: [TYPE_IDS.psychic] });
-    const zMove = createSyntheticMove({
-      id: "breakneck-blitz",
-      type: TYPE_IDS.normal,
-      power: 100,
-      category: MOVE_CATEGORIES.physical,
-    });
     // Mark as a Z-Move via the zMovePower field (set by Gen7ZMove.modifyMove)
-    (zMove as any).zMovePower = 100;
+    const zMove = {
+      ...createSyntheticMove({
+        id: "breakneck-blitz",
+        type: TYPE_IDS.normal,
+        power: 100,
+        category: MOVE_CATEGORIES.physical,
+      }),
+      zMovePower: 100,
+    } as MoveData;
 
     // Calculate normal damage (no Protect)
     const normalCtx = createDamageContext({
@@ -5092,12 +5102,10 @@ describe("Z-Move through Protect (hitThroughProtect)", () => {
     const protectCtx = createDamageContext({
       attacker: createOnFieldPokemon({ attack: 100, types: [TYPE_IDS.psychic] }),
       defender: createOnFieldPokemon({ defense: 100, types: [TYPE_IDS.psychic] }),
-      move: { ...zMove },
+      move: { ...zMove, zMovePower: 100 } as MoveData,
       seed: 42,
       hitThroughProtect: true,
     });
-    // Re-set zMovePower on the cloned move
-    (protectCtx.move as any).zMovePower = 100;
     const protectResult = calculateGen7Damage(protectCtx, typeChart);
     // Source: Showdown Gen 7 — Z-Move through Protect deals ≥1 damage
 
@@ -5120,13 +5128,15 @@ describe("Z-Move through Protect (hitThroughProtect)", () => {
 
     const attacker = createOnFieldPokemon({ attack: 100, types: [TYPE_IDS.fire] });
     const defender = createOnFieldPokemon({ defense: 100, types: [TYPE_IDS.normal] });
-    const zMove = createSyntheticMove({
-      id: "inferno-overdrive",
-      type: TYPE_IDS.fire,
-      power: 175,
-      category: MOVE_CATEGORIES.physical,
-    });
-    (zMove as any).zMovePower = 175;
+    const zMove = {
+      ...createSyntheticMove({
+        id: "inferno-overdrive",
+        type: TYPE_IDS.fire,
+        power: 175,
+        category: MOVE_CATEGORIES.physical,
+      }),
+      zMovePower: 175,
+    } as MoveData;
 
     const ctx = createDamageContext({
       attacker,
@@ -5152,12 +5162,11 @@ describe("Z-Move through Protect (hitThroughProtect)", () => {
     const protectCtx = createDamageContext({
       attacker: createOnFieldPokemon({ attack: 100, types: [TYPE_IDS.fire] }),
       defender: createOnFieldPokemon({ defense: 100, types: [TYPE_IDS.normal] }),
-      move: { ...zMove },
+      move: { ...zMove, zMovePower: 175 } as MoveData,
       seed: 42,
       hitThroughProtect: true,
       // Source: Showdown Gen 7 — Z-Move through Protect < full damage
     });
-    (protectCtx.move as any).zMovePower = 175;
     const protectResult = calculateGen7Damage(protectCtx, typeChart);
     // Source: Showdown Gen 7 — Z-Move through Protect exact via pokeRound(damage, 1024)
 
@@ -5230,13 +5239,15 @@ describe("Z-Move through Protect (hitThroughProtect)", () => {
 
     const attacker = createOnFieldPokemon({ level: 100, attack: 200, types: [TYPE_IDS.dragon] });
     const defender = createOnFieldPokemon({ level: 100, defense: 100, types: [TYPE_IDS.normal] });
-    const zMove = createSyntheticMove({
-      id: "devastating-drake",
-      type: TYPE_IDS.dragon,
-      power: 200,
-      category: MOVE_CATEGORIES.physical,
-    });
-    (zMove as any).zMovePower = 200;
+    const zMove = {
+      ...createSyntheticMove({
+        id: "devastating-drake",
+        type: TYPE_IDS.dragon,
+        power: 200,
+        category: MOVE_CATEGORIES.physical,
+      }),
+      zMovePower: 200,
+    } as MoveData;
 
     const normalCtx = createDamageContext({
       attacker,
@@ -5246,15 +5257,14 @@ describe("Z-Move through Protect (hitThroughProtect)", () => {
     });
     const normalResult = calculateGen7Damage(normalCtx, typeChart);
 
+    // Source: Showdown Gen 7 — Z-Move through Protect exact calculation
     const protectCtx = createDamageContext({
       attacker: createOnFieldPokemon({ level: 100, attack: 200, types: [TYPE_IDS.dragon] }),
       defender: createOnFieldPokemon({ level: 100, defense: 100, types: [TYPE_IDS.normal] }),
-      move: { ...zMove },
+      move: { ...zMove, zMovePower: 200 } as MoveData,
       seed: 42,
       hitThroughProtect: true,
     });
-    // Source: Showdown Gen 7 — Z-Move through Protect exact calculation
-    (protectCtx.move as any).zMovePower = 200;
     const protectResult = calculateGen7Damage(protectCtx, typeChart);
 
     // Source: Showdown Gen 7 — high-power Z-Move deals substantial damage

--- a/packages/gen7/tests/dual-gimmick.test.ts
+++ b/packages/gen7/tests/dual-gimmick.test.ts
@@ -89,7 +89,7 @@ function createSyntheticOnFieldPokemon(overrides: {
       heldItem: overrides.heldItem ?? null,
       status: null,
       friendship: 0,
-      gender: CORE_GENDERS.male as any,
+      gender: CORE_GENDERS.male,
       isShiny: false,
       metLocation: "",
       metLevel: 1,

--- a/packages/gen7/tests/exp-formula.test.ts
+++ b/packages/gen7/tests/exp-formula.test.ts
@@ -1,4 +1,5 @@
 import type { ExpContext } from "@pokemon-lib-ts/battle";
+import type { PokemonSpeciesData } from "@pokemon-lib-ts/core";
 import { DataManager } from "@pokemon-lib-ts/core";
 import { describe, expect, it } from "vitest";
 import { Gen7Ruleset } from "../src/Gen7Ruleset";
@@ -9,7 +10,8 @@ import { Gen7Ruleset } from "../src/Gen7Ruleset";
 function makeExpContext(overrides: Partial<ExpContext> = {}): ExpContext {
   return {
     defeatedLevel: overrides.defeatedLevel ?? 50,
-    defeatedSpecies: overrides.defeatedSpecies ?? ({ baseExp: 100 } as any),
+    defeatedSpecies:
+      overrides.defeatedSpecies ?? ({ baseExp: 100 } as unknown as PokemonSpeciesData),
     participantLevel: overrides.participantLevel ?? 50,
     participantCount: overrides.participantCount ?? 1,
     isTrainerBattle: overrides.isTrainerBattle ?? false,
@@ -40,7 +42,7 @@ describe("Gen7Ruleset -- calculateExpGain base formula", () => {
     // base = floor((100 * 50) / (5 * 1)) = floor(5000 / 5) = 1000
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
     });
     expect(ruleset.calculateExpGain(context)).toBe(1000);
   });
@@ -51,7 +53,7 @@ describe("Gen7Ruleset -- calculateExpGain base formula", () => {
     // base = floor((142 * 30) / (5 * 1)) = floor(4260 / 5) = floor(852) = 852
     const context = makeExpContext({
       defeatedLevel: 30,
-      defeatedSpecies: { baseExp: 142 } as any,
+      defeatedSpecies: { baseExp: 142 } as unknown as PokemonSpeciesData,
     });
     expect(ruleset.calculateExpGain(context)).toBe(852);
   });
@@ -62,7 +64,7 @@ describe("Gen7Ruleset -- calculateExpGain base formula", () => {
     // base = floor((64 * 1) / (5 * 1)) = floor(64 / 5) = floor(12.8) = 12
     const context = makeExpContext({
       defeatedLevel: 1,
-      defeatedSpecies: { baseExp: 64 } as any,
+      defeatedSpecies: { baseExp: 64 } as unknown as PokemonSpeciesData,
     });
     expect(ruleset.calculateExpGain(context)).toBe(12);
   });
@@ -73,7 +75,7 @@ describe("Gen7Ruleset -- calculateExpGain base formula", () => {
     // base = floor((255 * 100) / (5 * 1)) = floor(25500 / 5) = 5100
     const context = makeExpContext({
       defeatedLevel: 100,
-      defeatedSpecies: { baseExp: 255 } as any,
+      defeatedSpecies: { baseExp: 255 } as unknown as PokemonSpeciesData,
     });
     expect(ruleset.calculateExpGain(context)).toBe(5100);
   });
@@ -85,12 +87,12 @@ describe("Gen7Ruleset -- calculateExpGain base formula", () => {
     const ctx1 = makeExpContext({
       defeatedLevel: 50,
       participantLevel: 50,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
     });
     const ctx2 = makeExpContext({
       defeatedLevel: 50,
       participantLevel: 20,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
     });
     // Both should return the same value -- participant level is not used
     expect(ruleset.calculateExpGain(ctx1)).toBe(ruleset.calculateExpGain(ctx2));
@@ -106,7 +108,7 @@ describe("Gen7Ruleset -- calculateExpGain modifiers", () => {
     // trainer: floor(1000 * 1.5) = 1500
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
       isTrainerBattle: true,
     });
     expect(ruleset.calculateExpGain(context)).toBe(1500);
@@ -118,7 +120,7 @@ describe("Gen7Ruleset -- calculateExpGain modifiers", () => {
     // Lucky Egg: floor(1000 * 1.5) = 1500
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
       hasLuckyEgg: true,
     });
     expect(ruleset.calculateExpGain(context)).toBe(1500);
@@ -131,7 +133,7 @@ describe("Gen7Ruleset -- calculateExpGain modifiers", () => {
     // Lucky Egg: floor(1500 * 1.5) = 2250
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
       isTrainerBattle: true,
       hasLuckyEgg: true,
     });
@@ -147,7 +149,7 @@ describe("Gen7Ruleset -- calculateExpGain modifiers", () => {
     // Staged flooring = 226; proves the sequential Math.floor() behavior is correct.
     const context = makeExpContext({
       defeatedLevel: 5,
-      defeatedSpecies: { baseExp: 101 } as any,
+      defeatedSpecies: { baseExp: 101 } as unknown as PokemonSpeciesData,
       isTrainerBattle: true,
       hasLuckyEgg: true,
     });
@@ -159,7 +161,7 @@ describe("Gen7Ruleset -- calculateExpGain modifiers", () => {
     // base = floor((100 * 50) / (5 * 2)) = floor(5000 / 10) = 500
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
       participantCount: 2,
     });
     expect(ruleset.calculateExpGain(context)).toBe(500);
@@ -170,7 +172,7 @@ describe("Gen7Ruleset -- calculateExpGain modifiers", () => {
     // base = floor((100 * 50) / (5 * 3)) = floor(5000 / 15) = floor(333.33...) = 333
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
       participantCount: 3,
     });
     expect(ruleset.calculateExpGain(context)).toBe(333);
@@ -182,7 +184,7 @@ describe("Gen7Ruleset -- calculateExpGain modifiers", () => {
     // Math.max(1, 0) = 1
     const context = makeExpContext({
       defeatedLevel: 1,
-      defeatedSpecies: { baseExp: 1 } as any,
+      defeatedSpecies: { baseExp: 1 } as unknown as PokemonSpeciesData,
       participantCount: 6,
     });
     expect(ruleset.calculateExpGain(context)).toBe(1);
@@ -199,7 +201,7 @@ describe("Gen7Ruleset -- calculateExpGain traded Pokemon EXP bonus", () => {
     // traded (same language): floor(1000 * 1.5) = 1500
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
     });
     const notTraded = ruleset.calculateExpGain(context);
     const traded = ruleset.calculateExpGain({
@@ -218,7 +220,7 @@ describe("Gen7Ruleset -- calculateExpGain traded Pokemon EXP bonus", () => {
     // international traded: floor(1000 * 1.7) = 1700
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
     });
     const result = ruleset.calculateExpGain({
       ...context,
@@ -237,7 +239,7 @@ describe("Gen7Ruleset -- calculateExpGain traded Pokemon EXP bonus", () => {
     // international traded: floor(2250 * 1.7) = floor(3825) = 3825
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 100 } as any,
+      defeatedSpecies: { baseExp: 100 } as unknown as PokemonSpeciesData,
       isTrainerBattle: true,
       hasLuckyEgg: true,
     });
@@ -259,7 +261,7 @@ describe("Gen7Ruleset -- calculateExpGain with different baseExp values", () => 
     // base = floor((200 * 50) / 5) = floor(10000 / 5) = 2000
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 200 } as any,
+      defeatedSpecies: { baseExp: 200 } as unknown as PokemonSpeciesData,
     });
     expect(ruleset.calculateExpGain(context)).toBe(2000);
   });
@@ -269,7 +271,7 @@ describe("Gen7Ruleset -- calculateExpGain with different baseExp values", () => 
     // base = floor((50 * 50) / 5) = floor(2500 / 5) = 500
     const context = makeExpContext({
       defeatedLevel: 50,
-      defeatedSpecies: { baseExp: 50 } as any,
+      defeatedSpecies: { baseExp: 50 } as unknown as PokemonSpeciesData,
     });
     expect(ruleset.calculateExpGain(context)).toBe(500);
   });

--- a/packages/gen7/tests/integration/integration.test.ts
+++ b/packages/gen7/tests/integration/integration.test.ts
@@ -10,6 +10,7 @@ import type {
   ActivePokemon,
   BattleConfig,
   BattleEvent,
+  BattleSide,
   BattleState,
 } from "@pokemon-lib-ts/battle";
 import { BATTLE_GIMMICK_IDS, BattleEngine } from "@pokemon-lib-ts/battle";
@@ -37,6 +38,7 @@ import {
   type MoveData,
   type PokemonInstance,
   type PokemonType,
+  type PrimaryStatus,
   SeededRandom,
 } from "@pokemon-lib-ts/core";
 import { describe, expect, it } from "vitest";
@@ -132,7 +134,6 @@ function createSyntheticPokemonInstance(overrides: {
     gender: overrides.gender ?? GENDERS.male,
     friendship: createFriendship(overrides.friendship ?? species.baseFriendship),
     heldItem: overrides.heldItem ?? null,
-    status: (overrides.status ?? null) as any,
     nickname: overrides.nickname ?? null,
     moves: moveIds,
     metLocation: "test",
@@ -144,6 +145,7 @@ function createSyntheticPokemonInstance(overrides: {
     const move = getCanonicalMove(moveId);
     return createMoveSlot(moveId, move.pp);
   });
+  pokemon.status = (overrides.status ?? null) as PrimaryStatus | null;
   pokemon.currentHp = overrides.currentHp ?? hp;
   pokemon.ability = overrides.ability ?? ABILITIES.none;
   pokemon.calculatedStats = { hp, attack, defense, spAttack, spDefense, speed };
@@ -847,7 +849,7 @@ describe("Integration: Aurora Veil + Hail damage reduction", () => {
       screens: [{ type: AURORA_VEIL, turnsLeft: 5 }],
       hazards: {},
       tailwind: { active: false, turnsLeft: 0 },
-    } as any;
+    } as unknown as BattleSide;
 
     const stateWithoutVeil = createSyntheticBattleState({
       weather: { type: WEATHER.hail, turnsLeft: 5 },
@@ -858,7 +860,7 @@ describe("Integration: Aurora Veil + Hail damage reduction", () => {
       screens: [],
       hazards: {},
       tailwind: { active: false, turnsLeft: 0 },
-    } as any;
+    } as unknown as BattleSide;
 
     const resultWithVeil = calculateGen7Damage(
       {

--- a/packages/gen7/tests/ruleset.test.ts
+++ b/packages/gen7/tests/ruleset.test.ts
@@ -11,7 +11,17 @@
  *
  * Source: Showdown sim/pokemon.ts, sim/battle.ts, Bulbapedia ability/item pages
  */
-import type { ActivePokemon, BattleAction, BattleSide, BattleState } from "@pokemon-lib-ts/battle";
+import type {
+  AbilityContext,
+  ActivePokemon,
+  BattleAction,
+  BattleSide,
+  BattleState,
+  CritContext,
+  ItemContext,
+  MoveEffectContext,
+} from "@pokemon-lib-ts/battle";
+import type { MoveData, PokemonType, TwoTurnMoveVolatile } from "@pokemon-lib-ts/core";
 import {
   CORE_ABILITY_IDS,
   CORE_ABILITY_SLOTS,
@@ -118,7 +128,7 @@ function createSyntheticActive(
       accuracy: 0,
       evasion: 0,
     },
-    types: (overrides.types ?? DEFAULT_SPECIES.types) as any,
+    types: (overrides.types ?? DEFAULT_SPECIES.types) as PokemonType[],
     volatileStatuses: new Map(
       (overrides.volatiles ?? []).map(([k, v]) => [k, v] as [string, unknown]),
     ),
@@ -780,13 +790,13 @@ describe("Gen7Ruleset — capLethalDamage (Sturdy)", () => {
       ability: ABILITY_IDS.sturdy,
       hp: 200,
       currentHp: 200,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       300,
       defender,
       attacker,
-      DEFAULT_MOVE as any,
+      DEFAULT_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Sturdy caps lethal damage to maxHp-1 at full HP
@@ -803,13 +813,13 @@ describe("Gen7Ruleset — capLethalDamage (Sturdy)", () => {
       ability: ABILITY_IDS.sturdy,
       hp: 200,
       currentHp: 150,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       200,
       defender,
       attacker,
-      DEFAULT_MOVE as any,
+      DEFAULT_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Sturdy only works at full HP, damage is uncapped
@@ -820,13 +830,13 @@ describe("Gen7Ruleset — capLethalDamage (Sturdy)", () => {
 
   it("given defender without Sturdy at full HP and lethal damage, when capping, then does NOT cap", () => {
     // Source: Showdown data/abilities.ts -- only Sturdy triggers this
-    const defender = createSyntheticActive({ hp: 200, currentHp: 200 }) as any;
+    const defender = createSyntheticActive({ hp: 200, currentHp: 200 });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       300,
       defender,
       attacker,
-      DEFAULT_MOVE as any,
+      DEFAULT_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — without Sturdy, lethal damage is not capped
@@ -841,13 +851,13 @@ describe("Gen7Ruleset — capLethalDamage (Sturdy)", () => {
       ability: ABILITY_IDS.sturdy,
       hp: 200,
       currentHp: 200,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       100,
       defender,
       attacker,
-      DEFAULT_MOVE as any,
+      DEFAULT_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Sturdy only caps lethal damage, not non-lethal
@@ -862,13 +872,13 @@ describe("Gen7Ruleset — capLethalDamage (Sturdy)", () => {
       ability: ABILITY_IDS.sturdy,
       hp: 200,
       currentHp: 200,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       300,
       defender,
       attacker,
-      SUNSTEEL_STRIKE_MOVE as any,
+      SUNSTEEL_STRIKE_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Sunsteel Strike ignores Sturdy ability
@@ -883,13 +893,13 @@ describe("Gen7Ruleset — capLethalDamage (Sturdy)", () => {
       ability: ABILITY_IDS.sturdy,
       hp: 200,
       currentHp: 200,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       300,
       defender,
       attacker,
-      MOONGEIST_BEAM_MOVE as any,
+      MOONGEIST_BEAM_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Moongeist Beam ignores Sturdy ability
@@ -910,13 +920,13 @@ describe("Gen7Ruleset — capLethalDamage (Disguise bypass)", () => {
       ability: ABILITY_IDS.disguise,
       hp: 200,
       currentHp: 200,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       120,
       defender,
       attacker,
-      SUNSTEEL_STRIKE_MOVE as any,
+      SUNSTEEL_STRIKE_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Sunsteel Strike ignores Disguise ability
@@ -933,13 +943,13 @@ describe("Gen7Ruleset — capLethalDamage (Disguise bypass)", () => {
       ability: ABILITY_IDS.disguise,
       hp: 200,
       currentHp: 200,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       120,
       defender,
       attacker,
-      MOONGEIST_BEAM_MOVE as any,
+      MOONGEIST_BEAM_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Moongeist Beam ignores Disguise ability
@@ -963,13 +973,13 @@ describe("Gen7Ruleset — capLethalDamage (Focus Sash)", () => {
       heldItem: ITEM_IDS.focusSash,
       hp: 200,
       currentHp: 200,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       300,
       defender,
       attacker,
-      DEFAULT_MOVE as any,
+      DEFAULT_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Focus Sash caps lethal damage to maxHp-1 at full HP
@@ -988,13 +998,13 @@ describe("Gen7Ruleset — capLethalDamage (Focus Sash)", () => {
       heldItem: ITEM_IDS.focusSash,
       hp: 200,
       currentHp: 150,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       200,
       defender,
       attacker,
-      DEFAULT_MOVE as any,
+      DEFAULT_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Focus Sash requires full HP to activate
@@ -1013,13 +1023,13 @@ describe("Gen7Ruleset — capLethalDamage (Focus Sash)", () => {
       heldItem: ITEM_IDS.focusSash,
       hp: 200,
       currentHp: 200,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       300,
       defender,
       attacker,
-      DEFAULT_MOVE as any,
+      DEFAULT_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Klutz suppresses Focus Sash activation
@@ -1038,13 +1048,13 @@ describe("Gen7Ruleset — capLethalDamage (Focus Sash)", () => {
       hp: 200,
       currentHp: 200,
       volatiles: [[VOLATILE_IDS.embargo, { turnsLeft: 5 }]],
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const result = ruleset.capLethalDamage(
       300,
       defender,
       attacker,
-      DEFAULT_MOVE as any,
+      DEFAULT_MOVE,
       {} as BattleState,
     );
     // Source: Showdown Gen 7 — Embargo suppresses Focus Sash activation
@@ -1062,10 +1072,10 @@ describe("Gen7Ruleset — capLethalDamage (Focus Sash)", () => {
       heldItem: ITEM_IDS.focusSash,
       hp: 200,
       currentHp: 200,
-    }) as any;
+    });
     const attacker = createSyntheticActive();
     const state = { magicRoom: { active: true, turnsLeft: 3 } } as BattleState;
-    const result = ruleset.capLethalDamage(300, defender, attacker, DEFAULT_MOVE as any, state);
+    const result = ruleset.capLethalDamage(300, defender, attacker, DEFAULT_MOVE, state);
     // Source: Showdown Gen 7 — Magic Room suppresses Focus Sash activation
     expect(result.damage).toBe(300);
     // Source: Showdown Gen 7 — Pokemon faints when Focus Sash is suppressed by Magic Room
@@ -1082,59 +1092,52 @@ describe("Gen7Ruleset — capLethalDamage (Focus Sash)", () => {
 describe("Gen7Ruleset — canHitSemiInvulnerable", () => {
   it("given thousand-arrows vs flying, when checking semi-invulnerable bypass, then returns true", () => {
     // Source: Showdown data/moves.ts -- thousandarrows hits Flying semi-invulnerable state
-    expect(
-      ruleset.canHitSemiInvulnerable(MOVE_IDS.thousandArrows, VOLATILE_IDS.flying as any),
-    ).toBe(true);
+    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.thousandArrows, VOLATILE_IDS.flying)).toBe(true);
   });
 
   it("given hurricane vs flying, when checking semi-invulnerable bypass, then returns true", () => {
     // Source: Showdown -- Hurricane hits Fly/Bounce targets
-    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.hurricane, VOLATILE_IDS.flying as any)).toBe(
-      true,
-    );
+    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.hurricane, VOLATILE_IDS.flying)).toBe(true);
   });
 
   it("given flamethrower vs flying, when checking semi-invulnerable bypass, then returns false", () => {
     // Source: Showdown -- normal moves cannot hit Fly targets
-    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.flamethrower, VOLATILE_IDS.flying as any)).toBe(
-      false,
-    );
+    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.flamethrower, VOLATILE_IDS.flying)).toBe(false);
   });
 
   it("given earthquake vs underground, when checking semi-invulnerable bypass, then returns true", () => {
     // Source: Showdown -- Earthquake hits Dig targets
-    expect(
-      ruleset.canHitSemiInvulnerable(MOVE_IDS.earthquake, VOLATILE_IDS.underground as any),
-    ).toBe(true);
+    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.earthquake, VOLATILE_IDS.underground)).toBe(
+      true,
+    );
   });
 
   it("given surf vs underwater, when checking semi-invulnerable bypass, then returns true", () => {
     // Source: Showdown -- Surf hits Dive targets
-    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.surf, VOLATILE_IDS.underwater as any)).toBe(
-      true,
-    );
+    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.surf, VOLATILE_IDS.underwater)).toBe(true);
   });
 
   it("given any move vs shadow-force-charging, when checking semi-invulnerable bypass, then returns false", () => {
     // Source: Showdown -- nothing bypasses Shadow Force / Phantom Force
     expect(
-      ruleset.canHitSemiInvulnerable(MOVE_IDS.earthquake, VOLATILE_IDS.shadowForceCharging as any),
+      ruleset.canHitSemiInvulnerable(MOVE_IDS.earthquake, VOLATILE_IDS.shadowForceCharging),
     ).toBe(false);
   });
 
   it("given any move vs charging, when checking semi-invulnerable bypass, then returns true (not semi-invulnerable)", () => {
     // Source: Showdown -- charging moves (SolarBeam) are not semi-invulnerable
-    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.tackle, VOLATILE_IDS.charging as any)).toBe(
-      true,
-    );
+    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.tackle, VOLATILE_IDS.charging)).toBe(true);
   });
 
   it("given any move vs unknown volatile, when checking semi-invulnerable bypass, then returns false", () => {
     // Default branch
     // Source: Showdown Gen 7 — unknown volatiles are not semi-invulnerable states
-    expect(ruleset.canHitSemiInvulnerable(MOVE_IDS.tackle, VOLATILE_IDS.confusion as any)).toBe(
-      false,
-    );
+    expect(
+      ruleset.canHitSemiInvulnerable(
+        MOVE_IDS.tackle,
+        VOLATILE_IDS.confusion as unknown as TwoTurnMoveVolatile,
+      ),
+    ).toBe(false);
   });
 });
 
@@ -1145,31 +1148,33 @@ describe("Gen7Ruleset — canHitSemiInvulnerable", () => {
 describe("Gen7Ruleset — rollCritical (ability immunity)", () => {
   it("given defender with battle-armor, when rolling crit, then always returns false", () => {
     // Source: Showdown sim/battle-actions.ts -- Battle Armor prevents crits
-    const context = {
+    const context: CritContext = {
       attacker: createSyntheticActive(),
       defender: createSyntheticActive({ ability: ABILITY_IDS.battleArmor }),
-      move: { critRatio: 0 } as any,
+      move: { critRatio: 0 } as unknown as MoveData,
       rng: { int: () => 1 } as unknown as SeededRandom,
+      state: {} as BattleState,
     };
     // Source: Showdown Gen 7 — Battle Armor prevents critical hits
-    expect(ruleset.rollCritical(context as any)).toBe(false);
+    expect(ruleset.rollCritical(context)).toBe(false);
   });
 
   it("given defender with shell-armor, when rolling crit, then always returns false", () => {
     // Source: Showdown sim/battle-actions.ts -- Shell Armor prevents crits
-    const context = {
+    const context: CritContext = {
       attacker: createSyntheticActive(),
       defender: createSyntheticActive({ ability: ABILITY_IDS.shellArmor }),
-      move: { critRatio: 0 } as any,
+      move: { critRatio: 0 } as unknown as MoveData,
       rng: { int: () => 1 } as unknown as SeededRandom,
+      state: {} as BattleState,
     };
     // Source: Showdown Gen 7 — Shell Armor prevents critical hits
-    expect(ruleset.rollCritical(context as any)).toBe(false);
+    expect(ruleset.rollCritical(context)).toBe(false);
   });
 
   it("given Moongeist Beam against Battle Armor with guaranteed crit stage, when rolling crit, then Battle Armor is ignored", () => {
     // Source: Showdown data/moves.ts -- moongeist-beam: ignoreAbility
-    const context = {
+    const context: CritContext = {
       attacker: createSyntheticActive({
         ability: ABILITY_IDS.superLuck,
         heldItem: ITEM_IDS.scopeLens,
@@ -1178,15 +1183,16 @@ describe("Gen7Ruleset — rollCritical (ability immunity)", () => {
       defender: createSyntheticActive({ ability: ABILITY_IDS.battleArmor }),
       move: MOONGEIST_BEAM_MOVE,
       rng: { int: () => 1 } as unknown as SeededRandom,
+      state: {} as BattleState,
     };
 
     // Source: Showdown Gen 7 — Moongeist Beam ignores Battle Armor
-    expect(ruleset.rollCritical(context as any)).toBe(true);
+    expect(ruleset.rollCritical(context)).toBe(true);
   });
 
   it("given Sunsteel Strike against Shell Armor with guaranteed crit stage, when rolling crit, then Shell Armor is ignored", () => {
     // Source: Showdown data/moves.ts -- sunsteel-strike: ignoreAbility
-    const context = {
+    const context: CritContext = {
       attacker: createSyntheticActive({
         ability: ABILITY_IDS.superLuck,
         heldItem: ITEM_IDS.scopeLens,
@@ -1195,15 +1201,16 @@ describe("Gen7Ruleset — rollCritical (ability immunity)", () => {
       defender: createSyntheticActive({ ability: ABILITY_IDS.shellArmor }),
       move: SUNSTEEL_STRIKE_MOVE,
       rng: { int: () => 1 } as unknown as SeededRandom,
+      state: {} as BattleState,
     };
 
     // Source: Showdown Gen 7 — Sunsteel Strike ignores Shell Armor
-    expect(ruleset.rollCritical(context as any)).toBe(true);
+    expect(ruleset.rollCritical(context)).toBe(true);
   });
 
   it("given Photon Geyser against Battle Armor with guaranteed crit stage, when rolling crit, then Battle Armor is ignored", () => {
     // Source: Showdown data/moves.ts -- photongeyser: ignoreAbility
-    const context = {
+    const context: CritContext = {
       attacker: createSyntheticActive({
         ability: ABILITY_IDS.superLuck,
         heldItem: ITEM_IDS.scopeLens,
@@ -1212,10 +1219,11 @@ describe("Gen7Ruleset — rollCritical (ability immunity)", () => {
       defender: createSyntheticActive({ ability: ABILITY_IDS.battleArmor }),
       move: PHOTON_GEYSER_MOVE,
       rng: { int: () => 1 } as unknown as SeededRandom,
+      state: {} as BattleState,
     };
 
     // Source: Showdown Gen 7 — Photon Geyser ignores Battle Armor
-    expect(ruleset.rollCritical(context as any)).toBe(true);
+    expect(ruleset.rollCritical(context)).toBe(true);
   });
 });
 
@@ -1288,13 +1296,13 @@ describe("Gen7Ruleset — stub methods return defaults", () => {
     // Source: Showdown Gen 7 — executeMoveEffect delegates to BaseRuleset without throwing
     expect(() => {
       ruleset.executeMoveEffect({
-        move: DEFAULT_MOVE as any,
+        move: DEFAULT_MOVE,
         attacker: createSyntheticActive(),
         defender: createSyntheticActive(),
         state: createBattleState(),
         rng: createTestRng(),
         damage: 0,
-      } as any);
+      } as unknown as MoveEffectContext);
     }).not.toThrow();
   });
 
@@ -1345,7 +1353,7 @@ describe("Gen7Ruleset — stub methods return defaults", () => {
       },
       state: {},
       rng: {},
-    } as any;
+    } as unknown as ItemContext;
     const result = ruleset.applyHeldItem("on-damage", mockContext);
     // Source: Showdown Gen 7 — no held item means item trigger is not activated
     expect(result.activated).toBe(false);
@@ -1363,7 +1371,7 @@ describe("Gen7Ruleset — stub methods return defaults", () => {
       state: {},
       rng: {},
       trigger: CORE_ABILITY_TRIGGER_IDS.onSwitchIn,
-    } as any;
+    } as unknown as AbilityContext;
     const result = ruleset.applyAbility(CORE_ABILITY_TRIGGER_IDS.onSwitchIn, mockContext);
     // Source: Showdown Gen 7 — non-surge abilities return not activated on switch-in (stub)
     expect(result.activated).toBe(false);

--- a/packages/gen7/tests/smoke/smoke.test.ts
+++ b/packages/gen7/tests/smoke/smoke.test.ts
@@ -99,14 +99,18 @@ describe("Gen7Ruleset", () => {
       const ruleset = createTestRuleset();
       // The getStatusCatchModifiers is protected, so we verify via behavior
       // For scaffold smoke tests, we use a type assertion to access it
-      const modifiers = (ruleset as any).getStatusCatchModifiers();
+      const modifiers = (
+        ruleset as unknown as { getStatusCatchModifiers(): Record<string, number> }
+      ).getStatusCatchModifiers();
       expect(modifiers.sleep).toBe(2.5);
     });
 
     it("given a Gen7Ruleset, when getting status catch modifiers, then freeze modifier is 2.5x", () => {
       // Source: Bulbapedia -- Catch rate: Gen 5+ uses 2.5x for sleep/freeze
       const ruleset = createTestRuleset();
-      const modifiers = (ruleset as any).getStatusCatchModifiers();
+      const modifiers = (
+        ruleset as unknown as { getStatusCatchModifiers(): Record<string, number> }
+      ).getStatusCatchModifiers();
       expect(modifiers.freeze).toBe(2.5);
     });
   });

--- a/packages/gen7/tests/terrain.test.ts
+++ b/packages/gen7/tests/terrain.test.ts
@@ -1,5 +1,5 @@
 import type { AbilityContext, ActivePokemon, BattleState } from "@pokemon-lib-ts/battle";
-import type { PokemonType, TerrainType } from "@pokemon-lib-ts/core";
+import type { PokemonType, PrimaryStatus, TerrainType } from "@pokemon-lib-ts/core";
 import {
   CORE_ABILITY_IDS,
   CORE_ABILITY_SLOTS,
@@ -78,7 +78,7 @@ function createSyntheticActivePokemon(overrides: {
       ability: overrides.ability ?? ABILITIES.none,
       abilitySlot: CORE_ABILITY_SLOTS.normal1,
       heldItem: overrides.heldItem ?? null,
-      status: (overrides.status ?? null) as any,
+      status: (overrides.status ?? null) as PrimaryStatus | null,
       friendship: 0,
       gender: CORE_GENDERS.male,
       isShiny: false,
@@ -927,7 +927,7 @@ describe("Suppressed Surge ability", () => {
       nickname: "Tapu Koko",
     });
     // Simulate suppressed ability via suppressedAbility field
-    (pokemon as any).suppressedAbility = ABILITIES.electricSurge;
+    (pokemon as Record<string, unknown>).suppressedAbility = ABILITIES.electricSurge;
     const state = createSyntheticBattleState();
     const context = createAbilityContext({ pokemon, state });
 

--- a/packages/gen7/tests/ultra-burst.test.ts
+++ b/packages/gen7/tests/ultra-burst.test.ts
@@ -8,7 +8,12 @@
  * Source: Pokémon Showdown data/pokedex.ts + data/moves.ts for stat and move values
  */
 
-import type { ActivePokemon, BattleSide, BattleState } from "@pokemon-lib-ts/battle";
+import type {
+  ActivePokemon,
+  BattleSide,
+  BattleState,
+  UltraBurstEvent,
+} from "@pokemon-lib-ts/battle";
 import { BATTLE_GIMMICK_IDS } from "@pokemon-lib-ts/battle";
 import type { MoveData, PokemonType } from "@pokemon-lib-ts/core";
 import {
@@ -92,7 +97,7 @@ function createNecrozmaOnField(overrides: {
       heldItem: overrides.heldItem ?? ULTRANECROZIUM_Z,
       status: null,
       friendship: 0,
-      gender: CORE_GENDERS.unknown as any,
+      gender: CORE_GENDERS.genderless,
       isShiny: false,
       metLocation: "",
       metLevel: 1,
@@ -226,7 +231,7 @@ function createSyntheticOnFieldPokemon(overrides: {
       heldItem: overrides.heldItem ?? null,
       status: null,
       friendship: 0,
-      gender: CORE_GENDERS.female as any,
+      gender: CORE_GENDERS.female,
       isShiny: false,
       metLocation: "",
       metLevel: 1,
@@ -511,8 +516,8 @@ describe("Gen7UltraBurst -- activate()", () => {
 
     expect(events).toHaveLength(1);
     expect(events[0].type).toBe("ultra-burst");
-    expect((events[0] as any).side).toBe(0);
-    expect((events[0] as any).pokemon).toBe("test-necrozma");
+    expect((events[0] as UltraBurstEvent).side).toBe(0);
+    expect((events[0] as UltraBurstEvent).pokemon).toBe("test-necrozma");
   });
 
   it("given Ultra Burst activates, when checking Z-Move usage, then Z-Move is NOT marked as used", () => {
@@ -668,7 +673,7 @@ describe("Gen7DamageCalc -- Neuroforce ability", () => {
       attacker,
       defender,
       move,
-      state: { weather: null, terrain: null, sides: [] } as any,
+      state: { weather: null, terrain: null, sides: [] } as unknown as BattleState,
       isCrit: false,
       rng: new SeededRandom(42),
     };
@@ -685,7 +690,7 @@ describe("Gen7DamageCalc -- Neuroforce ability", () => {
       attacker: attackerNoNeuroforce,
       defender,
       move,
-      state: { weather: null, terrain: null, sides: [] } as any,
+      state: { weather: null, terrain: null, sides: [] } as unknown as BattleState,
       isCrit: false,
       rng: new SeededRandom(42),
     };
@@ -724,7 +729,7 @@ describe("Gen7DamageCalc -- Neuroforce ability", () => {
       attacker,
       defender,
       move,
-      state: { weather: null, terrain: null, sides: [] } as any,
+      state: { weather: null, terrain: null, sides: [] } as unknown as BattleState,
       isCrit: false,
       rng: new SeededRandom(42),
     };
@@ -741,7 +746,7 @@ describe("Gen7DamageCalc -- Neuroforce ability", () => {
       attacker: attackerNoNeuroforce,
       defender,
       move,
-      state: { weather: null, terrain: null, sides: [] } as any,
+      state: { weather: null, terrain: null, sides: [] } as unknown as BattleState,
       isCrit: false,
       rng: new SeededRandom(42),
     };
@@ -756,7 +761,7 @@ describe("Gen7Ruleset -- getBattleGimmick", () => {
   it("given getBattleGimmick('ultraburst'), then returns a Gen7UltraBurst instance", () => {
     // Verifies the ruleset properly exposes Ultra Burst to the engine
     const ruleset = new Gen7Ruleset(DATA_MANAGER);
-    const gimmick = ruleset.getBattleGimmick(BATTLE_GIMMICK_IDS.ultraBurst as any);
+    const gimmick = ruleset.getBattleGimmick(BATTLE_GIMMICK_IDS.ultraBurst);
 
     expect(gimmick).not.toBeNull();
     expect(gimmick).toBeInstanceOf(Gen7UltraBurst);
@@ -765,7 +770,7 @@ describe("Gen7Ruleset -- getBattleGimmick", () => {
   it("given getBattleGimmick('zmove'), then still returns a Z-Move instance (coexistence)", () => {
     // Z-Moves and Ultra Burst coexist in Gen 7
     const ruleset = new Gen7Ruleset(DATA_MANAGER);
-    const gimmick = ruleset.getBattleGimmick(BATTLE_GIMMICK_IDS.zMove as any);
+    const gimmick = ruleset.getBattleGimmick(BATTLE_GIMMICK_IDS.zMove);
 
     expect(gimmick).not.toBeNull();
   });

--- a/packages/gen7/tests/z-move.test.ts
+++ b/packages/gen7/tests/z-move.test.ts
@@ -108,7 +108,7 @@ function createOnFieldPokemon(overrides: {
       heldItem: overrides.heldItem ?? null,
       status: null,
       friendship: 0,
-      gender: CORE_GENDERS.male as any,
+      gender: CORE_GENDERS.male,
       isShiny: false,
       metLocation: "",
       metLevel: 1,


### PR DESCRIPTION
Eliminate every `as any` cast in `packages/gen7/tests/` (136 total across 16 files).

## Changes

Replace `as any` with proper typed alternatives throughout:
- **Redundant casts removed**: VOLATILE_IDS strings, move constants, createSyntheticActive returns, gender constants
- **Status fields**: `as PrimaryStatus | null` replacing `as any`
- **Context types**: Added `CritContext`, `MoveEffectContext`, `AbilityContext`, `ItemContext` imports
- **Move effects**: `as unknown as MoveEffect` for discriminated union stubs
- **statStages mutations**: Direct assignment (field is not readonly)
- **Z-Move power**: Object spread `{ ...move, zMovePower: N } as MoveData` instead of runtime mutation
- **Partial objects**: `as unknown as SomeType` to document intent with minimal overhead

All 1,219 gen7 tests pass. `tsc --noEmit` clean.

Closes #1143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved TypeScript type safety across test suites by replacing unsafe generic type casts with explicit, concrete types from the core library.
  * Enhanced compile-time typing for battle contexts, Pokémon instances, move effects, and event assertions.
  * Strengthened type contracts for test helpers and synthetic object factories throughout the test codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->