### PR TITLE
docs: refresh status docs after held-item seam routing

### DIFF
--- a/specs/reference/battle-status.md
+++ b/specs/reference/battle-status.md
@@ -1,6 +1,6 @@
 # Battle Implementation Status
 
-**Last updated:** 2026-03-27
+**Last updated:** 2026-03-31
 **Overall estimate:** Feature-complete for singles battles, but this page is a summary, not a correctness proof.
 **Architecture:** Pluggable gen-agnostic engine. Delegates ALL gen-specific behavior to GenerationRuleset. Depends only on @pokemon-lib-ts/core.
 
@@ -77,8 +77,10 @@ Gen 5+ stubs (moody, harvest, grassy-terrain-heal now implemented in gen5+ rules
 - Actual implementations in gen rulesets
 
 ### Held Item System (hooks, not implementations)
-- before-move, on-damage-taken, on-hit, EoT item hooks
+- before-turn-order, before-move, holder-side stat-change, foe-side stat-change, on-damage-taken, on-hit, on-contact, and EoT item hooks
+- Deferred held-item reactions now flush through move-prevented, passive-immunity, flinch, and failed reactive-switch exits so item consumers stay on the engine-owned seam instead of helper-only branches
 - `processItemResult()` handles 8 effect types
+- Engine-path regression coverage now pins the shared item seams directly in `packages/battle/tests/integration/engine/held-item-stat-change.test.ts` and `packages/battle/tests/integration/engine/item-force-switch.test.ts`
 - Actual implementations in gen rulesets
 
 ### Weather System
@@ -124,6 +126,7 @@ Gen 5+ stubs (moody, harvest, grassy-terrain-heal now implemented in gen5+ rules
 | Doubles/Triples/Rotation formats | Massive separate initiative; BattleFormat type exists |
 | Greedy AI controller | Spec'd but deferred; RandomAI is sufficient for current gens |
 | Minimax AI controller | Spec'd but deferred |
+| Later-gen held-item trigger surfaces for move miss / sound-move use / room activation | Tracked by `#1746`; Gen 8-9 `Blunder Policy`, `Throat Spray`, and `Room Service` still lack engine dispatch hooks |
 
 This page no longer claims "no missing issues" for singles correctness. New seam regressions are expected to be caught by invariant tests and CI, not by this summary doc.
 
@@ -151,3 +154,4 @@ This page no longer claims "no missing issues" for singles correctness. New seam
 | #636 | fix/battle,gen6 | `getBattleGimmick()` gains type parameter for Gen 7 disambiguation |
 | #1067 | chore/core-battle-confidence-phase1 | BattleEngine deserialize now rejects lossy non-checkpoint restores, re-links active Pokemon back to saved team instances, and rejects contradictory active/team checkpoint state |
 | #1068 | chore/core-battle-confidence-phase2 | Battle helper fixture surfaces now pin malformed `createOnFieldPokemon()` / `createBattleSide()` / `createBattleState()` inputs with direct invariant tests while preserving supported active-only and Tera fallback fixture shapes |
+| #1797 | feat/trigger-surface-routing | Shared held-item stat-change / reactive-switch seams for Adrenaline Orb, Eject Pack, Mirror Herb, Clear Amulet, Red Card, and Eject Button, plus early-return flushing for deferred item reactions |

--- a/specs/reference/gen7-status.md
+++ b/specs/reference/gen7-status.md
@@ -1,6 +1,6 @@
 # Gen7 Implementation Status
 
-**Last updated:** 2026-03-27
+**Last updated:** 2026-03-31
 **Overall estimate:** 100% complete (all waves merged — PR #703 final)
 **Architecture:** Extends `BaseRuleset`
 **Spec:** `specs/battle/08-gen7.md`
@@ -111,9 +111,9 @@
 
 ## Test Coverage
 
-25 test files, 1,178 tests (as of 2026-03-27).
+29 test files, 1,231 tests (as of 2026-03-31).
 
-Test files: `abilities-damage.test.ts`, `abilities-nerfs.test.ts`, `abilities-new.test.ts`, `abilities-switch-contact.test.ts`, `aurora-veil.test.ts`, `bugfix-phase2.test.ts`, `coverage-gaps.test.ts`, `crit-calc.test.ts`, `damage-calc.test.ts`, `data-loading.test.ts`, `dual-gimmick.test.ts`, `entry-hazards.test.ts`, `exp-formula.test.ts`, `integration.test.ts`, `items.test.ts`, `mega-evolution.test.ts`, `move-effects.test.ts`, `ruleset.test.ts`, `smoke.test.ts`, `status.test.ts`, `terrain.test.ts`, `type-chart.test.ts`, `weather.test.ts`, `z-move.test.ts`, `z-move-status.test.ts`
+Test files: `abilities-damage.test.ts`, `abilities-nerfs.test.ts`, `abilities-new.test.ts`, `abilities-switch-contact.test.ts`, `aurora-veil.test.ts`, `bugfix-phase2.test.ts`, `cloud-nine-suppression.test.ts`, `coverage-gaps.test.ts`, `crit-calc.test.ts`, `damage-calc.test.ts`, `data-loading.test.ts`, `dual-gimmick.test.ts`, `entry-hazards.test.ts`, `exp-formula.test.ts`, `facade-power-doubling.test.ts`, `gimmick-state.test.ts`, `integration/integration.test.ts`, `items.test.ts`, `mega-evolution.test.ts`, `move-effects.test.ts`, `ruleset.test.ts`, `smoke/smoke.test.ts`, `status.test.ts`, `terrain.test.ts`, `type-chart.test.ts`, `ultra-burst.test.ts`, `weather.test.ts`, `z-move.test.ts`, `z-move-status.test.ts`
 
 ---
 
@@ -131,6 +131,7 @@ None. All tracked bugs closed.
 - PR #1054: Sunsteel Strike / Moongeist Beam now ignore target abilities through the shared Mold Breaker-style bypass path (partial close for #789)
 - PR #1055: Sunsteel Strike / Moongeist Beam now also bypass Battle Armor / Shell Armor crit immunity through the same shared signature-move ignore-ability set
 - PR #1061: Spectral Thief now steals positive boosts before damage through a shared pre-damage move-effect hook so the same hit uses the stolen stages (closes #1059)
+- PR #1797: Adrenaline Orb now routes through the shared held-item stat-change seam, uses the active battle ability for Contrary's +6 cap check, and keeps Red Card / Eject Button on the engine-owned reactive-switch seam (closes #1709; shared switch routing work also closes #1739)
 
 ## PR History
 
@@ -151,3 +152,4 @@ None. All tracked bugs closed.
 | #785 | fix/gen5-8-bughunt-status | Bughunt wave 2: Rayquaza mega, Disguise non-lethal, Beast Boost/Moxie, pinch berries EoT, Focus Sash (closes #701 #687 #688 #683 #725) |
 | #786 | fix/gen5-9-unaware-simple-priority | fix: Unaware/Simple priority and Mold Breaker-family bypass directionality (closes #757) |
 | #1061 | fix/gen7-spectral-thief | fix: Spectral Thief boost stealing before damage via shared pre-damage move-effect hook (closes #1059) |
+| #1797 | feat/trigger-surface-routing | Shared held-item stat-change seam for Adrenaline Orb plus reactive-switch seam hardening for Red Card / Eject Button (closes #1709; shared routing work also closes #1739) |

--- a/specs/reference/gen8-status.md
+++ b/specs/reference/gen8-status.md
@@ -1,6 +1,6 @@
 # Gen 8 (Sword/Shield) Implementation Status
 
-**Last updated:** 2026-03-22
+**Last updated:** 2026-03-31
 **Overall estimate:** 100% complete (Waves 0–9 merged; Wave 10 docs)
 **Architecture:** Extends `BaseRuleset`
 **Spec:** `specs/battle/09-gen8.md`
@@ -80,6 +80,7 @@
 - New: Heavy-Duty Boots, Room Service, Eject Pack, Blunder Policy, Throat Spray, Utility Umbrella
 - No Z-Crystals, no Mega Stones (removed in Gen 8)
 - Choice item lock suppressed during Dynamax
+- `Adrenaline Orb` and `Eject Pack` now route through the shared held-item stat-change seam, while `Red Card` / `Eject Button` stay on the real switch seam even when the replacement fails
 
 ### Move Effects (Wave 7 — PR #709)
 - **Rapid Spin**: 50 BP (was 20) + **+1 Speed on hit**
@@ -117,17 +118,17 @@
 
 ## Test Coverage
 
-28 test files, **1,208 tests** (as of PR #786 — `fix/remaining-issues-684-756-757`).
-**Branch coverage: 82.27%** (threshold: 80%).
-Statement: 87.05% | Functions: 87.87% | Lines: 87.05%
+32 test files, **1,267 tests** (as of PR #1797).
+**Last recorded branch coverage baseline: 82.27%** (threshold: 80%).
+Last recorded statement baseline: 87.05% | functions: 87.87% | lines: 87.05%
 
-Test files: `abilities-damage.test.ts`, `abilities-dispatcher.test.ts`, `abilities-routing.test.ts`, `abilities-stat.test.ts`, `abilities-switch.test.ts`, `coverage-gaps.test.ts`, `coverage-gaps-2.test.ts`, `coverage-gaps-3.test.ts`, `coverage-gaps-4.test.ts`, `coverage-gaps-5.test.ts`, `crit-calc.test.ts`, `damage-calc.test.ts`, `data-loading.test.ts`, `dynamax.test.ts`, `entry-hazards.test.ts`, `exp-formula.test.ts`, `gmax-moves.test.ts`, `integration.test.ts`, `items.test.ts`, `max-moves.test.ts`, `move-effects.test.ts`, `ruleset.test.ts`, `smoke.test.ts`, `status.test.ts`, `terrain.test.ts`, `type-chart.test.ts`, `weather.test.ts`
+Test files: `abilities-damage.test.ts`, `abilities-dispatcher.test.ts`, `abilities-routing.test.ts`, `abilities-stat.test.ts`, `abilities-switch.test.ts`, `bugfix-phase2.test.ts`, `cloud-nine-suppression.test.ts`, `coverage-gaps.test.ts`, `coverage-gaps-2.test.ts`, `coverage-gaps-3.test.ts`, `coverage-gaps-4.test.ts`, `coverage-gaps-5.test.ts`, `crit-calc.test.ts`, `damage-calc.test.ts`, `data-loading.test.ts`, `dynamax.test.ts`, `entry-hazards.test.ts`, `exp-formula.test.ts`, `facade-power-doubling.test.ts`, `gmax-moves.test.ts`, `integration/integration.test.ts`, `items.test.ts`, `max-moves.test.ts`, `move-effects.test.ts`, `priority-boost.test.ts`, `public-api.test.ts`, `ruleset.test.ts`, `smoke/smoke.test.ts`, `status.test.ts`, `terrain.test.ts`, `type-chart.test.ts`, `weather.test.ts`
 
 ---
 
 ## OPEN BUGS
 
-None. All tracked bugs closed.
+- `#1746` remains open: `Blunder Policy`, `Throat Spray`, and `Room Service` still have helper definitions but no engine trigger surfaces for move-miss, sound-move, or room-activation dispatch.
 
 ## CLOSED BUGS
 
@@ -139,6 +140,8 @@ None. All tracked bugs closed.
 | #713 | #785 | Choice lock applied during Dynamax (should be suppressed) |
 | #694 | #785 | Gen 8 package.json exports missing ./data entry |
 | #757 | #786 | Unaware/Simple priority + Mold Breaker bypass directionality in getEffectiveStatStage |
+| #1709 | #1797 | Adrenaline Orb now activates through the shared held-item stat-change seam, using the holder's active ability state for Contrary's +6 cap check |
+| #1739 | #1797 | Eject Pack, Red Card, and Eject Button now stay on the real engine stat-change / reactive-switch seams, including no-replacement failure handling |
 
 ---
 
@@ -161,3 +164,4 @@ None. All tracked bugs closed.
 | #752 | fix/gen5-8-bughunt | Deep bughunt: applyAbility routing (C1), getEndOfTurnOrder (C2), capLethalDamage (C3), canBypassProtect delegation, Dynamax revert fixes, closes #732 #733 #734 #735 #736 #739 #740 #741 #742 #746 #747 |
 | #785 | fix/gen5-8-bughunt-status | Bughunt wave 2: Disguise non-lethal + 1/8 chip via capLethalDamage, Choice lock Dynamax suppression, package.json exports (closes #687 #738 #713 #694) |
 | #786 | fix/gen5-9-unaware-simple-priority | fix: Unaware/Simple priority and Mold Breaker-family bypass directionality (closes #757) |
+| #1797 | feat/trigger-surface-routing | Shared held-item stat-change seam for Adrenaline Orb / Eject Pack and reactive-switch seam hardening for Red Card / Eject Button (closes #1709 #1739) |

--- a/specs/reference/gen9-status.md
+++ b/specs/reference/gen9-status.md
@@ -1,6 +1,6 @@
 # Gen 9 Implementation Status
 
-**Last updated:** 2026-03-22
+**Last updated:** 2026-03-31
 **Overall estimate:** 100% complete (all 10 waves merged)
 **Architecture:** Extends `BaseRuleset`
 **Spec:** `specs/battle/10-gen9.md`
@@ -21,7 +21,7 @@
 | 7 | Held Items + Booster Energy | Merged (PR #720) |
 | 8A | Abilities (Stat/Switch/New) | Merged (PR #729) |
 | 8B | Move Effects | Merged (PR #728) |
-| 9 | Integration Tests + Docs | This PR |
+| 9 | Integration Tests + Docs | Merged (PR #753) |
 
 ---
 
@@ -38,7 +38,7 @@
 | 7 | #720 | Held items + Booster Energy -- Gen9Items.ts, choice items, berries, terrain extenders |
 | 8A | #729 | New Gen 9 abilities -- Protosynthesis, Quark Drive, Toxic Chain, Good as Gold, Mycelium Might, Embody Aspect, etc. |
 | 8B | #728 | Move effects -- Population Bomb, Rage Fist, Last Respects, Shed Tail, Tidy Up, Salt Cure, Tera Blast, Make It Rain, Revival Blessing |
-| 9 | (this PR) | Integration tests, coverage verification, gen9-ground-truth.md, docs update |
+| 9 | #753 | Integration tests, coverage verification, gen9-ground-truth.md, docs update |
 
 ---
 
@@ -69,9 +69,9 @@
 | 8B | ~74 | Move effects (Population Bomb, Salt Cure, Shed Tail, etc.) |
 | 9 | 35 | Integration tests (cross-mechanic, determinism, Tera+damage) |
 
-**Total: 1,053 tests**
+**Total: 1,126 tests**
 
-Coverage (v8):
+Last recorded v8 coverage baseline:
 - Statements: 91.56%
 - Branches: 82.04%
 - Functions: 94.31%
@@ -81,7 +81,7 @@ Coverage (v8):
 
 ## Open Bugs
 
-None. All tracked bugs closed.
+- `#1746` remains open: `Blunder Policy`, `Throat Spray`, and `Room Service` still have helper definitions but no engine trigger surfaces for move-miss, sound-move, or room-activation dispatch.
 
 ## Closed Bugs
 
@@ -96,6 +96,9 @@ None. All tracked bugs closed.
 | #726 | #785 | LOW | Lansat Berry sets focus-energy volatile for crit-rate boost |
 | #731 | #785 | LOW | Sturdy wired to capLethalDamage (full HP only — blocks OHKO) |
 | #757 | #786 | MEDIUM | Unaware/Simple priority + Mold Breaker bypass directionality in getEffectiveStatStage |
+| #1709 | #1797 | MEDIUM | Adrenaline Orb now activates through the shared held-item stat-change seam, using the holder's active ability state for Contrary's +6 cap check |
+| #1739 | #1797 | HIGH | Eject Pack, Red Card, and Eject Button now stay on the real engine stat-change / reactive-switch seams, including no-replacement failure handling |
+| #1745 | #1797 | HIGH | Mirror Herb and Clear Amulet now receive held-item stat-change triggers; Clear Amulet blocks opposing drops and Mirror Herb copies foe boosts before consuming |
 
 
 ---
@@ -108,3 +111,4 @@ None. All tracked bugs closed.
 | #753 | feat/gen9-wave9 | Wave 9: integration tests + 100% completion docs |
 | #785 | fix/gen5-8-bughunt-status | Bughunt wave 2: timesAttacked reset, Shed Tail transfer, Population Bomb multiaccuracy, Sturdy/Focus Sash capLethalDamage, Misty/Psychic terrain, Lansat Berry (closes #749 #750 #751 #723 #724 #725 #726 #731) |
 | #786 | fix/gen5-9-unaware-simple-priority | fix: Unaware/Simple priority and Mold Breaker-family bypass directionality (closes #757) |
+| #1797 | feat/trigger-surface-routing | Shared held-item stat-change seam for Adrenaline Orb / Eject Pack / Mirror Herb / Clear Amulet and reactive-switch seam hardening for Red Card / Eject Button (closes #1709 #1739 #1745) |

--- a/specs/reference/testing-status.md
+++ b/specs/reference/testing-status.md
@@ -1,6 +1,6 @@
 # Testing and Confidence Status
 
-**Last updated:** 2026-03-27
+**Last updated:** 2026-03-31
 **Purpose:** Track behavioral coverage confidence, architecture/testability hotspots, and cartridge-compliance rollout across the repo.
 
 This document exists because raw line/branch coverage is not enough to claim correctness confidence. The repo needs visible status for:
@@ -30,6 +30,7 @@ Confidence levels:
 - `battle` is functionally broad and documents a complete singles engine in [battle-status.md](./battle-status.md), including turn flow and end-of-turn handler coverage.
 - `battle` has direct deterministic ordering coverage for same-speed ties, action-type priority, and forced-switch queued-action invalidation in its shared unit/integration suites.
 - `battle` also now has direct setup/runtime invariant coverage for helper-built active/side/state wrappers in `packages/battle/tests/unit/utils/battle-helpers.test.ts`, plus stronger deserialize checkpoint/relink validation in `packages/battle/tests/integration/engine/deserialize.test.ts`.
+- `battle` now also has direct engine-path coverage for the shared held-item stat-change and reactive-switch seams in `packages/battle/tests/integration/engine/held-item-stat-change.test.ts` and `packages/battle/tests/integration/engine/item-force-switch.test.ts`, including blocked drops, foe-post-boost copying, deferred item flushing, and no-replacement failure paths.
 - Gen 1 has the deepest source-backed confidence today:
   - ground-truth / deep-dive coverage
   - replay validation
@@ -65,6 +66,7 @@ Showdown parity is not the success criterion for Gen 1-4. For those gens, cartri
 | Speed tie determinism | battle | `strong` | Direct deterministic coverage exists in `packages/battle/tests/unit/ruleset/base-ruleset-branches.test.ts`, `packages/battle/tests/unit/ruleset/base-ruleset-rng-determinism.test.ts`, and `packages/battle/tests/integration/engine/battle-engine-branches.test.ts` | Keep strong local coverage and eventually add replay/trace parity for engine-level tie outcomes |
 | Bracket modifiers (priority / Trick Room / go-first item family) | battle + all gens | `weak` | Shared engine coverage exists for move priority, action-type priority, and selected go-first items, but the repo still lacks a maintained matrix for combined bracket interactions and cross-gen negative-order classes | Build ordering rows keyed to specific bracket modifiers and close the remaining matrix gaps |
 | Queued-action invalidation on forced switch | battle | `strong` | Direct regression coverage exists in `packages/battle/tests/integration/engine/forced-switch.test.ts` and `packages/battle/tests/integration/engine/item-force-switch.test.ts`, including queued move, Struggle, recharge, and item-driven invalidation | Extend the same explicit invalidation checks to the remaining forced-switch sources and faint-replacement edges |
+| Held-item stat-change / reactive-switch seams | battle + gen7-9 | `strong` to `weak` mixed | Direct engine-path coverage now exists in `packages/battle/tests/integration/engine/held-item-stat-change.test.ts`, `packages/battle/tests/integration/engine/item-force-switch.test.ts`, and later-gen item suites for Adrenaline Orb, Clear Amulet, Mirror Herb, Eject Pack, Red Card, and Eject Button; move-miss / sound-move / room-activation item seams are still open under `#1746` | Extend the same seam matrix to `Blunder Policy`, `Throat Spray`, and `Room Service` before claiming closure for later-gen item routing |
 | Base end-of-turn ordering | battle | `strong` | BaseRuleset and engine suites cover default handler ordering and confusion/countdown paths directly | Keep strong local confidence and extend later to trace/oracle validation |
 | Gen-specific end-of-turn ordering | battle + gen1-9 | `weak` to `strong` mixed | Engine and per-gen suites cover many handlers, but there is no maintained per-generation order matrix | Build per-gen ordering matrix against tests + source notes |
 | Hazard / grounded / semi-invulnerable interactions | gen5-9 | `weak` | Multiple historical bughunt fixes landed across gen5-9, but there is still no maintained confidence row tying those interactions to current test evidence | Audit tests against current rulesets and identify remaining blind spots |
@@ -113,6 +115,7 @@ Cartridge-accuracy gaps with limited competitive impact:
 Missing singles mechanic gaps:
 - `#793` Forecast type change missing in Gen 4-9
 - `#788` Ultra Burst missing in Gen 7
+- `#1746` Blunder Policy / Throat Spray / Room Service still remain helper-only because the engine lacks move-miss, sound-move, and room-activation item dispatch seams
 
 Open tracker overlap requiring cleanup:
 - `#789` remains as the umbrella tracker for the remaining Gen 7 move-effect tail.


### PR DESCRIPTION
## Summary
- refresh the battle, gen7, gen8, gen9, and testing status docs after merged PR #1797
- record the new held-item stat-change / reactive-switch seam coverage and the later-gen item trigger gap that remains open under #1746
- update the affected per-gen test totals and PR history rows without changing runtime code

## Verification
- `git diff --check`
- manual doc diff review against merged PR #1797, related issues (#1709, #1739, #1745, #1746), and current test inventories

Closes: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated implementation status and test coverage metrics for Generation 7, 8, and 9 reference documentation
  * Enhanced documentation of held-item mechanics with clarified routing and trigger behavior
  * Added tracking for new regression tests and identified outstanding implementation gaps for certain item triggers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->