### PR TITLE
feat: enforce required proof suites from impacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -98,3 +99,26 @@ jobs:
           else
             echo "No publishable package source or data files changed — changeset not required."
           fi
+
+  proof-gate:
+    name: proof-gate
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run proof:preview -- --mode ci-preview
+      - run: npm run test:workflow
+      - run: npm run test
+      - run: npm run ci:package-boundaries
+      - run: npm run typecheck:contracts
+      - run: npm run validate:pret
+      - run: npm run oracle:fast
+      - run: npm run proof:enforce -- --mode ci-preview --executed-suite changeset-check --executed-suite oracle-fast --executed-suite package-boundaries --executed-suite pret-validate --executed-suite proof-preview --executed-suite test --executed-suite typecheck:contracts --executed-suite workflow-contract

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "oracle:groundtruth": "tsx tools/oracle-validation/src/runner.ts --suite groundTruth",
     "oracle:fast": "tsx tools/oracle-validation/src/runner.ts --suite fast",
     "proof:preview": "tsx tools/oracle-validation/src/changed-mechanics.ts",
+    "proof:enforce": "tsx tools/oracle-validation/src/enforce-impacts.ts",
     "proof:audit:mutation": "tsx tools/oracle-validation/src/direct-mutation-audit.ts",
     "smoke": "tsx tools/oracle-validation/src/runner.ts --suite smoke",
     "compliance": "tsx tools/oracle-validation/src/runner.ts --suite all",

--- a/scripts/lib/workflow-contract.mjs
+++ b/scripts/lib/workflow-contract.mjs
@@ -54,3 +54,27 @@ export function validatePrTriggerWorkflow(repoRoot, workflowFile) {
     errors,
   };
 }
