### PR TITLE
fix(oracle-validation): validate protocol capability ownership

### DIFF
--- a/tools/oracle-validation/control-plane/mechanic-catalog.v1.json
+++ b/tools/oracle-validation/control-plane/mechanic-catalog.v1.json
@@ -135,7 +135,7 @@
     },
     {
       "mechanicId": "shared.engine.support-utils",
-      "cluster": "workflow-integrity",
+      "cluster": "support-utils",
       "topologies": ["singles"],
       "orderingSensitive": false,
       "persistent": false,

--- a/tools/oracle-validation/control-plane/obligation-catalog.v1.json
+++ b/tools/oracle-validation/control-plane/obligation-catalog.v1.json
@@ -25,6 +25,11 @@
       "cluster": "move-effect-ownership",
       "requiredProofs": ["source", "semantic", "runtime", "behavior"],
       "requiredSuites": ["test", "oracle-fast"]
+    },
+    {
+      "cluster": "support-utils",
+      "requiredProofs": ["source", "semantic", "runtime"],
+      "requiredSuites": ["test"]
     }
   ]
 }

--- a/tools/oracle-validation/control-plane/protocol-capability-matrix.v1.json
+++ b/tools/oracle-validation/control-plane/protocol-capability-matrix.v1.json
@@ -5,7 +5,7 @@
       "cluster": "workflow-integrity",
       "operations": ["changed-mechanics-report", "versioned-artifact-write"],
       "supportedTopologies": ["singles"],
-      "engineOwner": "oracle:tooling:runner"
+      "engineOwners": ["oracle:tooling:runner", "workflow:tooling:compliance"]
     },
     {
       "cluster": "protocol-completeness",
@@ -41,26 +41,51 @@
         "splitTargetMultiHit",
         "scalingMultiHit"
       ],
-      "supportedTopologies": ["singles", "bench", "serialization"],
-      "engineOwner": "battle:contract:move-effect-result"
+      "supportedTopologies": ["singles", "bench", "serialization", "switch-legality"],
+      "engineOwners": [
+        "core:leaf-mechanic:entities-and-constants",
+        "battle:contract:damage-context",
+        "battle:contract:hit-check-contexts",
+        "battle:contract:move-effect-context",
+        "battle:contract:move-effect-result",
+        "battle:contract:ability-context-result",
+        "battle:contract:item-context-result",
+        "battle:contract:field-effect-results"
+      ]
     },
     {
       "cluster": "switch-legality",
       "operations": ["switchLegalityCheck", "reactiveSwitch", "forcedSwitchBlock"],
       "supportedTopologies": ["singles", "switch-legality"],
-      "engineOwner": "battle:shared-seam:engine"
+      "engineOwners": ["battle:shared-seam:engine"]
     },
     {
       "cluster": "effective-speed-order",
       "operations": ["effectiveSpeed", "turnOrder", "preMoveOrdering"],
       "supportedTopologies": ["singles"],
-      "engineOwner": "battle:shared-seam:engine"
+      "engineOwners": ["battle:shared-seam:engine"]
     },
     {
       "cluster": "move-effect-ownership",
       "operations": ["moveEffectDispatch", "itemTriggerDispatch", "abilityTriggerDispatch"],
       "supportedTopologies": ["singles"],
-      "engineOwner": "gen8:leaf-mechanic:ruleset-and-handlers"
+      "engineOwners": [
+        "gen1:leaf-mechanic:ruleset-and-handlers",
+        "gen2:leaf-mechanic:ruleset-and-handlers",
+        "gen3:leaf-mechanic:ruleset-and-handlers",
+        "gen4:leaf-mechanic:ruleset-and-handlers",
+        "gen5:leaf-mechanic:ruleset-and-handlers",
+        "gen6:leaf-mechanic:ruleset-and-handlers",
+        "gen7:leaf-mechanic:ruleset-and-handlers",
+        "gen8:leaf-mechanic:ruleset-and-handlers",
+        "gen9:leaf-mechanic:ruleset-and-handlers"
+      ]
+    },
+    {
+      "cluster": "support-utils",
+      "operations": ["battleUtilityDispatch"],
+      "supportedTopologies": ["singles"],
+      "engineOwners": ["battle:shared-seam:utils"]
     }
   ]
 }

