### PR TITLE
refactor: replace raw generation number literals with GEN_NUMBERS constants

### DIFF
--- a/.changeset/gen-numbers-const.md
+++ b/.changeset/gen-numbers-const.md
@@ -1,0 +1,5 @@
+---
+"@pokemon-lib-ts/battle": patch
+---
+
+Replace raw generation number literals with GEN_NUMBERS constants in battle src files

--- a/packages/battle/src/engine/BattleEngine.ts
+++ b/packages/battle/src/engine/BattleEngine.ts
@@ -20,6 +20,7 @@ import {
   CORE_STATUS_IDS,
   CORE_TYPE_IDS,
   CORE_VOLATILE_IDS,
+  GEN_NUMBERS,
   getExpForLevel,
   getStatStageMultiplier,
   SeededRandom,
@@ -331,7 +332,11 @@ export class BattleEngine implements BattleEventEmitter {
         // battle generation supports them, the pokemon carries a nature field, and the
         // DataManager has natures loaded. Skip the check when the DataManager has no natures
         // (e.g. Gen 1-2 data managers or minimal test fixtures that omit natures intentionally).
-        if (config.generation >= 3 && pokemon.nature && dataManager.getAllNatures().length > 0) {
+        if (
+          config.generation >= GEN_NUMBERS.gen3 &&
+          pokemon.nature &&
+          dataManager.getAllNatures().length > 0
+        ) {
           try {
             dataManager.getNature(pokemon.nature);
           } catch {

--- a/packages/battle/src/ruleset/BaseRuleset.ts
+++ b/packages/battle/src/ruleset/BaseRuleset.ts
@@ -28,6 +28,7 @@ import {
   calculateModifiedCatchRate,
   calculateShakeChecks,
   DataManager,
+  GEN_NUMBERS,
   getStatStageMultiplier,
   validateEvs,
   validateFriendship,
@@ -753,8 +754,9 @@ export abstract class BaseRuleset implements GenerationRuleset {
   }
 
   getExpRecipients(context: ExpRecipientSelectionContext): readonly ExpRecipient[] {
-    const usesHeldExpShare = this.generation >= 2 && this.generation <= 5;
-    const hasAlwaysOnExpShare = this.generation >= 6;
+    const usesHeldExpShare =
+      this.generation >= GEN_NUMBERS.gen2 && this.generation <= GEN_NUMBERS.gen5;
+    const hasAlwaysOnExpShare = this.generation >= GEN_NUMBERS.gen6;
     const recipients: ExpRecipient[] = [];
 
     for (const pokemon of context.winnerTeam) {

--- a/tools/data-importer/src/pret-overrides/apply-overrides.ts
+++ b/tools/data-importer/src/pret-overrides/apply-overrides.ts
@@ -10,6 +10,7 @@
  * - showdownValue mismatch: warning (Showdown may have been updated)
  */
 
+import { GEN_NUMBERS } from "@pokemon-lib-ts/core";
 import type { MoveOverride, PokemonOverride, PretOverride } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -60,7 +61,8 @@ export function applyMoveOverrides(
   overrides: readonly PretOverride[],
 ): ImportedMove[] {
   // For Gen 2, first apply the bulk priority scale shift: all priority=0 → 1
-  const result = gen === 2 ? applyGen2PriorityScale(moves) : moves.map((m) => ({ ...m }));
+  const result =
+    gen === GEN_NUMBERS.gen2 ? applyGen2PriorityScale(moves) : moves.map((m) => ({ ...m }));
 
   const moveOverrides = overrides.filter((o): o is MoveOverride => o.target === "move");
 

--- a/tools/data-importer/src/pret-overrides/validate-committed-data.ts
+++ b/tools/data-importer/src/pret-overrides/validate-committed-data.ts
@@ -18,6 +18,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as url from "node:url";
+import { GEN_NUMBERS } from "@pokemon-lib-ts/core";
 import { getOverridesForGen } from "./index";
 import type { MoveOverride, PokemonOverride } from "./types";
 
@@ -181,7 +182,7 @@ function validateGen(gen: number): ValidationError[] {
   }
 
   const moveOverrides = overrides.filter((o): o is MoveOverride => o.target === "move");
-  if (moveOverrides.length === 0 && gen !== 2) {
+  if (moveOverrides.length === 0 && gen !== GEN_NUMBERS.gen2) {
     // No explicit move overrides for this gen — nothing to validate
     return errors;
   }
@@ -208,7 +209,7 @@ function validateGen(gen: number): ValidationError[] {
   const moveById = new Map(moves.map((m) => [m.id, m]));
 
   // ── For Gen 2: validate bulk priority scale (all normal moves should be 1) ──
-  if (gen === 2) {
+  if (gen === GEN_NUMBERS.gen2) {
     // Only skip moves that have an explicit priority override (not overrides for other fields).
     // Skipping all overridden moves would hide priority regressions on moves that have
     // non-priority overrides (e.g., a future power override on a move with wrong priority).

--- a/tools/data-importer/src/pret-readers/pret-diff.ts
+++ b/tools/data-importer/src/pret-readers/pret-diff.ts
@@ -11,6 +11,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { Generations } from "@pkmn/data";
 import { Dex } from "@pkmn/dex";
+import { GEN_NUMBERS } from "@pokemon-lib-ts/core";
 import { readGen1Data } from "./gen1-reader";
 import { readGen2Data } from "./gen2-reader";
 import { readGen3Data } from "./gen3-reader";
@@ -221,7 +222,11 @@ export function diffMoves(gen: number, pretData: PretGenData, repoRoot: string):
     }
 
     // Compare category (Gen 4 only — Gen 1-3 derive from type split)
-    if (gen === 4 && pretMove.category !== undefined && pretMove.category !== ours.category) {
+    if (
+      gen === GEN_NUMBERS.gen4 &&
+      pretMove.category !== undefined &&
+      pretMove.category !== ours.category
+    ) {
       diffs.push({
         gen,
         kind: "move",
@@ -309,7 +314,7 @@ export function diffPokemon(gen: number, pretData: PretGenData, repoRoot: string
 
 export function diffTypeChart(gen: number, pretData: PretGenData, repoRoot: string): DiffRecord[] {
   // Gen 4 type chart is in C code, not data files — skip
-  if (gen === 4 || pretData.typeChart.length === 0) return [];
+  if (gen === GEN_NUMBERS.gen4 || pretData.typeChart.length === 0) return [];
 
   const committed = loadCommittedTypeChart(repoRoot, gen);
   const diffs: DiffRecord[] = [];

--- a/tools/oracle-validation/src/battle-replay.ts
+++ b/tools/oracle-validation/src/battle-replay.ts
@@ -17,7 +17,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { DataManager, PokemonType, TypeChart } from "@pokemon-lib-ts/core";
-import { CORE_TYPE_IDS, getTypeEffectiveness } from "@pokemon-lib-ts/core";
+import { CORE_TYPE_IDS, GEN_NUMBERS, getTypeEffectiveness } from "@pokemon-lib-ts/core";
 import { createGen1DataManager } from "@pokemon-lib-ts/gen1";
 import { createGen2DataManager } from "@pokemon-lib-ts/gen2";
 import { createGen3DataManager } from "@pokemon-lib-ts/gen3";
@@ -107,8 +107,10 @@ function getStatusImmuneTypes(statusId: string, gen: number): string[] {
   ) {
     return [CORE_TYPE_IDS.poison, CORE_TYPE_IDS.steel];
   }
-  if (statusId === SHOWDOWN_STATUS_CODES.freeze && gen >= 2) return [CORE_TYPE_IDS.ice];
-  if (statusId === SHOWDOWN_STATUS_CODES.paralysis && gen >= 6) return [CORE_TYPE_IDS.electric];
+  if (statusId === SHOWDOWN_STATUS_CODES.freeze && gen >= GEN_NUMBERS.gen2)
+    return [CORE_TYPE_IDS.ice];
+  if (statusId === SHOWDOWN_STATUS_CODES.paralysis && gen >= GEN_NUMBERS.gen6)
+    return [CORE_TYPE_IDS.electric];
   return [];
 }
 

--- a/tools/oracle-validation/src/compare-damage.ts
+++ b/tools/oracle-validation/src/compare-damage.ts
@@ -33,6 +33,7 @@ import {
   CORE_GENDERS,
   CORE_ITEM_IDS,
   CORE_NATURE_IDS,
+  GEN_NUMBERS,
 } from "../../../packages/core/src/constants/index.js";
 import type { MoveData } from "../../../packages/core/src/entities/move.js";
 import type { NatureData } from "../../../packages/core/src/entities/nature.js";
@@ -236,9 +237,9 @@ function buildActivePokemon(
 ): ActivePokemon {
   // Calculate and attach stats
   let calculatedStats: PokemonInstance["calculatedStats"];
-  if (gen <= 2) {
+  if (gen <= GEN_NUMBERS.gen2) {
     // Gen 1-2: DV-based stat calc (no natures)
-    const statCalc = gen === 1 ? calculateGen1Stats : calculateGen2Stats;
+    const statCalc = gen === GEN_NUMBERS.gen1 ? calculateGen1Stats : calculateGen2Stats;
     calculatedStats = statCalc(pokemon, speciesData);
   } else {
     // Gen 3+: IV/EV-based stat calc with natures
@@ -496,7 +497,7 @@ export function runDamageSuite(
 
   const dataManager = factory();
   const typeChart = dataManager.getTypeChart();
-  const nature = gen >= 3 ? dataManager.getNature(CORE_NATURE_IDS.hardy) : null;
+  const nature = gen >= GEN_NUMBERS.gen3 ? dataManager.getNature(CORE_NATURE_IDS.hardy) : null;
   const battleState = createBattleState({ generation: gen as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 });
 
   const oracleGen = PKMN_GENERATIONS.get(gen);
@@ -593,14 +594,14 @@ export function runDamageSuite(
         }
 
         const attackerPokemon =
-          gen <= 2
+          gen <= GEN_NUMBERS.gen2
             ? createGen12PokemonInstance(speciesData.id, localMoveData.id, localMoveData.pp)
             : createGen3PlusPokemonInstance(speciesData.id, localMoveData.id, localMoveData.pp);
 
         const attackerActive = buildActivePokemon(gen, attackerPokemon, speciesData, nature);
         // Ensure defender HP is set from calculatedStats
         const defenderPokemonRefreshed =
-          gen <= 2
+          gen <= GEN_NUMBERS.gen2
             ? createGen12PokemonInstance(defenderSpeciesData.id, "tackle", 35)
             : createGen3PlusPokemonInstance(defenderSpeciesData.id, "tackle", 35);
         const freshDefenderActive = buildActivePokemon(
@@ -629,12 +630,12 @@ export function runDamageSuite(
         // ── Build @smogon/calc objects ───────────────────────────────────
         const smogonGenNum = gen as GenerationNum;
         const smogonAttacker =
-          gen <= 2
+          gen <= GEN_NUMBERS.gen2
             ? buildSmogonPokemonGen12(smogonGenNum, speciesName)
             : buildSmogonPokemonGen3Plus(smogonGenNum, speciesName);
 
         const smogonDefender =
-          gen <= 2
+          gen <= GEN_NUMBERS.gen2
             ? buildSmogonPokemonGen12(smogonGenNum, GENERIC_DEFENDER_NAME)
             : buildSmogonPokemonGen3Plus(smogonGenNum, GENERIC_DEFENDER_NAME);
 

--- a/tools/oracle-validation/src/compare-data.ts
+++ b/tools/oracle-validation/src/compare-data.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Generations } from "@pkmn/data";
 import { Dex } from "@pkmn/dex";
+import { GEN_NUMBERS } from "@pokemon-lib-ts/core";
 import {
   type KnownDisagreement,
   type OracleCheck,
@@ -112,7 +113,8 @@ export function runDataSuite(
   }
 
   const localTypes = Object.keys(localTypeChart).sort();
-  const expectedTypeCount = generation.gen === 1 ? 15 : generation.gen <= 5 ? 17 : 18;
+  const expectedTypeCount =
+    generation.gen === GEN_NUMBERS.gen1 ? 15 : generation.gen <= GEN_NUMBERS.gen5 ? 17 : 18;
   if (localTypes.length !== expectedTypeCount) {
     failures.push(
       `Gen ${generation.gen}: type count mismatch (ours=${localTypes.length}, expected=${expectedTypeCount})`,

--- a/tools/oracle-validation/src/compare-gimmicks.ts
+++ b/tools/oracle-validation/src/compare-gimmicks.ts
@@ -33,6 +33,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Generations } from "@pkmn/data";
 import { Dex } from "@pkmn/dex";
+import { GEN_NUMBERS } from "@pokemon-lib-ts/core";
 import { getZMovePower } from "../../../packages/gen7/src/Gen7ZMove.js";
 // Import our actual Gen 7/8 gimmick functions to test against oracle.
 // Source-level imports (not public API) — same pattern as compare-damage.ts.
@@ -215,7 +216,7 @@ export function runGimmicksSuite(
 ): SuiteResult {
   const gen = generation.gen;
 
-  if (gen <= 5) {
+  if (gen <= GEN_NUMBERS.gen5) {
     return makeSkip();
   }
 
@@ -224,14 +225,14 @@ export function runGimmicksSuite(
 
   // ── Gen 6: Mega Evolution ─────────────────────────────────────────────────
 
-  if (gen === 6 || gen === 7) {
+  if (gen === GEN_NUMBERS.gen6 || gen === GEN_NUMBERS.gen7) {
     notes.push(
       `Gen ${gen}: Mega Evolution — Mega Stone triggers mid-battle transformation. ` +
         "Stat changes apply on the Mega turn and persist through switches (ERRATA #18 — NOT reverted on switch-out). " +
         "Source: Showdown sim/battle-actions.ts onAfterMove Mega Evolution handler",
     );
     notes.push(
-      gen === 6
+      gen === GEN_NUMBERS.gen6
         ? "Gen 6: Speed on Mega turn: Pokemon acts at pre-Mega Speed (priority determined before transformation). " +
             "Source: Showdown sim/battle-actions.ts Gen 6 — speed recalc deferred"
         : "Gen 7: Speed on Mega turn: Pokemon acts at post-Mega Speed (changed from Gen 6 behavior). " +
@@ -242,7 +243,7 @@ export function runGimmicksSuite(
 
   // ── Gen 7: Z-Moves ────────────────────────────────────────────────────────
 
-  if (gen === 7) {
+  if (gen === GEN_NUMBERS.gen7) {
     buildZMovePowerChecks(generation, oracleChecks, notes);
 
     notes.push(
@@ -258,7 +259,7 @@ export function runGimmicksSuite(
 
   // ── Gen 8: Dynamax ────────────────────────────────────────────────────────
 
-  if (gen === 8) {
+  if (gen === GEN_NUMBERS.gen8) {
     buildDynamaxHPChecks(generation, oracleChecks, notes);
 
     notes.push(
@@ -283,7 +284,7 @@ export function runGimmicksSuite(
 
   // ── Gen 9: Terastallization ───────────────────────────────────────────────
 
-  if (gen === 9) {
+  if (gen === GEN_NUMBERS.gen9) {
     notes.push(
       "Gen 9: Terastallization — changes Pokemon's type to its Tera type for the battle. " +
         "Base types retain 1.5× STAB even after Tera (ERRATA #30). " +

--- a/tools/oracle-validation/src/compare-ground-truth.ts
+++ b/tools/oracle-validation/src/compare-ground-truth.ts
@@ -8,6 +8,7 @@ import {
   CORE_GENDERS,
   CORE_ITEM_IDS,
   CORE_NATURE_IDS,
+  GEN_NUMBERS,
 } from "../../../packages/core/src/constants/index.js";
 import type { PokemonInstance } from "../../../packages/core/src/entities/pokemon.js";
 import type { PokemonType } from "../../../packages/core/src/entities/types.js";
@@ -509,7 +510,7 @@ export function runGroundTruthSuite(
     if (testCase.kind === "typeChart") {
       failure = evaluateTypeChartCase(testCase, typeChart);
     } else if (testCase.kind === "derivedStat") {
-      if (gen !== 1) {
+      if (gen !== GEN_NUMBERS.gen1) {
         deferredCases += 1;
         continue;
       }
@@ -518,7 +519,7 @@ export function runGroundTruthSuite(
       }
       failure = evaluateDerivedStatCase(testCase, gen1DataManager);
     } else if (testCase.kind === "critRate") {
-      if (gen !== 1) {
+      if (gen !== GEN_NUMBERS.gen1) {
         deferredCases += 1;
         continue;
       }
@@ -551,7 +552,7 @@ export function runGroundTruthSuite(
     notes.push(`${deferredCases} documentation-only or engine-deferred case(s) skipped`);
   }
 
-  if (gen === 1) {
+  if (gen === GEN_NUMBERS.gen1) {
     notes.push(
       "Gen 1 suite uses cartridge-authoritative data; later Gen 1-4 suites treat Showdown as a differential cross-check.",
     );

--- a/tools/oracle-validation/src/compare-mechanics.ts
+++ b/tools/oracle-validation/src/compare-mechanics.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Generations } from "@pkmn/data";
 import { Dex } from "@pkmn/dex";
+import { GEN_NUMBERS } from "@pokemon-lib-ts/core";
 import {
   type KnownDisagreement,
   type OracleCheck,
@@ -128,7 +129,7 @@ export function runMechanicsSuite(
     // A "neutral" Gen 2 move has our priority=1 and oracle priority=0.
     // Skip these normal moves — the scale difference is intentional and documented.
     // Source: pret/pokecrystal data/moves/effects_priorities.asm
-    const basePriority = generation.gen === 2 ? 1 : 0;
+    const basePriority = generation.gen === GEN_NUMBERS.gen2 ? 1 : 0;
     if (ourPriority === basePriority && oraclePriority === 0) {
       continue;
     }
@@ -150,7 +151,7 @@ export function runMechanicsSuite(
 
   // ── 2. Ability Assignment (Gen 3+ only) ────────────────────────────────────
 
-  if (generation.gen >= 3) {
+  if (generation.gen >= GEN_NUMBERS.gen3) {
     const localPokemon = JSON.parse(
       readFileSync(join(generation.dataDir, "pokemon.json"), "utf8"),
     ) as LocalSpecies[];

--- a/tools/oracle-validation/src/compare-stats.ts
+++ b/tools/oracle-validation/src/compare-stats.ts
@@ -5,6 +5,7 @@ import {
   CORE_ITEM_IDS,
   CORE_MOVE_IDS,
   CORE_NATURE_IDS,
+  GEN_NUMBERS,
 } from "../../../packages/core/src/constants/index.js";
 import type { PokemonInstance } from "../../../packages/core/src/entities/pokemon.js";
 import { createFriendship } from "../../../packages/core/src/logic/friendship-inputs.js";
@@ -165,7 +166,7 @@ function runGen3PlusStatCheck(gen: number): string[] {
 export function runStatsSuite(generation: ImplementedGeneration): SuiteResult {
   const failures: string[] = [];
 
-  if (generation.gen === 1) {
+  if (generation.gen === GEN_NUMBERS.gen1) {
     const dataManager = createGen1DataManager();
     const species = dataManager.getSpeciesByName("charizard");
     const tackle = dataManager.getMove(CORE_MOVE_IDS.tackle);
@@ -177,7 +178,7 @@ export function runStatsSuite(generation: ImplementedGeneration): SuiteResult {
     }
   }
 
-  if (generation.gen === 2) {
+  if (generation.gen === GEN_NUMBERS.gen2) {
     const dataManager = createGen2DataManager();
     const species = dataManager.getSpeciesByName("charizard");
     const tackle = dataManager.getMove(CORE_MOVE_IDS.tackle);
@@ -188,7 +189,7 @@ export function runStatsSuite(generation: ImplementedGeneration): SuiteResult {
     }
   }
 
-  if (generation.gen >= 3) {
+  if (generation.gen >= GEN_NUMBERS.gen3) {
     failures.push(...runGen3PlusStatCheck(generation.gen));
   }
 

--- a/tools/oracle-validation/src/compare-terrain.ts
+++ b/tools/oracle-validation/src/compare-terrain.ts
@@ -18,6 +18,7 @@
  *             NOT all damage types.
  */
 
+import { GEN_NUMBERS } from "@pokemon-lib-ts/core";
 import { getTerrainDamageModifier as getGen6TerrainDamageModifier } from "../../../packages/gen6/src/Gen6Terrain.js";
 import {
   TERRAIN_DEFAULT_TURNS as GEN7_TERRAIN_DEFAULT_TURNS,
@@ -99,19 +100,19 @@ interface TerrainDurationValues {
 }
 
 function getDurationValues(gen: number): TerrainDurationValues {
-  if (gen === 6) {
+  if (gen === GEN_NUMBERS.gen6) {
     // Gen 6: Terrain Extender not introduced until Gen 7.
     // Duration is 5 turns; no item extends it.
     // Source: Bulbapedia "Terrain" — Terrain Extender introduced in Gen 7
     return { defaultTurns: 5, extendedTurns: null };
   }
-  if (gen === 7) {
+  if (gen === GEN_NUMBERS.gen7) {
     return {
       defaultTurns: GEN7_TERRAIN_DEFAULT_TURNS,
       extendedTurns: GEN7_TERRAIN_EXTENDED_TURNS,
     };
   }
-  if (gen === 8) {
+  if (gen === GEN_NUMBERS.gen8) {
     return {
       defaultTurns: GEN8_TERRAIN_DEFAULT_TURNS,
       extendedTurns: GEN8_TERRAIN_EXTENDED_TURNS,
@@ -139,7 +140,7 @@ export function runTerrainSuite(
 ): SuiteResult {
   const gen = generation.gen;
 
-  if (gen <= 5) {
+  if (gen <= GEN_NUMBERS.gen5) {
     return makeSkip();
   }
 
@@ -174,7 +175,7 @@ export function runTerrainSuite(
 
   // ── Gen 6: damage modifier checks (getTerrainDamageModifier is exported) ──
 
-  if (gen === 6) {
+  if (gen === GEN_NUMBERS.gen6) {
     // Electric Terrain: 1.5× for Electric moves vs grounded attacker
     // Source: Showdown data/conditions.ts — electricterrain.onBasePower chainModify(1.5)
     const electricMod = getGen6TerrainDamageModifier(
@@ -222,7 +223,7 @@ export function runTerrainSuite(
   // Note: getTerrainDamageModifier is a private function in Gen 7-9 DamageCalc modules.
   // The boost value is documented here and validated indirectly through compare-damage.ts.
 
-  if (gen === 7) {
+  if (gen === GEN_NUMBERS.gen7) {
     notes.push(
       "Gen 7: Electric Terrain boost 1.5× (6144/4096) — same as Gen 6. " +
         "Source: Showdown data/conditions.ts electricterrain.onBasePower",
@@ -241,7 +242,7 @@ export function runTerrainSuite(
     );
   }
 
-  if (gen >= 8) {
+  if (gen >= GEN_NUMBERS.gen8) {
     notes.push(
       `Gen ${gen}: Electric/Grassy/Psychic Terrain boost 1.3× (5325/4096) — nerfed from 1.5× in Gen 7 (ERRATA #17). ` +
         "Source: Showdown data/mods/gen8/scripts.ts terrain boost",
@@ -268,7 +269,7 @@ export function runTerrainSuite(
       "Source: Showdown data/conditions.ts grassyterrain.onResidual",
   );
 
-  if (gen >= 7) {
+  if (gen >= GEN_NUMBERS.gen7) {
     notes.push(
       `Gen ${gen}: Psychic Terrain — prevents priority moves targeting grounded Pokemon. ` +
         "Source: Showdown data/conditions.ts psychicterrain.onTryHit",

--- a/tools/oracle-validation/src/damage-trace.ts
+++ b/tools/oracle-validation/src/damage-trace.ts
@@ -34,6 +34,7 @@ import {
   createEvs,
   createIvs,
   createStatExp,
+  GEN_NUMBERS,
   MAX_DV,
   MAX_IV,
   SeededRandom,
@@ -117,7 +118,7 @@ function generateTeam(gen: number, dataManager: DataManager, rng: SeededRandom, 
     if (moves.length === 0) continue;
 
     const ivs =
-      gen <= 2
+      gen <= GEN_NUMBERS.gen2
         ? createDvs({
             attack: MAX_DV,
             defense: MAX_DV,
@@ -133,11 +134,11 @@ function generateTeam(gen: number, dataManager: DataManager, rng: SeededRandom, 
             spDefense: MAX_IV,
             speed: MAX_IV,
           });
-    const evs = gen <= 2 ? createStatExp() : createEvs();
+    const evs = gen <= GEN_NUMBERS.gen2 ? createStatExp() : createEvs();
 
     const abilitySlot = CORE_ABILITY_SLOTS.normal1;
     let ability = "";
-    if (gen >= 3) {
+    if (gen >= GEN_NUMBERS.gen3) {
       const candidate = species.abilities.normal[0] ?? "";
       if (!candidate) continue;
       try {
@@ -154,7 +155,7 @@ function generateTeam(gen: number, dataManager: DataManager, rng: SeededRandom, 
       nickname: null,
       level: 50,
       experience: 0,
-      nature: gen <= 2 ? CORE_NATURE_IDS.serious : CORE_NATURE_IDS.hardy,
+      nature: gen <= GEN_NUMBERS.gen2 ? CORE_NATURE_IDS.serious : CORE_NATURE_IDS.hardy,
       ivs,
       evs,
       currentHp: 1,

--- a/tools/oracle-validation/src/smoke-runner.ts
+++ b/tools/oracle-validation/src/smoke-runner.ts
@@ -34,6 +34,7 @@ import {
   createEvs,
   createIvs,
   createStatExp,
+  GEN_NUMBERS,
   MAX_DV,
   MAX_IV,
   SeededRandom,
@@ -105,8 +106,8 @@ export function generateMinimalTeam(
   // Pre-build item pool and nature list once per team
   // Items: Gen 2+ has held items in the DataManager (62 in Gen 2, growing in later gens)
   // Natures: Gen 3+ only (Gen 1-2 have no nature mechanic)
-  const allItems = gen >= 2 ? dataManager.getAllItems() : [];
-  const allNatures = gen >= 3 ? dataManager.getAllNatures() : [];
+  const allItems = gen >= GEN_NUMBERS.gen2 ? dataManager.getAllItems() : [];
+  const allNatures = gen >= GEN_NUMBERS.gen3 ? dataManager.getAllNatures() : [];
 
   for (const species of shuffled) {
     if (team.length >= TEAM_SIZE) break;
@@ -131,7 +132,7 @@ export function generateMinimalTeam(
     if (moves.length === 0) continue;
 
     const ivs =
-      gen <= 2
+      gen <= GEN_NUMBERS.gen2
         ? createDvs({
             attack: MAX_DV,
             defense: MAX_DV,
@@ -147,12 +148,12 @@ export function generateMinimalTeam(
             spDefense: MAX_IV,
             speed: MAX_IV,
           });
-    const evs = gen <= 2 ? createStatExp() : createEvs();
+    const evs = gen <= GEN_NUMBERS.gen2 ? createStatExp() : createEvs();
 
     // Randomly select an ability slot from available options
     let ability = "";
     let abilitySlot: AbilitySlot = CORE_ABILITY_SLOTS.normal1;
-    if (gen >= 3) {
+    if (gen >= GEN_NUMBERS.gen3) {
       const candidates: [string, AbilitySlot][] = [];
       if (species.abilities.normal[0])
         candidates.push([species.abilities.normal[0], CORE_ABILITY_SLOTS.normal1]);
@@ -188,13 +189,13 @@ export function generateMinimalTeam(
 
     // Randomly pick a held item (Gen 2+)
     let heldItem: string | null = null;
-    if (gen >= 2 && allItems.length > 0) {
+    if (gen >= GEN_NUMBERS.gen2 && allItems.length > 0) {
       heldItem = rng.pick(allItems).id;
     }
 
     // Randomly pick a nature (Gen 3+), or use neutral for Gen 1-2
     let nature: NatureId;
-    if (gen <= 2) {
+    if (gen <= GEN_NUMBERS.gen2) {
       nature = CORE_NATURE_IDS.serious;
     } else if (allNatures.length > 0) {
       nature = rng.pick(allNatures).id;

--- a/tools/replay-parser/src/simulation/team-generator.ts
+++ b/tools/replay-parser/src/simulation/team-generator.ts
@@ -16,6 +16,7 @@ import {
   createFriendship,
   createIvs,
   createStatExp,
+  GEN_NUMBERS,
   MAX_DV,
   MAX_IV,
   MIN_DV,
@@ -51,7 +52,7 @@ function createGenerationStatInputs(
   generation: number,
   rng: SeededRandom,
 ): Pick<PokemonInstance, "ivs" | "evs"> {
-  if (generation <= 2) {
+  if (generation <= GEN_NUMBERS.gen2) {
     const specialDv = rng.int(MIN_DV, MAX_DV);
     return {
       ivs: createDvs({
@@ -83,7 +84,7 @@ function determineAbilitySlot(
   species: PokemonSpeciesData,
   rng: SeededRandom,
 ): PokemonInstance["abilitySlot"] {
-  if (generation < 3) {
+  if (generation < GEN_NUMBERS.gen3) {
     return CORE_ABILITY_SLOTS.normal1;
   }
 
@@ -165,13 +166,14 @@ export function generateRandomTeam(
     const { ivs, evs } = createGenerationStatInputs(generation, rng);
     const abilitySlot = determineAbilitySlot(generation, species, rng);
     const ability =
-      generation >= 3
+      generation >= GEN_NUMBERS.gen3
         ? abilitySlot === CORE_ABILITY_SLOTS.normal2 && species.abilities.normal[1] != null
           ? species.abilities.normal[1]
           : (species.abilities.normal[0] ?? "")
         : "";
     const gender = determineGender(species, rng);
-    const nature = generation <= 2 ? rng.pick(NEUTRAL_NATURES) : rng.pick(ALL_NATURE_IDS);
+    const nature =
+      generation <= GEN_NUMBERS.gen2 ? rng.pick(NEUTRAL_NATURES) : rng.pick(ALL_NATURE_IDS);
 
     const pokemon: PokemonInstance = {
       uid: `${opts.uidPrefix}-${++nextUidIndex}`,

--- a/tools/replay-parser/src/validator.ts
+++ b/tools/replay-parser/src/validator.ts
@@ -1,5 +1,5 @@
 import type { DataManager, PokemonType, TypeChart } from "@pokemon-lib-ts/core";
-import { CORE_TYPE_IDS, getTypeEffectiveness } from "@pokemon-lib-ts/core";
+import { CORE_TYPE_IDS, GEN_NUMBERS, getTypeEffectiveness } from "@pokemon-lib-ts/core";
 import { createGen1DataManager } from "@pokemon-lib-ts/gen1";
 import { createGen2DataManager } from "@pokemon-lib-ts/gen2";
 import { createGen3DataManager } from "@pokemon-lib-ts/gen3";
@@ -55,8 +55,9 @@ function getStatusImmuneTypes(statusId: string, generation: number): string[] {
   ) {
     return [CORE_TYPE_IDS.poison, CORE_TYPE_IDS.steel];
   }
-  if (statusId === SHOWDOWN_STATUS_CODES.freeze && generation >= 2) return [CORE_TYPE_IDS.ice];
-  if (statusId === SHOWDOWN_STATUS_CODES.paralysis && generation >= 6)
+  if (statusId === SHOWDOWN_STATUS_CODES.freeze && generation >= GEN_NUMBERS.gen2)
+    return [CORE_TYPE_IDS.ice];
+  if (statusId === SHOWDOWN_STATUS_CODES.paralysis && generation >= GEN_NUMBERS.gen6)
     return [CORE_TYPE_IDS.electric];
   return [];
 }


### PR DESCRIPTION
## Summary

- Adopts `GEN_NUMBERS` (already in `@pokemon-lib-ts/core`) across all `src/` files that used raw integer literals in generation comparisons
- ~50 replacements across `battle/BaseRuleset.ts`, `battle/BattleEngine.ts`, and 15 tool files in oracle-validation, replay-parser, and data-importer
- No behavioral changes

## Test plan

- [ ] `npm run typecheck` passes (26/26)
- [ ] `npm run test` passes

Closes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized generation number checks across the codebase to use centralized constants instead of hardcoded values for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->