+
+export function validateCiWorkflow(repoRoot) {
+  const workflow = readWorkflow(repoRoot, "ci.yml");
+  const errors = [];
+
+  for (const expected of [
+    "ready_for_review",
+    "converted_to_draft",
+    "proof-gate:",
+    "npm run proof:preview -- --mode ci-preview",
+    "npm run test:workflow",
+    "npm run oracle:fast",
+    "npm run proof:enforce -- --mode ci-preview",
+  ]) {
+    if (!workflow.includes(expected)) {
+      errors.push(`Missing expected CI workflow contract snippet: ${expected}`);
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}

--- a/scripts/tests/workflow-contract.test.mjs
+++ b/scripts/tests/workflow-contract.test.mjs
@@ -3,6 +3,7 @@ import { dirname, resolve } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
+  validateCiWorkflow,
   validateComplianceWorkflow,
   validatePrTriggerWorkflow,
 } from "../lib/workflow-contract.mjs";
@@ -21,5 +22,10 @@ test("pr review workflow retriggers on draft state changes", () => {
 
 test("issue-link workflow retriggers on draft state changes", () => {
   const result = validatePrTriggerWorkflow(repoRoot, "check-issue-link.yml");
+  assert.equal(result.isValid, true, result.errors.join("\n"));
+});
+
+test("ci workflow runs proof-gate enforcement with preview artifacts", () => {
+  const result = validateCiWorkflow(repoRoot);
   assert.equal(result.isValid, true, result.errors.join("\n"));
 });

--- a/scripts/verify-local.mjs
+++ b/scripts/verify-local.mjs
@@ -44,6 +44,7 @@ console.log("\n==> running lint, typecheck, tests, and boundaries in parallel...
 await Promise.all([
   runStep("proof preview", ["run", "proof:preview"]),
   runStep("direct mutation audit", ["run", "proof:audit:mutation"]),
+  runStep("oracle fast", ["run", "oracle:fast"]),
   runStep("workflow validator tests", ["run", "test:workflow"]),
   runStep("lint", ["run", "lint:check"]),
   runStep("tests (unit + integration)", ["run", "test"]),
@@ -64,5 +65,46 @@ if (changesetResult.status !== 0) {
   process.exit(changesetResult.status ?? 1);
 }
 console.log("==> PASSED: changeset gate");
+
+console.log("\n==> impacts enforcement");
+const enforceResult = spawnSync(
+  "npm",
+  [
+    "run",
+    "proof:enforce",
+    "--",
+    "--mode",
+    "local-preview",
+    "--executed-suite",
+    "changeset-check",
+    "--executed-suite",
+    "lint",
+    "--executed-suite",
+    "oracle-fast",
+    "--executed-suite",
+    "package-boundaries",
+    "--executed-suite",
+    "pret-validate",
+    "--executed-suite",
+    "proof-preview",
+    "--executed-suite",
+    "test",
+    "--executed-suite",
+    "typecheck",
+    "--executed-suite",
+    "typecheck:contracts",
+    "--executed-suite",
+    "workflow-contract",
+  ],
+  {
+    stdio: "inherit",
+    env: process.env,
+  },
+);
+if (enforceResult.status !== 0) {
+  console.error("\n==> FAILED: impacts enforcement");
+  process.exit(enforceResult.status ?? 1);
+}
+console.log("==> PASSED: impacts enforcement");
 
 console.log("\nLocal verification passed.");

--- a/tools/oracle-validation/control-plane/mechanic-catalog.v1.json
+++ b/tools/oracle-validation/control-plane/mechanic-catalog.v1.json
@@ -20,7 +20,7 @@
       "persistent": true,
       "proofStatus": "proved",
       "authorityKey": "shared.control-plane",
-      "requiredSuites": ["oracle-runner"],
+      "requiredSuites": ["oracle-fast"],
       "obligationSeed": "artifacts"
     },
     {

--- a/tools/oracle-validation/src/enforce-impacts.ts
+++ b/tools/oracle-validation/src/enforce-impacts.ts
@@ -1,0 +1,166 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { type ImpactsReport, impactsReportSchema } from "./proof-artifact-schema.js";
+
+const knownSuites = new Set([
+  "changeset-check",
+  "lint",
+  "oracle-fast",
+  "package-boundaries",
+  "pret-validate",
+  "proof-preview",
+  "test",
+  "typecheck",
+  "typecheck:contracts",
+  "workflow-contract",
+]);
+
+interface Args {
+  readonly mode: string;
+  readonly executedSuites: string[];
+}
+
+interface EnforcementResult {
+  readonly errors: string[];
+  readonly requiredSuites: string[];
+  readonly executedSuites: string[];
+}
+
+function parseArgs(argv: string[]): Args {
+  let mode = "local-preview";
+  const executedSuites: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--mode") {
+      mode = argv[index + 1] ?? mode;
+      index += 1;
+      continue;
+    }
+    if (arg === "--executed-suite") {
+      const suite = argv[index + 1];
+      if (suite) executedSuites.push(suite);
+      index += 1;
+    }
+  }
+
+  return { mode, executedSuites };
+}
+
+function git(repoRoot: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }).trim();
+}
+
+function canonicalizeSuiteId(suiteId: string): string {
+  switch (suiteId) {
+    case "oracle-runner":
+      return "oracle-fast";
+    default:
+      return suiteId;
+  }
+}
+
+export function evaluateImpactsEnforcement(
+  impacts: ImpactsReport,
+  executedSuites: readonly string[],
+): EnforcementResult {
+  const errors: string[] = [];
+  const canonicalExecutedSuites = [...new Set(executedSuites.map(canonicalizeSuiteId))].sort();
+  const requiredSuites = [...new Set(impacts.requiredSuites.map(canonicalizeSuiteId))].sort();
+
+  for (const suiteId of canonicalExecutedSuites) {
+    if (!knownSuites.has(suiteId)) {
+      errors.push(`Unknown executed suite id: ${suiteId}`);
+    }
+  }
+
+  for (const suiteId of requiredSuites) {
+    if (!knownSuites.has(suiteId)) {
+      errors.push(`Unknown required suite id in impacts.v1.json: ${suiteId}`);
+      continue;
+    }
+    if (!canonicalExecutedSuites.includes(suiteId)) {
+      errors.push(`Required suite ${suiteId} was not executed for mode ${impacts.mode}.`);
+    }
+  }
+
+  if (impacts.lowConfidenceFiles.length > 0) {
+    errors.push(
+      `Low-confidence ownership mapping detected: ${impacts.lowConfidenceFiles.join(", ")}`,
+    );
+  }
+
+  if (impacts.unmappedRuntimeOwningFiles.length > 0) {
+    errors.push(
+      `Unmapped runtime-owning files detected: ${impacts.unmappedRuntimeOwningFiles.join(", ")}`,
+    );
+  }
+
+  return {
+    errors,
+    requiredSuites,
+    executedSuites: canonicalExecutedSuites,
+  };
+}
+
+function loadImpactsReport(repoRoot: string, mode: string): ImpactsReport {
+  const gitSha = git(repoRoot, "rev-parse", "HEAD");
+  const impactsPath = join(
+    repoRoot,
+    "tools",
+    "oracle-validation",
+    "results",
+    gitSha,
+    mode,
+    "impacts.v1.json",
+  );
+
+  let rawJson: string;
+  try {
+    rawJson = readFileSync(impactsPath, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Missing impacts artifact at ${impactsPath}: ${message}`);
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(rawJson);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid impacts artifact JSON at ${impactsPath}: ${message}`);
+  }
+
+  return impactsReportSchema.parse(parsedJson);
+}
+
+function main(): void {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+  const args = parseArgs(process.argv.slice(2));
+  const impacts = loadImpactsReport(repoRoot, args.mode);
+  const result = evaluateImpactsEnforcement(impacts, args.executedSuites);
+
+  if (result.errors.length > 0) {
+    console.error(`Impacts enforcement failed for ${args.mode}.`);
+    for (const error of result.errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Impacts enforcement passed for ${args.mode}. Required suites: ${result.requiredSuites.join(", ") || "(none)"}`,
+  );
+}
+
+const entrypoint = process.argv[1];
+if (entrypoint && import.meta.url === pathToFileURL(resolve(entrypoint)).href) {
+  main();
+}

--- a/tools/oracle-validation/tests/enforce-impacts.test.ts
+++ b/tools/oracle-validation/tests/enforce-impacts.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { evaluateImpactsEnforcement } from "../src/enforce-impacts.js";
+import type { ImpactsReport } from "../src/proof-artifact-schema.js";
+
+function createImpactsReport(overrides: Partial<ImpactsReport> = {}): ImpactsReport {
+  return {
+    schemaVersion: "impacts.v1",
+    gitSha: "abc123",
+    timestamp: "2026-03-31T00:00:00.000Z",
+    mode: "local-preview",
+    requestedBaseRef: "origin/main",
+    resolvedBaseRef: "origin/main",
+    usedFallbackBaseRef: false,
+    changedFiles: [],
+    unmappedRuntimeOwningFiles: [],
+    directOwnershipKeys: [],
+    transitiveOwnershipKeys: [],
+    directMechanicIds: [],
+    transitiveMechanicIds: [],
+    touchedAuthorityKeys: [],
+    requiredSuites: ["proof-preview"],
+    lowConfidenceFiles: [],
+    fileClassifications: [],
+    ...overrides,
+  };
+}
+
+describe("evaluateImpactsEnforcement", () => {
+  it("passes when all required suites executed and no ambiguity exists", () => {
+    const result = evaluateImpactsEnforcement(createImpactsReport(), ["proof-preview"]);
+
+    expect(result.errors).toEqual([]);
+    expect(result.requiredSuites).toEqual(["proof-preview"]);
+  });
+
+  it("fails when a required suite was not executed", () => {
+    const result = evaluateImpactsEnforcement(
+      createImpactsReport({ requiredSuites: ["proof-preview", "workflow-contract"] }),
+      ["proof-preview"],
+    );
+
+    expect(result.errors).toContain(
+      "Required suite workflow-contract was not executed for mode local-preview.",
+    );
+  });
+
+  it("fails on unknown required suite ids", () => {
+    const result = evaluateImpactsEnforcement(
+      createImpactsReport({ requiredSuites: ["unknown-suite"] }),
+      ["proof-preview"],
+    );
+
+    expect(result.errors).toContain("Unknown required suite id in impacts.v1.json: unknown-suite");
+  });
+
+  it("fails on low-confidence mappings", () => {
+    const result = evaluateImpactsEnforcement(
+      createImpactsReport({ lowConfidenceFiles: ["packages/battle/src/engine/BattleEngine.ts"] }),
+      ["proof-preview"],
+    );
+
+    expect(result.errors).toContain(
+      "Low-confidence ownership mapping detected: packages/battle/src/engine/BattleEngine.ts",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a fail-closed `proof:enforce` verifier for `impacts.v1.json`
- wire required-suite enforcement into `verify:local` and a dedicated CI `proof-gate` job
- add workflow-contract and oracle-validation tests covering the new enforcement path

## Testing
- npm run test --workspace oracle-validation -- enforce-impacts
- npm run test:workflow
- npm run typecheck --workspace oracle-validation
- npm run verify:local

Closes: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded CI workflow to run on additional pull request activity types: opened, synchronize, reopened, ready_for_review, converted_to_draft, and edited.
  * Added validation enforcement to CI and local verification pipelines with contract validation.

* **Tests**
  * Added tests for CI workflow contract validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->