### PR TITLE
feat(oracle-validation): harden direct mutation audit

### DIFF
--- a/tools/oracle-validation/src/direct-mutation-audit.ts
+++ b/tools/oracle-validation/src/direct-mutation-audit.ts
@@ -22,11 +22,12 @@ const directMutationAuditSchema = z.strictObject({
   findings: z.array(directMutationFindingSchema),
 });
 
-const assignmentOperatorPattern = String.raw`(?:\+\+|--|(?:\+\+|--)\s*|(?:\+|-|\*|\/|%|<<|>>|>>>|&|\^|\||\*\*)?=(?!=))`;
+const assignmentOperatorPattern = String.raw`(?:\+\+|--|(?:\+\+|--)\s*|(?:\?\?|\|\||&&|\+|-|\*|\/|%|<<|>>|>>>|&|\^|\||\*\*)?=(?!=))`;
 const propertyAccessPattern = String.raw`(?:\.[A-Za-z_$][\w$]*|\[[^\]\n]+\])+`;
 const stateTargetPattern = String.raw`ctx\.state${propertyAccessPattern}`;
 const activePokemonTargetPattern = String.raw`ctx\.(?:attacker|defender)(?:\.pokemon)?${propertyAccessPattern}`;
 const mutatorMethodNames = new Set([
+  "add",
   "set",
   "delete",
   "clear",
@@ -44,12 +45,15 @@ const trackedContextRoots: ReadonlyMap<string, MutationRootKind> = new Map([
 ]);
 const assignmentOperatorKinds = new Set([
   ts.SyntaxKind.EqualsToken,
+  ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+  ts.SyntaxKind.BarBarEqualsToken,
   ts.SyntaxKind.PlusEqualsToken,
   ts.SyntaxKind.MinusEqualsToken,
   ts.SyntaxKind.AsteriskEqualsToken,
   ts.SyntaxKind.AsteriskAsteriskEqualsToken,
   ts.SyntaxKind.SlashEqualsToken,
   ts.SyntaxKind.PercentEqualsToken,
+  ts.SyntaxKind.QuestionQuestionEqualsToken,
   ts.SyntaxKind.LessThanLessThanEqualsToken,
   ts.SyntaxKind.GreaterThanGreaterThanEqualsToken,
   ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
@@ -167,23 +171,25 @@ function recordAliasFromDeclaration(
   }
 
   const initializer = unwrapExpression(declaration.initializer);
-  const isTrackedContextRoot =
+  const contextRoot =
     ts.isIdentifier(initializer) && (initializer.text === "ctx" || initializer.text === "context");
-  if (!isTrackedContextRoot) {
-    return;
-  }
+  const rootKind = contextRoot ? null : resolveMutationRootKind(declaration.initializer, aliases);
 
   for (const element of declaration.name.elements) {
     if (element.dotDotDotToken || !ts.isIdentifier(element.name)) {
       continue;
     }
 
-    const propertyName =
-      element.propertyName && ts.isIdentifier(element.propertyName)
-        ? element.propertyName.text
-        : element.name.text;
-    const rootKind = trackedContextRoots.get(propertyName);
-    if (rootKind) {
+    const propertyName = element.propertyName ?? element.name;
+    if (contextRoot && ts.isIdentifier(propertyName)) {
+      const propertyRootKind = trackedContextRoots.get(propertyName.text);
+      if (propertyRootKind) {
+        aliases.set(element.name.text, propertyRootKind);
+      }
+      continue;
+    }
+
+    if (rootKind && ts.isIdentifier(propertyName)) {
       aliases.set(element.name.text, rootKind);
     }
   }

--- a/tools/oracle-validation/tests/direct-mutation-audit.test.ts
+++ b/tools/oracle-validation/tests/direct-mutation-audit.test.ts
@@ -15,6 +15,15 @@ describe("detectDirectMutationPatterns", () => {
     expect(detectDirectMutationPatterns('ctx.state.phase = "move";')).toContain(
       "ctx-state-mutation",
     );
+    expect(detectDirectMutationPatterns('ctx.state.phase &&= "move";')).toContain(
+      "ctx-state-mutation",
+    );
+    expect(detectDirectMutationPatterns('ctx.state.phase ||= "switch";')).toContain(
+      "ctx-state-mutation",
+    );
+    expect(detectDirectMutationPatterns('ctx.state.phase ??= "idle";')).toContain(
+      "ctx-state-mutation",
+    );
     expect(detectDirectMutationPatterns("ctx.state.turnNumber++;")).toContain("ctx-state-mutation");
     expect(detectDirectMutationPatterns("--ctx.state.turnNumber;")).toContain("ctx-state-mutation");
   });
@@ -62,6 +71,21 @@ describe("scanSourceForDirectMutations", () => {
     ]);
   });
 
+  it("detects chained destructuring aliases from tracked roots", () => {
+    const findings = scanSourceForDirectMutations(
+      `
+      function sample(ctx: MoveEffectContext) {
+        const { attacker } = ctx;
+        const { pokemon } = attacker;
+        pokemon.currentHp = 10;
+      }
+      `,
+      "packages/gen9/src/Gen9MoveEffects.ts",
+    );
+
+    expect(findings.map((finding) => finding.pattern)).toEqual(["active-pokemon-mutation"]);
+  });
+
   it("ignores local scratch mutations that do not derive from tracked context", () => {
     const findings = scanSourceForDirectMutations(
       `
@@ -104,6 +128,19 @@ describe("scanSourceForDirectMutations", () => {
       "ctx-state-mutation",
       "ctx-state-mutation",
     ]);
+  });
+
+  it("detects mutator add calls on tracked sets", () => {
+    const findings = scanSourceForDirectMutations(
+      `
+      function sample(ctx: MoveEffectContext) {
+        ctx.state.pseudoWeather.add("trickroom");
+      }
+      `,
+      "packages/gen9/src/Gen9MoveEffects.ts",
+    );
+
+    expect(findings.map((finding) => finding.pattern)).toEqual(["ctx-state-mutation"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- replace line-only mutation detection with AST-backed scanning that follows tracked ctx/context aliases
- detect mutator method calls on tracked state and active Pokemon paths
- expand the inspected generation runtime file families and add regression tests

## Testing
- npm run test --workspace oracle-validation
- npm run typecheck --workspace oracle-validation
- npm run verify:local

Closes: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mutation-detection tooling upgraded for more accurate, AST-driven scanning with broader operator and mutator coverage, better alias/destructuring tracking, expanded module scope, de-duplicated and more precise location reporting.

* **Tests**
  * Added end-to-end tests covering aliasing, destructuring, mutator calls, iteration, compound operators, and path-based inclusion/exclusion to validate scanner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->