--- a/tools/oracle-validation/src/control-plane.ts
+++ b/tools/oracle-validation/src/control-plane.ts
@@ -172,7 +172,7 @@ const protocolCapabilityMatrixSchema = z.strictObject({
       cluster: z.string().min(1),
       operations: z.array(z.string().min(1)).min(1),
       supportedTopologies: z.array(z.string().min(1)).min(1),
-      engineOwner: z.string().min(1),
+      engineOwners: z.array(z.string().min(1)).min(1),
     }),
   ),
 });

--- a/tools/oracle-validation/src/validate-control-plane.ts
+++ b/tools/oracle-validation/src/validate-control-plane.ts
@@ -51,6 +51,11 @@ function sameMembers(actual: readonly string[], expected: readonly string[]): bo
   return actualSorted.every((value, index) => value === expectedSorted[index]);
 }
 
+function missingMembers(actual: readonly string[], expected: readonly string[]): string[] {
+  const actualSet = new Set(actual);
+  return [...new Set(expected)].filter((value) => !actualSet.has(value)).sort();
+}
+
 function activeWaiverMechanicIds(controlPlane: ControlPlane, now: Date): Set<string> {
   const active = new Set<string>();
 
@@ -79,15 +84,24 @@ export function validateControlPlane(
   const obligationClusters = new Set(
     controlPlane.obligationCatalog.clusters.map((entry) => entry.cluster),
   );
-  const protocolClusters = new Set(
-    controlPlane.protocolCapabilityMatrix.clusters.map((entry) => entry.cluster),
-  );
+  const protocolClusterEntries = controlPlane.protocolCapabilityMatrix.clusters;
+  const protocolClusters = new Set(protocolClusterEntries.map((entry) => entry.cluster));
   const authorityKeySet = new Set(authorityKeys);
   const mechanicIdSet = new Set(mechanicIds);
   const ownershipKeySet = new Set(ownershipKeys);
   const activeWaivers = activeWaiverMechanicIds(controlPlane, now);
   const mechanicById = new Map(
     controlPlane.mechanicCatalog.mechanics.map((entry) => [entry.mechanicId, entry] as const),
+  );
+  const protocolClusterByName = new Map(
+    protocolClusterEntries.map((entry) => [entry.cluster, entry] as const),
+  );
+  const mechanicIdsByCluster = new Map<string, string[]>();
+  const ownershipMechanicIdsByKey = new Map(
+    controlPlane.ownershipMap.ownershipRules.map((entry) => [
+      entry.ownershipKey,
+      new Set(entry.mechanicIds),
+    ]),
   );
 
   for (const duplicate of duplicateValues(authorityKeys)) {
@@ -104,10 +118,22 @@ export function validateControlPlane(
   )) {
     errors.push(`Duplicate cluster in obligation-catalog.v1.json: ${duplicate}`);
   }
-  for (const duplicate of duplicateValues(
-    controlPlane.protocolCapabilityMatrix.clusters.map((entry) => entry.cluster),
-  )) {
+  for (const duplicate of duplicateValues(protocolClusterEntries.map((entry) => entry.cluster))) {
     errors.push(`Duplicate cluster in protocol-capability-matrix.v1.json: ${duplicate}`);
+  }
+  for (const missing of missingMembers(
+    protocolClusterEntries.map((entry) => entry.cluster),
+    controlPlane.obligationCatalog.clusters.map((entry) => entry.cluster),
+  )) {
+    errors.push(
+      `Obligation cluster ${missing} is missing from protocol-capability-matrix.v1.json.`,
+    );
+  }
+  for (const extra of missingMembers(
+    controlPlane.obligationCatalog.clusters.map((entry) => entry.cluster),
+    protocolClusterEntries.map((entry) => entry.cluster),
+  )) {
+    errors.push(`Protocol cluster ${extra} has no matching obligation cluster.`);
   }
   for (const duplicate of duplicateValues(
     controlPlane.bootstrapWaivers.waivers.map((entry) => entry.waiverId),
@@ -139,6 +165,23 @@ export function validateControlPlane(
   for (const duplicate of duplicateValues(controlPlane.proofSchema.conclusions)) {
     errors.push(`Duplicate conclusion in proof-schema.v1.json: ${duplicate}`);
   }
+  for (const protocolCluster of protocolClusterEntries) {
+    for (const duplicate of duplicateValues(protocolCluster.operations)) {
+      errors.push(
+        `Protocol cluster ${protocolCluster.cluster} duplicates operation ${duplicate} in protocol-capability-matrix.v1.json.`,
+      );
+    }
+    for (const duplicate of duplicateValues(protocolCluster.supportedTopologies)) {
+      errors.push(
+        `Protocol cluster ${protocolCluster.cluster} duplicates supported topology ${duplicate} in protocol-capability-matrix.v1.json.`,
+      );
+    }
+    for (const duplicate of duplicateValues(protocolCluster.engineOwners)) {
+      errors.push(
+        `Protocol cluster ${protocolCluster.cluster} duplicates engine owner ${duplicate} in protocol-capability-matrix.v1.json.`,
+      );
+    }
+  }
   if (!sameMembers(controlPlane.proofSchema.checkStatuses, CHECK_STATUS_VALUES)) {
     errors.push(
       "proof-schema.v1.json checkStatuses must match proof-artifact-schema.ts checkStatusSchema exactly.",
@@ -161,6 +204,9 @@ export function validateControlPlane(
   }
 
   for (const mechanic of controlPlane.mechanicCatalog.mechanics) {
+    const mechanicsInCluster = mechanicIdsByCluster.get(mechanic.cluster) ?? [];
+    mechanicsInCluster.push(mechanic.mechanicId);
+    mechanicIdsByCluster.set(mechanic.cluster, mechanicsInCluster);
     if (!authorityKeySet.has(mechanic.authorityKey)) {
       errors.push(
         `Mechanic ${mechanic.mechanicId} references unknown authorityKey ${mechanic.authorityKey}.`,
@@ -180,6 +226,27 @@ export function validateControlPlane(
       if (!knownSuites.has(suiteId)) {
         errors.push(`Mechanic ${mechanic.mechanicId} requires unknown suite ${suiteId}.`);
       }
+    }
+    const protocolCluster = protocolClusterByName.get(mechanic.cluster);
+    if (!protocolCluster) {
+      continue;
+    }
+
+    for (const topology of mechanic.topologies) {
+      if (!protocolCluster.supportedTopologies.includes(topology)) {
+        errors.push(
+          `Mechanic ${mechanic.mechanicId} topology ${topology} is not covered by protocol cluster ${mechanic.cluster}.`,
+        );
+      }
+    }
+
+    const coveredByOwner = protocolCluster.engineOwners.some((engineOwner) =>
+      ownershipMechanicIdsByKey.get(engineOwner)?.has(mechanic.mechanicId),
+    );
+    if (!coveredByOwner) {
+      errors.push(
+        `Mechanic ${mechanic.mechanicId} is not covered by any protocol engineOwner declared for cluster ${mechanic.cluster}.`,
+      );
     }
   }
 
@@ -264,10 +331,17 @@ export function validateControlPlane(
     }
   }
 
-  for (const protocolCluster of controlPlane.protocolCapabilityMatrix.clusters) {
-    if (!ownershipKeySet.has(protocolCluster.engineOwner)) {
+  for (const protocolCluster of protocolClusterEntries) {
+    for (const engineOwner of protocolCluster.engineOwners) {
+      if (!ownershipKeySet.has(engineOwner)) {
+        errors.push(
+          `Protocol cluster ${protocolCluster.cluster} references unknown engineOwner ${engineOwner}.`,
+        );
+      }
+    }
+    if ((mechanicIdsByCluster.get(protocolCluster.cluster) ?? []).length === 0) {
       errors.push(
-        `Protocol cluster ${protocolCluster.cluster} references unknown engineOwner ${protocolCluster.engineOwner}.`,
+        `Protocol cluster ${protocolCluster.cluster} has no mechanics assigned in mechanic-catalog.v1.json.`,
       );
     }
   }

--- a/tools/oracle-validation/tests/validate-control-plane.test.ts
+++ b/tools/oracle-validation/tests/validate-control-plane.test.ts
@@ -85,7 +85,7 @@ function createControlPlane(overrides: Partial<ControlPlane> = {}): ControlPlane
           cluster: "effective-speed-order",
           operations: ["effectiveSpeed"],
           supportedTopologies: ["singles"],
-          engineOwner: "battle:shared-seam:engine",
+          engineOwners: ["battle:shared-seam:engine"],
         },
       ],
     },
@@ -285,7 +285,7 @@ describe("validateControlPlane", () => {
             cluster: "effective-speed-order",
             operations: ["effectiveSpeed"],
             supportedTopologies: ["singles"],
-            engineOwner: "battle:shared-seam:missing",
+            engineOwners: ["battle:shared-seam:missing"],
           },
         ],
       },
@@ -322,6 +322,89 @@ describe("validateControlPlane", () => {
     );
     expect(errors).toContain(
       "proof-schema.v1.json conclusions must match proof-artifact-schema.ts runConclusionSchema exactly.",
+    );
+  });
+
+  it("fails when an obligation cluster is missing from the protocol matrix", () => {
+    const controlPlane = createControlPlane({
+      protocolCapabilityMatrix: {
+        version: 1,
+        clusters: [],
+      },
+    });
+
+    expect(validateControlPlane(controlPlane).errors).toContain(
+      "Obligation cluster effective-speed-order is missing from protocol-capability-matrix.v1.json.",
+    );
+  });
+
+  it("fails when protocol topologies do not cover the mechanic topologies", () => {
+    const controlPlane = createControlPlane({
+      mechanicCatalog: {
+        version: 1,
+        mechanics: [
+          {
+            mechanicId: "shared.engine.turn-order",
+            cluster: "effective-speed-order",
+            topologies: ["singles", "switch-legality"],
+            orderingSensitive: true,
+            persistent: false,
+            proofStatus: "proved",
+            authorityKey: "shared.engine-contracts",
+            requiredSuites: ["test"],
+            obligationSeed: "turn-order",
+          },
+        ],
+      },
+    });
+
+    expect(validateControlPlane(controlPlane).errors).toContain(
+      "Mechanic shared.engine.turn-order topology switch-legality is not covered by protocol cluster effective-speed-order.",
+    );
+  });
+
+  it("fails when protocol engine owners do not cover the mechanics in their cluster", () => {
+    const controlPlane = createControlPlane({
+      protocolCapabilityMatrix: {
+        version: 1,
+        clusters: [
+          {
+            cluster: "effective-speed-order",
+            operations: ["effectiveSpeed"],
+            supportedTopologies: ["singles"],
+            engineOwners: ["unknown:owner"],
+          },
+        ],
+      },
+    });
+
+    const errors = validateControlPlane(controlPlane).errors;
+
+    expect(errors).toContain(
+      "Protocol cluster effective-speed-order references unknown engineOwner unknown:owner.",
+    );
+    expect(errors).toContain(
+      "Mechanic shared.engine.turn-order is not covered by any protocol engineOwner declared for cluster effective-speed-order.",
+    );
+  });
+
+  it("fails when a protocol cluster duplicates engine owners", () => {
+    const controlPlane = createControlPlane({
+      protocolCapabilityMatrix: {
+        version: 1,
+        clusters: [
+          {
+            cluster: "effective-speed-order",
+            operations: ["effectiveSpeed"],
+            supportedTopologies: ["singles"],
+            engineOwners: ["battle:shared-seam:engine", "battle:shared-seam:engine"],
+          },
+        ],
+      },
+    });
+
+    expect(validateControlPlane(controlPlane).errors).toContain(
+      "Protocol cluster effective-speed-order duplicates engine owner battle:shared-seam:engine in protocol-capability-matrix.v1.json.",
     );
   });
 });


### PR DESCRIPTION
## Summary
- validate protocol cluster ownership against mechanic coverage instead of only checking key existence
- require protocol clusters to cover mechanic topologies and forbid duplicate engine owners
- split shared support utils into their own cluster so workflow-integrity stays honest

## Verification
- npm exec -- tsx tools/oracle-validation/src/validate-control-plane.ts
- npm run test --workspace oracle-validation
- npm run typecheck --workspace oracle-validation
- npm run verify:local

Closes: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated cluster configuration structure to support multiple engine owners per cluster.
  * Added new cluster configuration entry and expanded validation coverage.
  * Enhanced system validation with improved checks for cluster correspondence, topology coverage, and ownership verification.

* **Tests**
  * Updated test cases to reflect cluster validation changes.
  * Added new test cases for cluster correspondence and ownership coverage validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->